### PR TITLE
A patch for #188, fatal on optional step arguments

### DIFF
--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -70,9 +70,14 @@ module Cucumber
           format % step_argument.val
         end
 
-        s[step_argument.offset + offset, step_argument.val.length] = replacement
-        offset += replacement.unpack('U*').length - step_argument.val.unpack('U*').length
-        past_offset = step_argument.offset + step_argument.val.length
+	if step_argument.val.nil?
+          s[step_argument.offset + offset, 0] = replacement
+          past_offset = step_argument.offset
+	else
+          s[step_argument.offset + offset, step_argument.val.length] = replacement
+          offset += replacement.unpack('U*').length - step_argument.val.unpack('U*').length
+          past_offset = step_argument.offset + step_argument.val.length
+	end
       end
       s
     end


### PR DESCRIPTION
Prevents fatal exception when a step is executed but not all matches have a hit (optional matches ... think a re with (\w)?

Apologies for any ruby faux pas, not really my competency
