### PR TITLE
Fix #322: sort Table columns by header, before pretty printing

### DIFF
--- a/lib/cucumber/ast/table.rb
+++ b/lib/cucumber/ast/table.rb
@@ -600,7 +600,7 @@ module Cucumber
       end
 
       def hashes_to_array(hashes) #:nodoc:
-        header = hashes[0].keys
+        header = hashes[0].keys.sort
         [header] + hashes.map{|hash| header.map{|key| hash[key]}}
       end
 

--- a/spec/cucumber/ast/table_spec.rb
+++ b/spec/cucumber/ast/table_spec.rb
@@ -494,8 +494,8 @@ module Cucumber
         it "should allow Array of Hash" do
           t1 = Table.new([{'name' => 'aslak', 'male' => 'true'}])
           t1.to_s(:indent => 12, :color => false).should == %{
-            |     name  |     male |
-            |     aslak |     true |
+            |     male |     name  |
+            |     true |     aslak |
           }
         end
       end


### PR DESCRIPTION
Similar to #320.

Seems like the specs were over-specifying, and the hash that (briefly) stores the Table row data doesn't return its keys in a consistent order. Sorting the keys fixes the problem, but it meant I had to re-order the output in the spec.
