### PR TITLE
Remove dependency term-ansicolor

### DIFF
--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -25,7 +25,6 @@ for important information about this release. Happy cuking!
 }
 
   s.add_dependency 'gherkin', '>= 2.3.5'
-  s.add_dependency 'term-ansicolor', '>= 1.0.5'
   s.add_dependency 'builder', '>= 2.1.2'
   s.add_dependency 'diff-lcs', '>= 1.1.2'
   s.add_dependency 'json', '>= 1.4.6'

--- a/lib/cucumber.rb
+++ b/lib/cucumber.rb
@@ -8,6 +8,7 @@ require 'cucumber/step_mother'
 require 'cucumber/cli/main'
 require 'cucumber/broadcaster'
 require 'cucumber/step_definitions'
+require 'cucumber/term/ansicolor'
 
 module Cucumber
   class << self

--- a/lib/cucumber/ast/table.rb
+++ b/lib/cucumber/ast/table.rb
@@ -449,13 +449,13 @@ module Cucumber
         options = {:color => true, :indent => 2, :prefixes => TO_S_PREFIXES}.merge(options)
         io = StringIO.new
 
-        c = Term::ANSIColor.coloring?
-        Term::ANSIColor.coloring = options[:color]
+        c = Cucumber::Term::ANSIColor.coloring?
+        Cucumber::Term::ANSIColor.coloring = options[:color]
         formatter = Formatter::Pretty.new(nil, io, options)
         formatter.instance_variable_set('@indent', options[:indent])
         TreeWalker.new(nil, [formatter]).visit_multiline_arg(self)
         
-        Term::ANSIColor.coloring = c
+        Cucumber::Term::ANSIColor.coloring = c
         io.rewind
         s = "\n" + io.read + (" " * (options[:indent] - 2))
         s

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -195,7 +195,7 @@ module Cucumber
           opts.on("-c", "--[no-]color",
             "Whether or not to use ANSI color in the output. Cucumber decides",
             "based on your platform and the output destination if not specified.") do |v|
-            Term::ANSIColor.coloring = v
+            Cucumber::Term::ANSIColor.coloring = v
           end
           opts.on("-d", "--dry-run", "Invokes formatters without executing the steps.",
             "This also omits the loading of your support/env.rb file if it exists.") do
@@ -206,7 +206,7 @@ module Cucumber
             "Be careful if you choose to overwrite the originals.",
             "Implies --dry-run --formatter pretty.") do |directory|
             @options[:autoformat] = directory
-            Term::ANSIColor.coloring = false
+            Cucumber::Term::ANSIColor.coloring = false
             @options[:dry_run] = true
             @quiet = true
           end

--- a/lib/cucumber/formatter/ansicolor.rb
+++ b/lib/cucumber/formatter/ansicolor.rb
@@ -1,10 +1,5 @@
-begin
-  require 'term/ansicolor'
-rescue LoadError
-  require 'rubygems'
-  require 'term/ansicolor'
-end
 require 'cucumber/platform'
+require 'cucumber/term/ansicolor'
 
 if Cucumber::IRONRUBY
 	begin
