### PR TITLE
Error when using html formatter on ruby19

### DIFF
--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -1,5 +1,6 @@
 require 'cucumber/cli/profile_loader'
 require 'cucumber/formatter/ansicolor'
+require 'cucumber/formatter/html'
 
 module Cucumber
   module Cli
@@ -64,7 +65,7 @@ module Cucumber
         @profiles = []
         @overridden_paths = []
         @options = default_options
-        
+
         @quiet = @disable_profile_loading = nil
       end
 
@@ -185,7 +186,7 @@ module Cucumber
             "Beware that if you want to use several negative tags to exclude several tags",
             "you have to use logical AND: --tags ~@fixme --tags ~@buggy.",
             "\n",
-            "Positive tags can be given a threshold to limit the number of occurrences.", 
+            "Positive tags can be given a threshold to limit the number of occurrences.",
             "Example: --tags @qa:3 will fail if there are more than 3 occurrences of the @qa tag.",
             "This can be practical if you are practicing Kanban or CONWIP.") do |v|
             @options[:tag_expressions] << v


### PR DESCRIPTION
I have a project that uses cucumber on ruby19 and when I run my tests I get this error:

undefined method `new' for Html:Module

Using ruby debugger I can see module Cucumber::Formatter doesnt have :Html on constants method, this because that file is not required.

I put that require before options class and everything works fine.

Thats all.
