### PR TITLE
add path and line number to stepdefs.json

### DIFF
--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -143,6 +143,7 @@ module Cucumber
               end
             end
           end
+          stepdef_hash['file_colon_line'] = stepdef.file_colon_line
           stepdef_hash['steps'] = steps.uniq.sort {|a,b| a['name'] <=> b['name']}
           stepdefs << stepdef_hash
         end


### PR DESCRIPTION
An option --dotcucumber is so nice that I, as a programmer, am encouraged to write more and more well understandable steps.Since I have many steps, I've wanted to glance an index, copy them to feature, and step into the definition.

So is it good to include step definition's path to `stepdefs.json` ?

An use case of this is: https://github.com/moro/unite-stepdefs -- a vim plugin using this file:column output.

thanks.
