### PR TITLE
Support for specify log prefix for junit formatter

### DIFF
--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -7,11 +7,24 @@ module Cucumber
     # The formatter used for <tt>--format junit</tt>
     class Junit
       include Io
-      
+
       class UnNamedFeatureError < StandardError
         def initialize(feature_file)
           super("The feature in '#{feature_file}' does not have a name. The JUnit XML format requires a name for the testsuite element.")
         end
+      end
+
+      # Sets log file prefix. If you specify an empty string (or nil)
+      # then no prefix will be prepended to the name of log files.
+      # By default, Cucumber prepends "TEST" for every file name for 
+      # the created logs.
+      def self.log_prefix=(prefix)
+        @@log_prefix = prefix
+      end
+      
+      # Returns with actual log file prefix
+      def self.log_prefix
+        defined?(@@log_prefix) ? @@log_prefix : "TEST"
       end
       
       def initialize(step_mother, io, options)
@@ -139,8 +152,17 @@ module Cucumber
         (["#{exception.message} (#{exception.class})"] + exception.backtrace).join("\n")
       end
       
+      def log_prefix
+        if defined?(@@log_prefix)
+          (@@log_prefix.nil? || @@log_prefix.empty?) ? "" : "#{@@log_prefix}-"
+        else
+          # Current behavior
+          "TEST-"
+        end
+      end
+
       def feature_result_filename(feature_file)
-        File.join(@reportdir, "TEST-#{basename(feature_file)}.xml")
+        File.join(@reportdir, "#{log_prefix}#{basename(feature_file)}.xml")
       end
       
       def basename(feature_file)


### PR DESCRIPTION
Introducing a way to specify log prefix for JUnit formatter.

Example code:

``` ruby
# features/support/junit.rb
require 'cucumber/formatter/junit'
Cucumber::Formatter::Junit.log_prefix = "FEATURE"
```

This implementation supports empty string what means formatter will not prepend any prefix for generated log file names.
If developer does not touch the prefix, it wouldn't change the current behavior, formatter prepend "TEST" for every filename
