### PR TITLE
Update gemspec

### DIFF
--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -26,12 +26,12 @@ for important information about this release. Happy cuking!
 
   s.add_dependency 'gherkin', '~> 2.3.0'
   s.add_dependency 'term-ansicolor', '~> 1.0.5'
-  s.add_dependency 'builder', '~> 2.1.2'
+  s.add_dependency 'builder', '~> 3.0.0'
   s.add_dependency 'diff-lcs', '~> 1.1.2'
   s.add_dependency 'json', '~> 1.4.6'
   
   s.add_development_dependency 'rake', '~> 0.8.7'
-  s.add_development_dependency 'rspec', '~> 2.0.1'
+  s.add_development_dependency 'rspec', '~> 2.2.0'
   s.add_development_dependency 'nokogiri', '~> 1.4.3'
   s.add_development_dependency 'prawn', '= 0.8.4'
   s.add_development_dependency 'prawn-layout', '= 0.8.4'


### PR DESCRIPTION
Rails 3 development now depends on builder-3.0.0, so projects that depend on both rails and cucumber-0.9.4 can not use bundler at the moment (because cucumber depends on builder ~> 2.1.2.

I updated the gemspec to use builder ~> 3.0.0 and all specs and features continue to pass. Also updated to rspec-2.2 while I was at it.

Cheers
