### PR TITLE
Fix Table#rows cell ordering in ruby 1.8

### DIFF
--- a/lib/cucumber/ast/table.rb
+++ b/lib/cucumber/ast/table.rb
@@ -169,7 +169,9 @@ module Cucumber
       end
 
       def rows
-        hashes.map(&:values)
+        hashes.map do |hash|
+          hash.values_at *headers
+        end
       end
 
       def each_cells_row(&proc) #:nodoc:

--- a/spec/cucumber/ast/table_spec.rb
+++ b/spec/cucumber/ast/table_spec.rb
@@ -61,6 +61,10 @@ module Cucumber
         @table.rows.first.should_not include('4444')
       end
 
+      it "should return the row values in order" do
+        @table.rows.first.should == %w{4444 55555 666666}
+      end
+
       it "should pass silently if a mapped column does not exist in non-strict mode" do
         lambda {
           @table.map_column!('two', false) { |v| v.to_i }


### PR DESCRIPTION
Pull request [25](https://github.com/aslakhellesoy/cucumber/pull/25) broke cell ordering in `Table#rows` for ruby 1.8.7 (like [you said it would](https://rspec.lighthouseapp.com/projects/16211/tickets/671-tablemap_columns-mutates-tablehashes-but-not-tablerows#ticket-671-6)).

This is a test and a fix.  Works on both 1.8 and 1.9.
