### PR TITLE
Bump json version to 1.5.1 to fix Windows fat binary

### DIFF
--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -28,7 +28,7 @@ for important information about this release. Happy cuking!
   s.add_dependency 'term-ansicolor', '>= 1.0.5'
   s.add_dependency 'builder', '>= 2.1.2'
   s.add_dependency 'diff-lcs', '>= 1.1.2'
-  s.add_dependency 'json', '>= 1.4.6'
+  s.add_dependency 'json', '>= 1.5.1'
   
   s.add_development_dependency 'aruba', '>= 0.3.4'
   s.add_development_dependency 'rake', '>= 0.8.7'


### PR DESCRIPTION
The json gem author has finally updated json to create a fat binary on Windows which means it installs correctly on Windows for both 1.8 and 1.9 users. This will make using cucumber on Windows much less painful.