@@ -17,11 +12,11 @@ end
 if Cucumber::WINDOWS_MRI
   unless ENV['ANSICON']
     STDERR.puts %{*** WARNING: You must use ANSICON 1.31 or higher (http://adoxa.110mb.com/ansicon) to get coloured output on Windows}
-    Term::ANSIColor.coloring = false
+    Cucumber::Term::ANSIColor.coloring = false
   end
 end
 
-Term::ANSIColor.coloring = false if !STDOUT.tty? && !ENV.has_key?("AUTOTEST")
+Cucumber::Term::ANSIColor.coloring = false if !STDOUT.tty? && !ENV.has_key?("AUTOTEST")
 
 module Cucumber
   module Formatter
@@ -57,11 +52,11 @@ module Cucumber
     # (If you're on Windows, use SET instead of export).
     # To see what colours and effects are available, just run this in your shell:
     #
-    #   ruby -e "require 'rubygems'; require 'term/ansicolor'; puts Term::ANSIColor.attributes"
+    #   ruby -e "require 'rubygems'; require 'term/ansicolor'; puts Cucumber::Term::ANSIColor.attributes"
     #
     # Although not listed, you can also use <tt>grey</tt>
     module ANSIColor
-      include Term::ANSIColor
+      include Cucumber::Term::ANSIColor
 
       ALIASES = Hash.new do |h,k|
         if k.to_s =~ /(.*)_param/
@@ -108,7 +103,7 @@ module Cucumber
           when 0
             raise "Your terminal doesn't support colours"
           when 1
-            ::Term::ANSIColor.coloring = false
+            ::Cucumber::Term::ANSIColor.coloring = false
             alias grey white
           when 2..8
             alias grey white
@@ -130,7 +125,7 @@ module Cucumber
       
       def self.define_real_grey #:nodoc:
         def grey(m) #:nodoc:
-          if ::Term::ANSIColor.coloring?
+          if ::Cucumber::Term::ANSIColor.coloring?
             "\e[90m#{m}\e[0m"
           else
             m

--- a/lib/cucumber/formatter/pretty.rb
+++ b/lib/cucumber/formatter/pretty.rb
@@ -203,7 +203,7 @@ module Cucumber
         cell_text = escape_cell(value.to_s || '')
         padded = cell_text + (' ' * (width - cell_text.unpack('U*').length))
         prefix = cell_prefix(status)
-        @io.print(' ' + format_string("#{prefix}#{padded}", status) + ::Term::ANSIColor.reset(" |"))
+        @io.print(' ' + format_string("#{prefix}#{padded}", status) + ::Cucumber::Term::ANSIColor.reset(" |"))
         @io.flush
       end
 

--- a/lib/cucumber/term/ansicolor.rb
+++ b/lib/cucumber/term/ansicolor.rb
@@ -1,0 +1,118 @@
+module Cucumber
+  module Term
+    # The ANSIColor module can be used for namespacing and mixed into your own
+    # classes.
+    module ANSIColor
+      # :stopdoc:
+      ATTRIBUTES = [
+        [ :clear        ,   0 ], 
+        [ :reset        ,   0 ],     # synonym for :clear
+        [ :bold         ,   1 ], 
+        [ :dark         ,   2 ], 
+        [ :italic       ,   3 ],     # not widely implemented
+        [ :underline    ,   4 ], 
+        [ :underscore   ,   4 ],     # synonym for :underline
+        [ :blink        ,   5 ], 
+        [ :rapid_blink  ,   6 ],     # not widely implemented
+        [ :negative     ,   7 ],     # no reverse because of String#reverse
+        [ :concealed    ,   8 ], 
+        [ :strikethrough,   9 ],     # not widely implemented
+        [ :black        ,  30 ], 
+        [ :red          ,  31 ], 
+        [ :green        ,  32 ], 
+        [ :yellow       ,  33 ], 
+        [ :blue         ,  34 ], 
+        [ :magenta      ,  35 ], 
+        [ :cyan         ,  36 ], 
+        [ :white        ,  37 ], 
+        [ :on_black     ,  40 ], 
+        [ :on_red       ,  41 ], 
+        [ :on_green     ,  42 ], 
+        [ :on_yellow    ,  43 ], 
+        [ :on_blue      ,  44 ], 
+        [ :on_magenta   ,  45 ], 
+        [ :on_cyan      ,  46 ], 
+        [ :on_white     ,  47 ], 
+      ]
+
+      ATTRIBUTE_NAMES = ATTRIBUTES.transpose.first
+      # :startdoc:
+
+      # Returns true, if the coloring function of this module
+      # is switched on, false otherwise.
+      def self.coloring?
+        @coloring
+      end
+
+      # Turns the coloring on or off globally, so you can easily do
+      # this for example:
+      #  Cucumber::Term::ANSIColor::coloring = STDOUT.isatty
+      def self.coloring=(val)
+        @coloring = val
+      end
+      self.coloring = true
+
+      ATTRIBUTES.each do |c, v|
+        eval %Q{
+            def #{c}(string = nil)
+              result = ''
+              result << "\e[#{v}m" if Cucumber::Term::ANSIColor.coloring?
+              if block_given?
+                result << yield
+              elsif string
+                result << string
+              elsif respond_to?(:to_str)
+                result << to_str
+              else
+                return result #only switch on
+              end
+              result << "\e[0m" if Cucumber::Term::ANSIColor.coloring?
+              result
+            end
+        }
+      end
+
+      # Regular expression that is used to scan for ANSI-sequences while
+      # uncoloring strings.
+      COLORED_REGEXP = /\e\[(?:[34][0-7]|[0-9])?m/
+
+
+      def self.included(klass)
+        if version_is_greater_than_18? and klass == String
+          ATTRIBUTES.delete(:clear)
+          ATTRIBUTE_NAMES.delete(:clear)
+        end
+      end
+
+      # Returns an uncolored version of the string, that is all
+      # ANSI-sequences are stripped from the string.
+      def uncolored(string = nil) # :yields:
+        if block_given?
+          yield.gsub(COLORED_REGEXP, '')
+        elsif string
+          string.gsub(COLORED_REGEXP, '')
+        elsif respond_to?(:to_str)
+          to_str.gsub(COLORED_REGEXP, '')
+        else
+          ''
+        end
+      end
+
+      module_function
+
+      # Returns an array of all Cucumber::Term::ANSIColor attributes as symbols.
+      def attributes
+        ATTRIBUTE_NAMES
+      end
+      extend self
+
+      private
+
+      def version_is_greater_than_18?
+        version = RUBY_VERSION.split('.')
+        version.map! &:to_i
+        version[0] >= 1 && version[1] > 8
+      end
+    end
+  end
+end

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -321,12 +321,12 @@ END_OF_MESSAGE
     end
 
     it "should accept --color option" do
-      Term::ANSIColor.should_receive(:coloring=).with(true)
+      Cucumber::Term::ANSIColor.should_receive(:coloring=).with(true)
       config.parse!(['--color'])
     end
 
     it "should accept --no-color option" do
-      Term::ANSIColor.should_receive(:coloring=).with(false)
+      Cucumber::Term::ANSIColor.should_receive(:coloring=).with(false)
       config = Configuration.new(StringIO.new)
       config.parse!(['--no-color'])
     end

--- a/spec/cucumber/formatter/ansicolor_spec.rb
+++ b/spec/cucumber/formatter/ansicolor_spec.rb
@@ -23,7 +23,7 @@ module Cucumber
       end
       
       it "should not generate ansi codes when colors are disabled" do
-        ::Term::ANSIColor.coloring = false
+        ::Cucumber::Term::ANSIColor.coloring = false
         passed("foo").should == "foo"
       end
     end

--- a/spec/cucumber/formatter/progress_spec.rb
+++ b/spec/cucumber/formatter/progress_spec.rb
@@ -6,7 +6,7 @@ module Cucumber
     describe Progress do
 
       before(:each) do
-        Term::ANSIColor.coloring = false
+        Cucumber::Term::ANSIColor.coloring = false
         @out = StringIO.new
         progress = Cucumber::Formatter::Progress.new(mock("step mother"), @out, {})
         @visitor = Cucumber::Ast::TreeWalker.new(nil, [progress])


### PR DESCRIPTION
Per the thread at http://groups.google.com/group/cukes/browse_thread/thread/4ffa442cdfb7ffac this commit embeds term-ansicolor under the Cucumber namespace and removes it from the gemspec.
