### PR TITLE
Part of #706 - "Possible to remove JSON lock at minor version?"

### DIFF
--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -28,7 +28,7 @@ for important information about this release. Happy cuking!
   s.add_dependency 'term-ansicolor', '~> 1.0.5'
   s.add_dependency 'builder', '>= 2.1.2'
   s.add_dependency 'diff-lcs', '~> 1.1.2'
-  s.add_dependency 'json', '~> 1.4.6'
+  s.add_dependency 'json', '~> 1.4'
   
   s.add_development_dependency 'rake', '~> 0.8.7'
   s.add_development_dependency 'rspec', '~> 2.5'


### PR DESCRIPTION
Hi Aslak,

https://rspec.lighthouseapp.com/projects/16211/tickets/706-possible-to-remove-json-lock-at-minor-version

Second part of #706.  The pointer to :gherkin will need to be updated once a new dot-release is done to capture to the changed JSON version dependency.  I removed the dependency locally and manually specified via :path in the Gemfile to test.

Rob
