### PR TITLE
Let #map_column! accept a symbol 

### DIFF
--- a/lib/cucumber/ast/table.rb
+++ b/lib/cucumber/ast/table.rb
@@ -276,8 +276,8 @@ module Cucumber
       #   end
       #
       def map_column!(column_name, strict=true, &conversion_proc)
-        verify_column(column_name) if strict
-        @conversion_procs[column_name] = conversion_proc
+        verify_column(column_name.to_s) if strict
+        @conversion_procs[column_name.to_s] = conversion_proc
       end
 
       # Compares +other_table+ to self. If +other_table+ contains columns

--- a/spec/cucumber/ast/table_spec.rb
+++ b/spec/cucumber/ast/table_spec.rb
@@ -45,8 +45,13 @@ module Cucumber
         @table.hashes.first[:one].should == '4444'
       end
 
-      it "should allow map'ing columns" do
+      it "should allow mapping columns" do
         @table.map_column!('one') { |v| v.to_i }
+        @table.hashes.first['one'].should == 4444
+      end
+
+      it "should allow mapping columns and take a symbol as the column name" do
+        @table.map_column!(:one) { |v| v.to_i }
         @table.hashes.first['one'].should == 4444
       end
 


### PR DESCRIPTION
table#map_column currently just takes a string it would be nice if you could pass it a symbol instead. That's what's implemented in this commit w/ a spec to cover the change.

Thanks,

Ed
