### PR TITLE
removed the script tag in the .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,2 @@
-script: "rake"
 rvm:
   - 1.9.2
-


### PR DESCRIPTION
Hey Guys,

I removed the script tag in the .travis.yml file as `bundle exec rake` is used by default by Travis.

This should get the tests running on Travis.

Please let me know what we can do to make Cucumber testing on Travis better.

Thanks,

Josh
