### PR TITLE
replace capturing groups with non-capturing in RbTransform#to_s

### DIFF
--- a/lib/cucumber/rb_support/rb_transform.rb
+++ b/lib/cucumber/rb_support/rb_transform.rb
@@ -34,11 +34,14 @@ module Cucumber
       end
     
       def to_s
-        strip_captures(strip_anchors(@regexp.source))
+         convert_captures(strip_anchors(@regexp.source))
       end
     
     private
-
+      def convert_captures(regexp_source)
+        regexp_source.gsub(/(\()(?!\?:)/,'(?:')
+      end
+      
       def strip_captures(regexp_source)
         regexp_source.
           gsub(/(\()/, '').

--- a/spec/cucumber/rb_support/rb_transform_spec.rb
+++ b/spec/cucumber/rb_support/rb_transform_spec.rb
@@ -8,8 +8,12 @@ module Cucumber
         RbTransform.new(nil, regexp, lambda { |a| })
       end
       describe "#to_s" do
-        it "removes the capture group parentheses" do
-          transform(/(a)bc/).to_s.should == "abc"
+        it "converts captures groups to non-capture groups" do
+          transform(/(a|b)bc/).to_s.should == "(?:a|b)bc"
+        end
+        
+        it "leaves non capture groups alone" do
+          transform(/(?:a|b)bc/).to_s.should == "(?:a|b)bc"
         end
         
         it "strips away anchors" do


### PR DESCRIPTION
Instead of just removing all parentheses in RbTransform#to_s replace the capturing groups with non-capturing.  This allows the use of the returned RbTransform object in more step definitions.

```
CAPTURE_MONEY = Transform /^(\$|£|€)(\d+)$/ do |currency, amount|
   ....
end

When /^I deposited (#{CAPTURE_MONEY})$/ do |money|
  ....
end
```

Without this change CAPTURE_MONEY.to_s returns  $|£|€\d+  which will not match correctly in the step definiton. With this change it will return  (?:$|£|€)(?:\d+)  which will match correctly in the When step.
