### PR TITLE
Add a feature describing how I think hooks should work

### DIFF
--- a/features/.cucumber/stepdefs.json
+++ b/features/.cucumber/stepdefs.json
@@ -20,105 +20,7 @@
     "flags": "",
     "file_colon_line": "aruba-0.4.11/lib/aruba/cucumber.rb:15",
     "steps": [
-      {
-        "name": "a file named \"features/doc_string.feature\" with:",
-        "args": [
-          {
-            "offset": 14,
-            "val": "features/doc_string.feature"
-          }
-        ]
-      },
-      {
-        "name": "a file named \"features/f.feature\" with:",
-        "args": [
-          {
-            "offset": 14,
-            "val": "features/f.feature"
-          }
-        ]
-      },
-      {
-        "name": "a file named \"features/only_background_and_hooks.feature\" with:",
-        "args": [
-          {
-            "offset": 14,
-            "val": "features/only_background_and_hooks.feature"
-          }
-        ]
-      },
-      {
-        "name": "a file named \"features/only_background_and_hooks_steps.rb\" with:",
-        "args": [
-          {
-            "offset": 14,
-            "val": "features/only_background_and_hooks_steps.rb"
-          }
-        ]
-      },
-      {
-        "name": "a file named \"features/step_definitions/doc_string_steps.rb\" with:",
-        "args": [
-          {
-            "offset": 14,
-            "val": "features/step_definitions/doc_string_steps.rb"
-          }
-        ]
-      },
-      {
-        "name": "a file named \"features/step_definitions/multiline_steps.rb\" with:",
-        "args": [
-          {
-            "offset": 14,
-            "val": "features/step_definitions/multiline_steps.rb"
-          }
-        ]
-      },
-      {
-        "name": "a file named \"features/step_definitions/steps.rb\" with:",
-        "args": [
-          {
-            "offset": 14,
-            "val": "features/step_definitions/steps.rb"
-          }
-        ]
-      },
-      {
-        "name": "a file named \"features/support/hooks.rb\" with:",
-        "args": [
-          {
-            "offset": 14,
-            "val": "features/support/hooks.rb"
-          }
-        ]
-      },
-      {
-        "name": "a file named \"features/support/jb/formatter.rb\" with:",
-        "args": [
-          {
-            "offset": 14,
-            "val": "features/support/jb/formatter.rb"
-          }
-        ]
-      },
-      {
-        "name": "a file named \"features/support/ze/formator.rb\" with:",
-        "args": [
-          {
-            "offset": 14,
-            "val": "features/support/ze/formator.rb"
-          }
-        ]
-      },
-      {
-        "name": "a file named \"features/test.feature\" with:",
-        "args": [
-          {
-            "offset": 14,
-            "val": "features/test.feature"
-          }
-        ]
-      }
+
     ]
   },
   {
@@ -199,24 +101,6 @@
     "file_colon_line": "aruba-0.4.11/lib/aruba/cucumber.rb:56",
     "steps": [
       {
-        "name": "I run `cucumber -f stepdefs --dry-run`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -f stepdefs --dry-run"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber -f usage --dry-run`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -f usage --dry-run"
-          }
-        ]
-      },
-      {
         "name": "I run `cucumber -o /dev/null features/all_hook_order.feature`",
         "args": [
           {
@@ -231,177 +115,6 @@
           {
             "offset": 7,
             "val": "cucumber -o /dev/null features/around_hook_covers_background.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber -q -t @one -t @three features/tagulicious.feature`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -q -t @one -t @three features/tagulicious.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber -q -t @one,@three features/tagulicious.feature`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -q -t @one,@three features/tagulicious.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber -q features/background_tagged_before_on_outline.feature`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -q features/background_tagged_before_on_outline.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber -q features/failing_background.feature`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -q features/failing_background.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber -q features/failing_background_after_success.feature`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -q features/failing_background_after_success.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber -q features/multiline_args_background.feature`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -q features/multiline_args_background.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber -q features/passing_background.feature:9`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -q features/passing_background.feature:9"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber -q features/passing_background.feature`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -q features/passing_background.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber -q features/pending_background.feature`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -q features/pending_background.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber -q features/scenario_outline_failing_background.feature`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -q features/scenario_outline_failing_background.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber -q features/scenario_outline_passing_background.feature`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -q features/scenario_outline_passing_background.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber -q features/tagulicious.feature`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber -q features/tagulicious.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber features/f.feature:2`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber features/f.feature:2"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber features/f.feature:6`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber features/f.feature:6"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber features/failing_hard.feature`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber features/failing_hard.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber features/only_background_and_hooks.feature`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber features/only_background_and_hooks.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber features/test.feature:5 -f progress`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber features/test.feature:5 -f progress"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber features/test.feature:8 -f progress`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber features/test.feature:8 -f progress"
-          }
-        ]
-      },
-      {
-        "name": "I run `cucumber`",
-        "args": [
-          {
-            "offset": 7,
-            "val": "cucumber"
           }
         ]
       }
