### PR TITLE
Deprecate another source tag names

### DIFF
--- a/lib/cucumber/ast/outline_table.rb
+++ b/lib/cucumber/ast/outline_table.rb
@@ -79,6 +79,11 @@ module Cucumber
           @scenario_exception = nil
         end
 
+        def source_tag_names
+          warn("Deprecated: please use #source_tags instead.")
+          source_tags.map { |tag| tag.name }
+        end
+
         def source_tags
           @table.source_tags
         end


### PR DESCRIPTION
Deprecate another source_tag_names method for capybara.

(parent: https://github.com/cucumber/cucumber/commit/844fefea2a31bf956610e4d1ee1bca2e14e3fc53)
