### PR TITLE
Add Code Climate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://secure.travis-ci.org/cucumber/cucumber.png)](http://travis-ci.org/cucumber/cucumber)
+[![Build Status](https://secure.travis-ci.org/cucumber/cucumber.png)](http://travis-ci.org/cucumber/cucumber) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/cucumber/cucumber)
 
 The main website is at http://cukes.info/
 The documentation is at https://wiki.github.com/cucumber/cucumber/


### PR DESCRIPTION
Hi Aslak, Matt, Joseph, Ben, et al.

Today I just fully launched Code Climate's free-for-OSS support. Code Climate provides hosted code quality metrics for Ruby apps/libraries. You can view the data for Cucumber here:

```
https://codeclimate.com/github/cucumber/cucumber
```

This is just a quick pull request that adds a badge to the Cucumber README, in case you want this information to be available to contributors, like RSpec does:

```
https://github.com/rspec/rspec-rails#readme
```

Let me know if you have any questions!

Best,

-Bryan
