### PR TITLE
Update table_spec.rb to document current URL for issue #220

### DIFF
--- a/spec/cucumber/ast/table_spec.rb
+++ b/spec/cucumber/ast/table_spec.rb
@@ -448,12 +448,8 @@ module Cucumber
             }, __FILE__, __LINE__)
             lambda { t1.dup.diff!(t2) }.should raise_error
 
-            begin
-              pending "https://github.com/cucumber/cucumber/issues/220" do
-                lambda { t1.dup.diff!(t2, :surplus_row => false) }.should_not raise_error
-              end
-            rescue => e
-              warn(e.message + " - see http://www.ruby-forum.com/topic/208508")
+            pending "https://github.com/cucumber/cucumber/issues/220" do
+              lambda { t1.dup.diff!(t2, :surplus_row => false) }.should_not raise_error
             end
           end
 


### PR DESCRIPTION
I've updated the description of the sole "pending" test in table_spec.rb to the current URL of the applicable issue (#220).

I've also removed a rescue clause that seems to be obsolete now.
