### PR TITLE
HTML Formatter should have collapsible backgrounds

### DIFF
--- a/lib/cucumber/formatter/cucumber.css
+++ b/lib/cucumber/formatter/cucumber.css
@@ -21,7 +21,7 @@ body {
   float: right;
   margin: 0 0 0 10px;
 }
-.cucumber .scenario h3, td .scenario h3, th .scenario h3 {
+.cucumber .scenario h3, td .scenario h3, th .scenario h3, .background h3 {
   font-size: 11px;
   padding: 3px;
   margin: 0;
@@ -29,6 +29,12 @@ body {
   color: white;
   font-weight: bold;
 }
+
+.background h3 {
+  font-size: 1.2em;
+  background: #666;
+}
+
 .cucumber h1, td h1, th h1 {
   margin: 0px 10px 0px 10px;
   padding: 10px;

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -143,7 +143,7 @@ module Cucumber
   
       def background_name(keyword, name, file_colon_line, source_indent)
         @listing_background = true
-        @builder.h3 do |h3|
+        @builder.h3(:id => "background_#{@scenario_number}") do |h3|
           @builder.span(keyword, :class => 'keyword')
           @builder.text!(' ')
           @builder.span(name, :class => 'val')
@@ -513,7 +513,7 @@ module Cucumber
       def inline_js_content
         <<-EOF
 
-  SCENARIOS = "h3[id^='scenario_']";
+  SCENARIOS = "h3[id^='scenario_'],h3[id^=background_]";
   
   $(document).ready(function() {
     $(SCENARIOS).css('cursor', 'pointer');


### PR DESCRIPTION
In some projects Backgrounds become very long. This patch styles them the same as Scenario headers (but in grey by default) and makes them collapsible by click on them or the "collapse all" link at the top.
