### PR TITLE
Add -l, --lines option just like rspec's

### DIFF
--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -240,6 +240,9 @@ module Cucumber
           opts.on("-g", "--guess", "Guess best match for Ambiguous steps.") do
             @options[:guess] = true
           end
+          opts.on("-l", "--lines LINES", "Run given line numbers. Equivalent to FILE:LINE syntax") do |lines|
+            @options[:lines] = lines
+          end
           opts.on("-x", "--expand", "Expand Scenario Outline Tables in output.") do
             @options[:expand] = true
           end
@@ -265,6 +268,7 @@ module Cucumber
           @options[:snippets] = true if @options[:snippets].nil?
           @options[:source]   = true if @options[:source].nil?
         end
+        @args.map! { |a| "#{a}:#{@options[:lines]}" } if @options[:lines]
 
         extract_environment_variables
         @options[:paths] = @args.dup #whatver is left over

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -112,6 +112,13 @@ module Cli
         end
       end
 
+      context '-l LINES or --lines LINES' do
+        it "adds line numbers to args" do
+          options.parse!(%w{-l24 FILE})
+          options.instance_variable_get(:@args).should == ['FILE:24']
+        end
+      end
+
       context '-p PROFILE or --profile PROFILE' do
 
         it "notifies the user that an individual profile is being used" do


### PR DESCRIPTION
Hi,
  I added a -l option as an alternative to the FILE:LINE syntax. My motivation is to able to fully use cucumber in conjunction with [lightning](http://github.com/cldwalker/lightning). Could also help for those used to only rspec. Thanks for making cucumber!

Gabriel
