### PR TITLE
Retry when feature_element returns failed

### DIFF
--- a/lib/cucumber/formatter/rerun.rb
+++ b/lib/cucumber/formatter/rerun.rb
@@ -46,7 +46,7 @@ module Cucumber
       end
 
       def after_feature_element(feature_element)
-        if @rerun
+        if @rerun || feature_element.failed?
           file, line = *feature_element.file_colon_line.split(':')
           @lines << line
           @file = file


### PR DESCRIPTION
Previously a feature element would only be retried if a step raised an exception. However feature elements can fail in before blocks as well. We should therefore check both the steps and the feature element's status to appropriately mark it for retry.
