### PR TITLE
suggestion for slightly cleaner regexps

### DIFF
--- a/lib/cucumber/js_support/js_snippets.rb
+++ b/lib/cucumber/js_support/js_snippets.rb
@@ -1,7 +1,7 @@
 module Cucumber
   module JsSupport
     module JsSnippets
-      PARAM_PATTERN = /"([^"]*)"/
+      PARAM_PATTERN = /"(.*?)"/
       ESCAPED_PARAM_PATTERN = '"([^\\"]*)"'
 
       def snippet_text(code_keyword, step_name, multiline_arg_class)

--- a/lib/cucumber/rb_support/rb_language.rb
+++ b/lib/cucumber/rb_support/rb_language.rb
@@ -75,7 +75,7 @@ module Cucumber
         end.compact
       end
 
-      ARGUMENT_PATTERNS = ['"([^"]*)"', '(\d+)']
+      ARGUMENT_PATTERNS = ['"(.*?)"', '(\d+)']
 
       def snippet_text(code_keyword, step_name, multiline_arg_class)
         snippet_pattern = Regexp.escape(step_name).gsub('\ ', ' ').gsub('/', '\/')

--- a/spec/cucumber/rb_support/rb_language_spec.rb
+++ b/spec/cucumber/rb_support/rb_language_spec.rb
@@ -31,7 +31,7 @@ module Cucumber
 
         it "should recognise a mix of ints, strings and why not a table too" do
           rb.snippet_text('Given', 'I have 9 "awesome" cukes in 37 "boxes"', Cucumber::Ast::Table).should == unindented(%{
-          Given /^I have (\\d+) "([^"]*)" cukes in (\\d+) "([^"]*)"$/ do |arg1, arg2, arg3, arg4, table|
+          Given /^I have (\\d+) "(.*?)" cukes in (\\d+) "(.*?)"$/ do |arg1, arg2, arg3, arg4, table|
             # table is a Cucumber::Ast::Table
             pending # express the regexp above with the code you wish you had
           end
@@ -40,7 +40,7 @@ module Cucumber
 
         it "should recognise quotes in name and make according regexp" do
           rb.snippet_text('Given', 'A "first" arg', nil).should == unindented(%{
-          Given /^A "([^"]*)" arg$/ do |arg1|
+          Given /^A "(.*?)" arg$/ do |arg1|
             pending # express the regexp above with the code you wish you had
           end
           })
@@ -48,7 +48,7 @@ module Cucumber
 
         it "should recognise several quoted words in name and make according regexp and args" do
           rb.snippet_text('Given', 'A "first" and "second" arg', nil).should == unindented(%{
-          Given /^A "([^"]*)" and "([^"]*)" arg$/ do |arg1, arg2|
+          Given /^A "(.*?)" and "(.*?)" arg$/ do |arg1, arg2|
             pending # express the regexp above with the code you wish you had
           end
           })
@@ -64,7 +64,7 @@ module Cucumber
 
         it "should be helpful with tables" do
           rb.snippet_text('Given', 'A "first" arg', Cucumber::Ast::Table).should == unindented(%{
-          Given /^A "([^"]*)" arg$/ do |arg1, table|
+          Given /^A "(.*?)" arg$/ do |arg1, table|
             # table is a Cucumber::Ast::Table
             pending # express the regexp above with the code you wish you had
           end


### PR DESCRIPTION
I suggested this change while reviewing a cucumber-using project:
- Given /^"([^"]*)" instance's provider is not accessible$/ do |arg1|
- Given /^"(._?)" instance's provider is not accessible$/ do |arg1|
  since the use of non-greedy ._? is equivalent and more readable.
  Then I learned that these were based on suggestions from cucumber,
  so now I'm suggesting the improvement here.
