### PR TITLE
js_dsl doesn't work with v8 example

### DIFF
--- a/lib/cucumber/js_support/js_dsl.js
+++ b/lib/cucumber/js_support/js_dsl.js
@@ -1,15 +1,15 @@
 var CucumberJsDsl = {
   registerStepDefinition: function(regexp, func) {
     if(func == null) {
-      jsLanguage.executeStepDefinition(regexp);
+      jsLanguage.execute_step_definition(regexp);
     }
     else{
-      jsLanguage.addStepDefinition(regexp, func);
+      jsLanguage.add_step_definition(regexp, func);
     }
   },
 
   registerTransform: function(regexp, func) {
-    jsLanguage.registerJsTransform(regexp, func);
+    jsLanguage.register_js_transform(regexp, func);
   },
 
   beforeHook: function(tag_expressions_or_func, func) {
@@ -40,9 +40,9 @@ var CucumberJsDsl = {
       var hook_func = tag_expressions_or_func;
       var tag_expressions = [];
     }
-    jsLanguage.registerJsHook(label, tag_expressions, hook_func);
+    jsLanguage.register_js_hook(label, tag_expressions, hook_func);
   }
-}
+};
 
 var Given = CucumberJsDsl.registerStepDefinition;
 var When = CucumberJsDsl.registerStepDefinition;


### PR DESCRIPTION
Hi,
This small change fixes the v8 example for JS support. Running the example as-is with cucumber-0.8.5 and therubyracer-0.7.5 produces:

```
Object #<a rb::JsLanguage> has no method 'registerJsHook' (V8::JSError)
at Object.__registerJsHook (/Library/Ruby/Gems/1.8/gems/cucumber-0.8.5/bin/../lib/cucumber/js_support/js_dsl.js:43:16)
at /Library/Ruby/Gems/1.8/gems/cucumber-0.8.5/bin/../lib/cucumber/js_support/js_dsl.js:16:19
at features/step_definitions/fib_steps.js:1:1
/Library/Ruby/Gems/1.8/gems/cucumber-0.8.5/bin/../lib/cucumber/js_support/js_language.rb:28:in `send'
/Library/Ruby/Gems/1.8/gems/cucumber-0.8.5/bin/../lib/cucumber/js_support/js_language.rb:28:in `method_missing'
/Library/Ruby/Gems/1.8/gems/cucumber-0.8.5/bin/../lib/cucumber/js_support/js_language.rb:114:in `load_code_file'
/Library/Ruby/Gems/1.8/gems/cucumber-0.8.5/bin/../lib/cucumber/step_mother.rb:108:in `load_code_file'
/Library/Ruby/Gems/1.8/gems/cucumber-0.8.5/bin/../lib/cucumber/step_mother.rb:100:in `load_code_files'
/Library/Ruby/Gems/1.8/gems/cucumber-0.8.5/bin/../lib/cucumber/step_mother.rb:99:in `each'
/Library/Ruby/Gems/1.8/gems/cucumber-0.8.5/bin/../lib/cucumber/step_mother.rb:99:in `load_code_files'
/Library/Ruby/Gems/1.8/gems/cucumber-0.8.5/bin/../lib/cucumber/cli/main.rb:56:in `execute!'
/Library/Ruby/Gems/1.8/gems/cucumber-0.8.5/bin/../lib/cucumber/cli/main.rb:25:in `execute'
/Library/Ruby/Gems/1.8/gems/cucumber-0.8.5/bin/cucumber:8
/usr/bin/cucumber:19:in `load'
/usr/bin/cucumber:19
```

The CamelCase to camel_case changes I made to the js_dsl.js file solve this problem, and the fibonacci example runs flawlessly after these changes are applied. 

Best,
Clay
