### PR TITLE
Render .wire files through ERB

### DIFF
--- a/legacy_features/wire_protocol.feature
+++ b/legacy_features/wire_protocol.feature
@@ -11,7 +11,7 @@ Feature: Wire Protocol
   #
   # Communication is over a TCP socket, which Cucumber connects to when it finds
   # a definition file with the .wire extension in the step_definitions folder
-  # (or other load path).
+  # (or other load path).  Note that these files are rendered with ERB when loaded.
   #
   # Cucumber sends the following request messages out over the wire:
   #
@@ -31,7 +31,7 @@ Feature: Wire Protocol
   # Some messages support more responses - see below for details.
   #
   # A WirePacket flowing in either direction is formatted as a JSON-encoded
-  # string, with a newline character signalling the end of a packet. See the
+  # string, with a newline character signaling the end of a packet. See the
   # specs for Cucumber::WireSupport::WirePacket for more details.
   #
   # These messages are described in detail below, with examples.

--- a/legacy_features/wire_protocol_erb.feature
+++ b/legacy_features/wire_protocol_erb.feature
@@ -1,0 +1,57 @@
+@wire
+Feature: Wire Protocol with ERB
+  In order to be allow Cucumber to touch my app in intimate places
+  As a developer on server with multiple users
+  I want to be able to configure which port my wire server runs on
+  So that I can avoid port conflicts
+
+  Background:
+    Given a standard Cucumber project directory structure
+    And a file named "features/wired.feature" with:
+      """
+      Feature: High strung
+        Scenario: Wired
+          Given we're all wired
+
+      """
+
+  Scenario: ERB is used in the wire file which references an environment variable that is not set
+      Given a file named "features/step_definitions/server.wire" with:
+        """
+        host: localhost
+        port: <%= ENV['PORT'] || 12345 %>
+        """
+      And there is a wire server running on port 12345 which understands the following protocol:
+        | request                                              | response       |
+        | ["step_matches",{"name_to_match":"we're all wired"}] | ["success",[]] |
+      When I run cucumber --dry-run --no-snippets -f progress
+      And it should pass with
+        """
+        U
+
+        1 scenario (1 undefined)
+        1 step (1 undefined)
+
+        """
+
+
+  Scenario: ERB is used in the wire file which references an environment variable
+      Given I have environment variable PORT set to "16816"
+      And a file named "features/step_definitions/server.wire" with:
+        """
+        host: localhost
+        port: <%= ENV['PORT'] || 12345 %>
+        """
+      And there is a wire server running on port 16816 which understands the following protocol:
+        | request                                              | response       |
+        | ["step_matches",{"name_to_match":"we're all wired"}] | ["success",[]] |
+      When I run cucumber --dry-run --no-snippets -f progress
+      And it should pass with
+        """
+        U
+
+        1 scenario (1 undefined)
+        1 step (1 undefined)
+
+        """
+

--- a/lib/cucumber/wire_support/configuration.rb
+++ b/lib/cucumber/wire_support/configuration.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'erb'
 
 module Cucumber
   module WireSupport
@@ -6,7 +7,7 @@ module Cucumber
       attr_reader :host, :port
       
       def initialize(wire_file)
-        params = YAML.load_file(wire_file)
+        params = YAML.load(ERB.new(File.read(wire_file)).result)
         @host = params['host']
         @port = params['port']
         @timeouts = default_timeouts.merge(params['timeout'] || {})


### PR DESCRIPTION
As per your request on Lighthouse #694, I've added the ability for .wire files to support ERB templating.  I added an additional feature file specifically for this feature since the existing wire protocol feature files have background steps that make it hard to test this feature.
