### PR TITLE
Exit status should be 1 if I ctrl+C

### DIFF
--- a/lib/cucumber/cli/main.rb
+++ b/lib/cucumber/cli/main.rb
@@ -42,7 +42,7 @@ module Cucumber
 
         runtime.run!
         runtime.write_stepdefs_json
-        runtime.results.failure?
+        runtime.results.failure? || Cucumber.wants_to_quit
       rescue ProfilesNotDefinedError, YmlLoadError, ProfileNotFound => e
         @error_stream.puts e.message
         true

--- a/spec/cucumber/cli/main_spec.rb
+++ b/spec/cucumber/cli/main_spec.rb
@@ -41,6 +41,22 @@ module Cucumber
             do_execute.should == expected_results.failure?
           end
         end
+
+        context "interrupted with ctrl-c" do
+          after do
+            Cucumber.wants_to_quit = false
+          end
+
+          it "should register as a failure" do
+            results = double('results', :failure? => false)
+            runtime = Runtime.any_instance
+            runtime.stub(:run!)
+            runtime.stub(:results).and_return(results)
+
+            Cucumber.wants_to_quit = true
+            subject.execute!.should be_true
+          end
+        end
       end
 
       describe "verbose mode" do


### PR DESCRIPTION
Hitting ctrl+c short circuits the rest of the tests. When scripts depend on cucumber failing or succeeding this is a bad thing as exiting with a 0 is a false positive.
