### PR TITLE
Bug with junit output using Scenario Outlines

### DIFF
--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -62,7 +62,10 @@ module Cucumber
         scenario_name = "Unnamed scenario" if name == ""
         @scenario = scenario_name
         description = "Scenario"
-        description << " outline" if keyword.include?('Scenario Outline')
+        if keyword.include?('Scenario Outline')
+          description << " outline" 
+          @in_examples = true
+        end
         @output = "#{description}: #{@scenario}\n\n"
       end
 


### PR DESCRIPTION
Given I am using junit output
When I have a passing scenario outline with examples
Then the header row should not have a failing entry in the junit output

The one line in this commit fixes this issue, I have tried for the better part of the day to get the specs to pass with this line but with no success.

Our automated build fails without this fix, the only failures are because of the header rows in scenario outlines.
