### PR TITLE
New rake support

### DIFF
--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -1,5 +1,12 @@
 require 'cucumber/platform'
 
+begin
+  # Support Rake > 0.8.7
+  require 'rake/dsl_definition'
+  include Rake::DSL
+rescue LoadError
+end
+
 module Cucumber
   module Rake
     # Defines a Rake task for running features.


### PR DESCRIPTION
I changed the Cucumber::Rake::Task according to the info in the CHANGES file in Rake.

Tested on Rake 0.9.0.beta.4

NOTE: for cucumber specs to run, an identical patch is needed for bundler:
 https://github.com/carlhuda/bundler/pull/1072
