### PR TITLE
Do not escape the replaced entity (&#x000A;)

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -291,7 +291,7 @@ module Cucumber
       def doc_string(string)
         return if @hide_this_step
         @builder.pre(:class => 'val') do |pre|
-          @builder << h(string.gsub("\n", '&#x000A;'))
+          @builder << h(string).gsub("\n", '&#x000A;')
         end
       end
   


### PR DESCRIPTION
HTML formatter was escaping the doc_string after having replaced `\n` by `&#x000A;`, thus escaping the entity.
