### PR TITLE
Guard against the require succeeding, but not properly loading a module. 

### DIFF
--- a/lib/cucumber/core_ext/disable_mini_and_test_unit_autorun.rb
+++ b/lib/cucumber/core_ext/disable_mini_and_test_unit_autorun.rb
@@ -1,13 +1,20 @@
 # Why: http://groups.google.com/group/cukes/browse_thread/thread/5682d41436e235d7
 begin
   require 'minitest/unit'
-  class MiniTest::Unit
-    class << self
-      @@installed_at_exit = true
-    end
+  # Don't attempt to monkeypatch if the require succeeded but didn't
+  # define the actual module.
+  #
+  # https://github.com/cucumber/cucumber/pull/93
+  # http://youtrack.jetbrains.net/issue/TW-17414
+  if defined?(MiniTest::Unit)
+    class MiniTest::Unit
+      class << self
+        @@installed_at_exit = true
+      end
 
-    def run(*)
-      0
+      def run(*)
+        0
+      end
     end
   end
 rescue LoadError => ignore
@@ -15,10 +22,17 @@ end
 
 # Do the same for Test::Unit
 begin
-  require 'test/unit'
-  module Test::Unit
-    def self.run?
-      true
+  require 'test/unit'  
+  # Don't attempt to monkeypatch if the require succeeded but didn't
+  # define the actual module.
+  #
+  # https://github.com/cucumber/cucumber/pull/93
+  # http://youtrack.jetbrains.net/issue/TW-17414
+  if defined?(Test::Unit)
+    module Test::Unit
+      def self.run?
+        true
+      end
     end
   end
 rescue LoadError => ignore


### PR DESCRIPTION
Guard against the require succeeding, but not properly loading a module.  Specifically, TeamCity attempts to monkeypatch minitest if it's defined, but ends up defining a minimal module causing test failures.