@@ -452,15 +165,7 @@
     "flags": "",
     "file_colon_line": "aruba-0.4.11/lib/aruba/cucumber.rb:82",
     "steps": [
-      {
-        "name": "the output should contain \"WARNING\"",
-        "args": [
-          {
-            "offset": 27,
-            "val": "WARNING"
-          }
-        ]
-      }
+
     ]
   },
   {
@@ -561,24 +266,7 @@
     "flags": "",
     "file_colon_line": "aruba-0.4.11/lib/aruba/cucumber.rb:134",
     "steps": [
-      {
-        "name": "it should fail with:",
-        "args": [
-          {
-            "offset": 10,
-            "val": "fail"
-          }
-        ]
-      },
-      {
-        "name": "it should pass with:",
-        "args": [
-          {
-            "offset": 10,
-            "val": "pass"
-          }
-        ]
-      }
+
     ]
   },
   {
@@ -586,24 +274,7 @@
     "flags": "",
     "file_colon_line": "aruba-0.4.11/lib/aruba/cucumber.rb:138",
     "steps": [
-      {
-        "name": "it should fail with exactly:",
-        "args": [
-          {
-            "offset": 10,
-            "val": "fail"
-          }
-        ]
-      },
-      {
-        "name": "it should pass with exactly:",
-        "args": [
-          {
-            "offset": 10,
-            "val": "pass"
-          }
-        ]
-      }
+
     ]
   },
   {
@@ -851,87 +522,7 @@
     "flags": "",
     "file_colon_line": "features/step_definitions/cucumber_steps.rb:1",
     "steps": [
-      {
-        "name": "I run cucumber \"--format json features/doc_string.feature\"",
-        "args": [
-          {
-            "offset": 16,
-            "val": "--format json features/doc_string.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run cucumber \"--format json features/one_passing_one_failing.feature\"",
-        "args": [
-          {
-            "offset": 16,
-            "val": "--format json features/one_passing_one_failing.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run cucumber \"-b --format json features/embed.feature\"",
-        "args": [
-          {
-            "offset": 16,
-            "val": "-b --format json features/embed.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run cucumber \"features/f.feature --format Jb::Formatter\"",
-        "args": [
-          {
-            "offset": 16,
-            "val": "features/f.feature --format Jb::Formatter"
-          }
-        ]
-      },
-      {
-        "name": "I run cucumber \"features/f.feature --format Ze::Formator\"",
-        "args": [
-          {
-            "offset": 16,
-            "val": "features/f.feature --format Ze::Formator"
-          }
-        ]
-      },
-      {
-        "name": "I run cucumber \"features/foo.feature\"",
-        "args": [
-          {
-            "offset": 16,
-            "val": "features/foo.feature"
-          }
-        ]
-      },
-      {
-        "name": "I run cucumber \"features/one_passing_one_failing.feature -r features -f rerun\"",
-        "args": [
-          {
-            "offset": 16,
-            "val": "features/one_passing_one_failing.feature -r features -f rerun"
-          }
-        ]
-      },
-      {
-        "name": "I run cucumber \"features/sample.feature --tags ~@wip\"",
-        "args": [
-          {
-            "offset": 16,
-            "val": "features/sample.feature --tags ~@wip"
-          }
-        ]
-      },
-      {
-        "name": "I run cucumber \"features/sample.feature -r features --tags ~@wip\"",
-        "args": [
-          {
-            "offset": 16,
-            "val": "features/sample.feature -r features --tags ~@wip"
-          }
-        ]
-      }
+
     ]
   },
   {
@@ -939,24 +530,7 @@
     "flags": "",
     "file_colon_line": "features/step_definitions/cucumber_steps.rb:5",
     "steps": [
-      {
-        "name": "it should fail with JSON:",
-        "args": [
-          {
-            "offset": 10,
-            "val": "fail"
-          }
-        ]
-      },
-      {
-        "name": "it should pass with JSON:",
-        "args": [
-          {
-            "offset": 10,
-            "val": "pass"
-          }
-        ]
-      }
+
     ]
   },
   {
@@ -964,12 +538,7 @@
     "flags": "",
     "file_colon_line": "features/step_definitions/cucumber_steps.rb:19",
     "steps": [
-      {
-        "name": "a directory without standard Cucumber project directory structure",
-        "args": [
 
-        ]
-      }
     ]
   },
   {
@@ -977,12 +546,7 @@
     "flags": "",
     "file_colon_line": "features/step_definitions/cucumber_steps.rb:25",
     "steps": [
-      {
-        "name": "a scenario with a step that looks like this:",
-        "args": [
 
-        ]
-      }
     ]
   },
   {
@@ -990,12 +554,7 @@
     "flags": "",
     "file_colon_line": "features/step_definitions/cucumber_steps.rb:31",
     "steps": [
-      {
-        "name": "a step definition that looks like this:",
-        "args": [
 
-        ]
-      }
     ]
   },
   {
@@ -1003,15 +562,7 @@
     "flags": "",
     "file_colon_line": "features/step_definitions/cucumber_steps.rb:35",
     "steps": [
-      {
-        "name": "I run the feature with the progress formatter",
-        "args": [
-          {
-            "offset": 27,
-            "val": "progress"
-          }
-        ]
-      }
+
     ]
   },
   {
@@ -1019,12 +570,7 @@
     "flags": "",
     "file_colon_line": "features/step_definitions/drb_steps.rb:1",
     "steps": [
-      {
-        "name": "I am running spork in the background",
-        "args": [
 
-        ]
-      }
     ]
   },
   {
@@ -1032,15 +578,7 @@
     "flags": "",
     "file_colon_line": "features/step_definitions/iso-8859-1_steps.rb:6",
     "steps": [
-      {
-        "name": "jeg drikker en \"øl\"",
-        "args": [
-          {
-            "offset": 16,
-            "val": "øl"
-          }
-        ]
-      }
+
     ]
   },
   {
@@ -1048,15 +586,7 @@
     "flags": "",
     "file_colon_line": "features/step_definitions/iso-8859-1_steps.rb:10",
     "steps": [
-      {
-        "name": "skal de andre si \"skål\"",
-        "args": [
-          {
-            "offset": 18,
-            "val": "skål"
-          }
-        ]
-      }
+
     ]
   }
 ]

--- a/features/hook_order.feature
+++ b/features/hook_order.feature
@@ -56,5 +56,5 @@ Feature: Hooks execute in defined order
     When I run `cucumber -o /dev/null features/all_hook_order.feature`
     Then the output should contain:
       """
-      Event order: around_begin background_step before scenario_step after around_end
+      Event order: around_begin before background_step scenario_step after around_end
       """


### PR DESCRIPTION
This feature was requested by cucumber/issues/52. It fails against cucumber/master right now, but it clearly demonstrates the issue:

```
Scenario: Around hooks cover background steps
...
-Event order: around_begin background_step scenario_step around_end
+Event order: background_step around_begin scenario_step around_end

Scenario: All hooks execute in expected order
...
-Event order: around_begin before background_step scenario_step after around_end
+Event order: before background_step around_begin scenario_step after around_end
```
