### PR TITLE
JUnit formatter, classname contains only the features name

### DIFF
--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -114,7 +114,7 @@ module Cucumber
 
       def build_testcase(duration, status, exception = nil, suffix = "")
         @time += duration
-        classname = "#{@feature_name}.#{@scenario}"
+        classname = @feature_name
         name = "#{@scenario}#{suffix}"
         pending = [:pending, :undefined].include?(status)
         passed = (status == :passed || (pending && !@options[:strict]))


### PR DESCRIPTION
In the `testcase` attribute `name` is the name of the test and `classname` of his group, which is often similar to the attribute `name` block `testsuite`.
