### PR TITLE
Fix #320: sort available profiles before printing, so specs don't random...

### DIFF
--- a/lib/cucumber/cli/profile_loader.rb
+++ b/lib/cucumber/cli/profile_loader.rb
@@ -15,7 +15,7 @@ module Cucumber
 Could not find profile: '#{profile}'
 
 Defined profiles in cucumber.yml:
-  * #{cucumber_yml.keys.join("\n  * ")}
+  * #{cucumber_yml.keys.sort.join("\n  * ")}
         END_OF_ERROR
         end
 


### PR DESCRIPTION
...ly fail _Dangit, commit message was too long, sorry._

I couldn't think of a good way to add a spec to cover this, since it was already covered by a spec. I think the problem was that the spec was (kind of) too specific.
