### PR TITLE
Include scenario file reference in html formatter output

### DIFF
--- a/lib/cucumber/formatter/cucumber.sass
+++ b/lib/cucumber/formatter/cucumber.sass
@@ -92,6 +92,10 @@ body
     a
       :color #999999
     
+  .scenario_file
+    :float right
+    :color #999999
+
 
   .tag
     :font-weight bold

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -164,6 +164,9 @@ module Cucumber
       end
 
       def scenario_name(keyword, name, file_colon_line, source_indent)
+        @builder.span(:class => 'scenario_file') do
+          @builder << file_colon_line
+        end
         @listing_background = false
         @builder.h3(:id => "scenario_#{@scenario_number}") do
           @builder.span(keyword + ':', :class => 'keyword')


### PR DESCRIPTION
It can be hard to uniquely identify scenarios when reviewing a long html formatter result file. Solved.
