### PR TITLE
Map column returns table

### DIFF
--- a/lib/cucumber/ast/table.rb
+++ b/lib/cucumber/ast/table.rb
@@ -278,6 +278,7 @@ module Cucumber
       def map_column!(column_name, strict=true, &conversion_proc)
         verify_column(column_name.to_s) if strict
         @conversion_procs[column_name.to_s] = conversion_proc
+        self
       end
 
       # Compares +other_table+ to self. If +other_table+ contains columns

--- a/spec/cucumber/ast/table_spec.rb
+++ b/spec/cucumber/ast/table_spec.rb
@@ -67,6 +67,10 @@ module Cucumber
         }.should raise_error('The column named "two" does not exist')
       end
 
+      it "should return the table" do
+        (@table.map_column!(:one) { |v| v.to_i }).should == @table
+      end
+
       describe "#match" do
         before(:each) do
           @table = Table.new([


### PR DESCRIPTION
https://rspec.lighthouseapp.com/projects/16211/tickets/671-tablemap_columns-mutates-tablehashes-but-not-tablerows also related to this ticket (if only just)

Table#map_column! is returning a proc instead of the table object, which seems useless to me, unless I'm missing something.  I would expect it to return the table object.

Cheers.
