### PR TITLE
Don't pollute RbWorld with the AnsiEscapes methods

### DIFF
--- a/lib/cucumber/rb_support/rb_world.rb
+++ b/lib/cucumber/rb_support/rb_world.rb
@@ -4,7 +4,7 @@ module Cucumber
   module RbSupport
     # All steps are run in the context of an object that extends this module.
     module RbWorld
-      include Gherkin::Formatter::AnsiEscapes
+      AnsiEscapes = Gherkin::Formatter::AnsiEscapes
 
       class << self
         def alias_adverb(adverb)
@@ -21,7 +21,7 @@ module Cucumber
       attr_writer :__cucumber_step_mother, :__natural_language
 
       def __cucumber_invoke(name, multiline_argument=nil) #:nodoc:
-        STDERR.puts failed + "WARNING: Using 'Given/When/Then' in step definitions is deprecated, use 'step' to call other steps instead:" + caller[0] + reset
+        STDERR.puts AnsiEscapes.failed + "WARNING: Using 'Given/When/Then' in step definitions is deprecated, use 'step' to call other steps instead:" + caller[0] + AnsiEscapes.reset
         @__cucumber_step_mother.invoke(name, multiline_argument)
       end
 
@@ -46,7 +46,7 @@ module Cucumber
       end
 
       def announce(*messages)
-        STDERR.puts failed + "WARNING: #announce is deprecated. Use #puts instead:" + caller[0] + reset
+        STDERR.puts AnsiEscapes.failed + "WARNING: #announce is deprecated. Use #puts instead:" + caller[0] + AnsiEscapes.reset
         puts(*messages)
       end
 


### PR DESCRIPTION
My alternate solution to #219. Alias AnsiEscapes where it's needed and call the methods on the module itself.

One failure on the full suite that I'm hoping someone can help with:

```
Using the default profile...
..........................................................................................................................................................................Using Cucumber, Unknown
Loading Spork.prefork block...
I'm loading all the heavy stuff...
Spork is ready and listening on 8990!
.Running tests with args ["features/sample.feature", "-r", "features", "--tags", "~@wip", "--format", "pretty", "--strict", "--tags", "~@wip", "--no-profile"]...
Done.

.......Using Cucumber, Unknown
Loading Spork.prefork block...
I'm loading all the heavy stuff...
Spork is ready and listening on 8990!
.Running tests with args ["features/sample.feature", "--tags", "~@wip", "--format", "pretty", "--strict", "--tags", "~@wip", "--no-profile"]...
Done.

............................................F...........................................

(::) failed steps (::)

expected "F\n\n(::) failed steps (::)\n\nundefined method `failed' for Gherkin::Formatter::AnsiEscapes:Module (NoMethodError)\n./features/step_definitions/test_steps2.rb:2:in `/two turtles/'\nfeatures/test_feature_1.feature:3:in `Given two turtles'\n\nFailing Scenarios:\ncucumber features/test_feature_1.feature:2 # Scenario: Test Scenario 1\n\n1 scenario (1 failed)\n1 step (1 failed)\n0m0.012s\n" to include "WARNING"
Diff:
@@ -1,2 +1,15 @@
-["WARNING"]
+F
+
+(::) failed steps (::)
+
+undefined method `failed' for Gherkin::Formatter::AnsiEscapes:Module (NoMethodError)
+./features/step_definitions/test_steps2.rb:2:in `/two turtles/'
+features/test_feature_1.feature:3:in `Given two turtles'
+
+Failing Scenarios:
+cucumber features/test_feature_1.feature:2 # Scenario: Test Scenario 1
+
+1 scenario (1 failed)
+1 step (1 failed)
+0m0.012s
 (RSpec::Expectations::ExpectationNotMetError)
features/nested_steps.feature:60:in `Then the output should contain "WARNING"'

Failing Scenarios:
cucumber features/nested_steps.feature:52 # Scenario: Use deprecated i18n methods

37 scenarios (1 failed, 36 passed)
237 steps (1 failed, 236 passed)
0m17.538s
```

That is, the failure doesn't occur when run directly, but seems to occur with spork. The failure itself (undefined method `failed' for Gherkin::Formatter::AnsiEscapes:Module) is demonstrably false, so I'm not sure what's up.
