### PR TITLE
Output the step cucumber is *about* to execute so user can see what is *currently* executing.

### DIFF
--- a/lib/cucumber/formatter/console.rb
+++ b/lib/cucumber/formatter/console.rb
@@ -26,6 +26,12 @@ module Cucumber
         format_string(line, status)
       end
 
+      # useful for before_step, which doesn't have access to step_match
+      def format_step_without_step_match(step)
+        line = step.keyword + step.name
+        format_string(line, step.status)
+      end
+
       def format_string(o, status)
         fmt = format_for(status)
         o.to_s.split("\n").map do |line|

--- a/lib/cucumber/formatter/pretty.rb
+++ b/lib/cucumber/formatter/pretty.rb
@@ -127,6 +127,15 @@ module Cucumber
       def before_step(step)
         @current_step = step
         @indent = 6
+
+        # Output the step we are *about* to execute so user can see what is *currently* executing.
+        # This causes each step to be displayed with the :skipped color initially and then for that
+        # line to be *redrawn* with the :passed or :failed color after it has finished executing.
+        # (The "\r" causes the cursor to return to the beginning of the line *without* moving to the
+        # next line ("\n"), so this output will get overwritten with the output from step_name() as
+        # soon as the step is finished.)
+        name_to_report = format_step_without_step_match(step) + "\r"
+        @io.print(name_to_report.indent(@scenario_indent + 2))
       end
 
       def before_step_result(keyword, step_match, multiline_arg, status, exception, source_indent, background, file_colon_line)


### PR DESCRIPTION
I find it somewhat confusing and unhelpful that cucumber only tells me which step has been executed
_after_ it has finished executing that step.

This is especially an issue when I am running tests that are driving interactions in a web browser
(with selenium webdriver) and watching both the output from cucumber and the interactions in the
browser at the same time. What I was seeing happening in the browser would appear to not match up
with the output provided by cucumber, because cucumber was "behind" -- still displaying the results
from the _previous_ step invocation.

I'd really like to be able to see what's going on inside cucumber a bit more and to be able to see
**which step is cucumber currently executing right now**.

This patch provides that behavior. I've been using it for a while now and it seems to work well.

As a side effect (not a bad side effect though, in my opinion, though that's debatable), if your
step happens to invoke _other_ steps as part of its step definition, this patch causes cucumber to
report which of those inner step invocations is currently being executed and not just the step that
is mentioned in your (outer) gherkin file.
