### PR TITLE
Cucumber fails on nil and does not print out failed tests

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -373,8 +373,8 @@ module Cucumber
         @builder.div(:class => 'message') do
           message = exception.message
           if defined?(RAILS_ROOT) && message.include?('Exception caught')
-            matches = message.match(/Showing <i>(.+)<\/i>(?:.+)#(\d+)/)
-            backtrace += ["#{RAILS_ROOT}/#{matches[1]}:#{matches[2]}"]
+            matches = message.match(/Showing <i>(.+)<\/i>(?:.+) #(\d+)/)
+            backtrace += ["#{RAILS_ROOT}/#{matches[1]}:#{matches[2]}"] if matches
             message = message.match(/<code>([^(\/)]+)<\//m)[1]
           end
           @builder.pre do 


### PR DESCRIPTION
Cucumber fails on nil and does not print out failed tests so its impossible to react on unsuccessful build.
