### PR TITLE
Add dependency status via Gemnasium to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://secure.travis-ci.org/cucumber/cucumber.png)](http://travis-ci.org/cucumber/cucumber)
+[![Build Status](https://secure.travis-ci.org/cucumber/cucumber.png)](http://travis-ci.org/cucumber/cucumber) [![Dependency Status](https://gemnasium.com/cucumber/cucumber.png)](https://gemnasium.com/cucumber/cucumber)
 
 The main website is at http://cukes.info/
 The documentation is at https://wiki.github.com/cucumber/cucumber/


### PR DESCRIPTION
The dependency status is an indicator of how up-to-date Cucumber's gem dependencies are with their latest versions. All Cucumber needs to be completely up-to-date is for prawn's requirement to be bumped up.
