### PR TITLE
JUnit Formatter: record skipped/pending/undefined scenario results (fixes #655)

### DIFF
--- a/fixtures/junit/features/pending.feature
+++ b/fixtures/junit/features/pending.feature
@@ -2,4 +2,6 @@ Feature: Pending step
 
   Scenario: Pending
     Given a pending step
-    
+
+  Scenario: Undefined
+    Given an undefined step

--- a/legacy_features/junit_formatter.feature
+++ b/legacy_features/junit_formatter.feature
@@ -15,7 +15,7 @@ Feature: JUnit output formatter
     And "fixtures/junit/tmp/TEST-one_passing_one_failing.xml" with junit duration "0.005" should contain
       """
       <?xml version="1.0" encoding="UTF-8"?>
-      <testsuite errors="0" failures="1" name="One passing scenario, one failing scenario" tests="2" time="0.005">
+      <testsuite errors="0" failures="1" name="One passing scenario, one failing scenario" skipped="0" tests="2" time="0.005">
       <testcase classname="One passing scenario, one failing scenario.Passing" name="Passing" time="0.005">
       </testcase>
       <testcase classname="One passing scenario, one failing scenario.Failing" name="Failing" time="0.005">
@@ -34,7 +34,7 @@ Feature: JUnit output formatter
 
       """
   
-  Scenario: pending steps are simply skipped
+  Scenario: pending and undefined steps are reported as skipped
     When I run cucumber --format junit --out tmp/ features/pending.feature
     Then it should pass with
       """
@@ -43,12 +43,18 @@ Feature: JUnit output formatter
     And "fixtures/junit/tmp/TEST-pending.xml" with junit duration "0.009" should contain
       """
       <?xml version="1.0" encoding="UTF-8"?>
-      <testsuite errors="0" failures="0" name="Pending step" tests="0" time="0.009">
+      <testsuite errors="0" failures="0" name="Pending step" skipped="2" tests="2" time="0.009">
+      <testcase classname="Pending step.Pending" name="Pending" time="0.009">
+        <skipped/>
+      </testcase>
+      <testcase classname="Pending step.Undefined" name="Undefined" time="0.009">
+        <skipped/>
+      </testcase>
       </testsuite>
       
       """
 
-  Scenario: pending step with strict option should fail
+  Scenario: pending and undefined steps with strict option should fail
     When I run cucumber --format junit --out tmp/ features/pending.feature --strict
     Then it should fail with
       """
@@ -57,7 +63,7 @@ Feature: JUnit output formatter
     And "fixtures/junit/tmp/TEST-pending.xml" with junit duration "0.000160" should contain
       """
       <?xml version="1.0" encoding="UTF-8"?>
-      <testsuite errors="0" failures="1" name="Pending step" tests="1" time="0.000160">
+      <testsuite errors="0" failures="2" name="Pending step" skipped="0" tests="2" time="0.000160">
       <testcase classname="Pending step.Pending" name="Pending" time="0.000160">
         <failure message="pending Pending" type="pending">
           <![CDATA[Scenario: Pending
@@ -65,6 +71,15 @@ Feature: JUnit output formatter
       ]]>
           <![CDATA[TODO (Cucumber::Pending)
       features/pending.feature:4:in `Given a pending step']]>
+        </failure>
+      </testcase>
+      <testcase classname="Pending step.Undefined" name="Undefined" time="0.000160">
+        <failure message="undefined Undefined" type="undefined">
+          <![CDATA[Scenario: Undefined
+      
+      ]]>
+          <![CDATA[Undefined step: "an undefined step" (Cucumber::Undefined)
+      features/pending.feature:7:in `Given an undefined step']]>
         </failure>
       </testcase>
       </testsuite>


### PR DESCRIPTION
Scenarios with undefined or pending steps are counted as skipped, if strict mode is not enabled. Otherwise they result in failures.

This patch allows the Hudson/Jenkins CI server to show tests which neither passed nor failed. These were ignored previously.

See also bug #655.
