### PR TITLE
fixes #188

### DIFF
--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -70,9 +70,10 @@ module Cucumber
           format % step_argument.val
         end
 
-        s[step_argument.offset + offset, step_argument.val.length] = replacement
-        offset += replacement.unpack('U*').length - step_argument.val.unpack('U*').length
-        past_offset = step_argument.offset + step_argument.val.length
+        val = String(step_argument.val)
+        s[step_argument.offset + offset, val.length] = replacement
+        offset += replacement.unpack('U*').length - val.unpack('U*').length
+        past_offset = step_argument.offset + val.length
       end
       s
     end


### PR DESCRIPTION
cast val to string since JRuby (1.6.5) complains if it is nil:

undefined method `length' for nil:NilClass (NoMethodError)
.../lib/cucumber/step_match.rb:73:in`replace_arguments'
