### PR TITLE
Show class name of exceptions in the HTML formatter

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -378,6 +378,11 @@ module Cucumber
             matches = message.match(/<code>([^(\/)]+)<\//m)
             message = matches ? matches[1] : ""
           end
+
+          unless exception.instance_of?(RuntimeError)
+            message << " (#{exception.class})"
+          end
+
           @builder.pre do 
             @builder.text!(message)
           end


### PR DESCRIPTION
Sometimes the exception class name is useful, and they're already printed when running from the command line. 

I've ignored RuntimeError - we could ignore others as well (perhaps RSpec::Expectations::ExpectationNotMetError).

I couldn't figure out how/if you're testing the HTML formatter at the moment (the legacy feature appears to be failing without my change), but `bundle exec rake` passed for me.
