### PR TITLE
Features files sorting

### DIFF
--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -106,7 +106,7 @@ module Cucumber
           path = path.gsub(/\\/, '/') # In case we're on windows. Globs don't work with backslashes.
           path = path.chomp('/')
           if File.directory?(path)
-            Dir["#{path}/**/*.feature"]
+            Dir["#{path}/**/*.feature"].sort
           elsif path[0..0] == '@' and # @listfile.txt
               File.file?(path[1..-1]) # listfile.txt is a file
             IO.read(path[1..-1]).split


### PR DESCRIPTION
Hello,

I encountered an issue where scenarios were working well on a colleague's computer and they were all wrong on the mine.

We dont precise features files in the arguments and we expect that they are launched per alpabetical order.
On my computer, it was not the case, the order is incoherent.

It appears that the function feature_files below in lib/cucumber/cli/configuration.rb use the Dir method which does not sort files so I just added a sort on the Dir.
      def feature_files
        potential_feature_files = paths.map do |path|
          path = path.gsub(/\/, '/') # In case we're on windows. Globs don't work with backslashes.
          path = path.chomp('/')
          if File.directory?(path)
            Dir["#{path}/*_/_.feature"]
          elsif path[0..0] == '@' and # @listfile.txt
              File.file?(path[1..-1]) # listfile.txt is a file
            IO.read(path[1..-1]).split
          else
            path
          end
        end.flatten.uniq
        remove_excluded_files_from(potential_feature_files)
        potential_feature_files
      end

Do you agree with that and if yes, can you merge that to the main branch please ?

Thank you,
Guewen Baconnier
