### PR TITLE
Add check for bundler

### DIFF
--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -65,7 +65,7 @@ module Cucumber
         end
 
         def runner
-          File.exist?("./Gemfile") ? ["bundle", "exec", RUBY] : [RUBY]
+          File.exist?("./Gemfile") && Gem.available?("bundler") ? ["bundle", "exec", RUBY] : [RUBY]
         end
 
         def run


### PR DESCRIPTION
Hi Aslak.
The additional check for 'bundler' supports continued compatibility w/ bundler08. For bundler08, ./Gemfile exists, but 'bundle exec' will fail.

-Sean
