### PR TITLE
Backported the Rake::DSL support from 0.10.5 into 0.8.5

### DIFF
--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -1,5 +1,11 @@
 require 'cucumber/platform'
 
+begin
+  # Support Rake > 0.8.7
+  require 'rake/dsl_definition'
+  include Rake::DSL
+rescue LoadError
+end
 module Cucumber
   module Rake
     # Defines a Rake task for running features.


### PR DESCRIPTION
I assume this would require a new 0.8.x version?

Signed-off-by: squeedee squeedee@gmail.com
