### PR TITLE
Set 'http-equiv' to meta tag for specifying charset

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -55,7 +55,7 @@ module Cucumber
 
         @builder << '<html xmlns ="http://www.w3.org/1999/xhtml">'
           @builder.head do
-          @builder.meta(:content => 'text/html;charset=utf-8')
+          @builder.meta('http-equiv' => 'Content-Type', :content => 'text/html;charset=utf-8')
           @builder.title 'Cucumber'
           inline_css
           inline_js


### PR DESCRIPTION
In order to specify the charset in the meta tag, `http-equiv="Content-Type"` should be set as an attribute of meta tag.
Some browsers couldn't recognize character code as UTF-8.

For example, the following browser:
- Google Chrome (21.0.1180.82)
