### PR TITLE
Diff tables with misplaced columns

### DIFF
--- a/lib/cucumber/ast/table.rb
+++ b/lib/cucumber/ast/table.rb
@@ -285,7 +285,8 @@ module Cucumber
       # #diff!. You can use #map_column! on either of the tables.
       #
       # A Different error is raised if there are missing rows or columns, or
-      # surplus rows. An error is <em>not</em> raised for surplus columns.
+      # surplus rows. An error is <em>not</em> raised for surplus columns. An
+      # error is <em>not</em> raised for misplaced (out of sequence) columns.
       # Whether to raise or not raise can be changed by setting values in
       # +options+ to true or false:
       #
@@ -293,6 +294,7 @@ module Cucumber
       # * <tt>surplus_row</tt> : Raise on surplus rows (defaults to true)
       # * <tt>missing_col</tt> : Raise on missing columns (defaults to true)
       # * <tt>surplus_col</tt> : Raise on surplus columns (defaults to false)
+      # * <tt>misplaced_col</tt> : Raise on misplaced columns (defaults to false)
       #
       # The +other_table+ argument can be another Table, an Array of Array or
       # an Array of Hash (similar to the structure returned by #hashes).
@@ -301,7 +303,13 @@ module Cucumber
       # a Table argument, if you want to compare that table to some actual values. 
       #
       def diff!(other_table, options={})
-        options = {:missing_row => true, :surplus_row => true, :missing_col => true, :surplus_col => false}.merge(options)
+        options = {
+          :missing_row   => true,
+          :surplus_row   => true,
+          :missing_col   => true,
+          :surplus_col   => false,
+          :misplaced_col => false
+        }.merge(options)
 
         other_table = ensure_table(other_table)
         other_table.convert_headers!
@@ -317,6 +325,7 @@ module Cucumber
 
         missing_col = cell_matrix[0].detect{|cell| cell.status == :undefined}
         surplus_col = padded_width > original_width
+        misplaced_col = cell_matrix[0] != other_table.cell_matrix[0]
 
         require_diff_lcs
         cell_matrix.extend(Diff::LCS)
@@ -365,7 +374,8 @@ module Cucumber
           missing_row_pos && options[:missing_row] ||
           insert_row_pos  && options[:surplus_row] ||
           missing_col     && options[:missing_col] ||
-          surplus_col     && options[:surplus_col]
+          surplus_col     && options[:surplus_col] ||
+          misplaced_col   && options[:misplaced_col]
         raise Different.new(self) if should_raise
       end
 

--- a/spec/cucumber/ast/table_spec.rb
+++ b/spec/cucumber/ast/table_spec.rb
@@ -474,6 +474,15 @@ module Cucumber
             lambda { @t.dup.diff!(t) }.should_not raise_error
             lambda { @t.dup.diff!(t, :surplus_col => true) }.should raise_error
           end
+
+          it "should not raise on misplaced columns" do
+            t = table(%{
+              | b | a |
+              | d | c |
+            }, __FILE__, __LINE__)
+            lambda { @t.dup.diff!(t) }.should_not raise_error
+            lambda { @t.dup.diff!(t, :misplaced_col => true) }.should raise_error
+          end
         end
 
         def table(text, file, offset)


### PR DESCRIPTION
With an optional `:misplaced_col` option to the `Cucumber::Ast::Table#diff!` method, one can ensure that column headings between the two tables are in the same order.

This is useful in a Cucumber step where you'd like to assert the exact contents of an HTML table, including structure. I ran into this in a JavaScript scenario where I test drag-and-drop column reordering.

The new option defaults to `false` so it should not break backwards compatibility.
