### PR TITLE
Rows reflects map column

### DIFF
--- a/lib/cucumber/ast/table.rb
+++ b/lib/cucumber/ast/table.rb
@@ -168,9 +168,8 @@ module Cucumber
         @col_names ||= cell_matrix[0].map { |cell| cell.value }
       end
 
-      # Same as #raw, but skips the first (header) row
       def rows
-        raw[1..-1]
+        hashes.map(&:values)
       end
 
       def each_cells_row(&proc) #:nodoc:

--- a/spec/cucumber/ast/table_spec.rb
+++ b/spec/cucumber/ast/table_spec.rb
@@ -55,6 +55,12 @@ module Cucumber
         @table.hashes.first['one'].should == 4444
       end
 
+      it "should allow mapping columns and modify the rows as well" do
+        @table.map_column!(:one) { |v| v.to_i }
+        @table.rows.first.should include(4444)
+        @table.rows.first.should_not include('4444')
+      end
+
       it "should pass silently if a mapped column does not exist in non-strict mode" do
         lambda {
           @table.map_column!('two', false) { |v| v.to_i }


### PR DESCRIPTION
https://rspec.lighthouseapp.com/projects/16211/tickets/671-tablemap_columns-mutates-tablehashes-but-not-tablerows

The conversion proc wasn't being called on Table#rows which was counterintuitive to how one would expect it to work, in my opinion.
