### PR TITLE
Obey program suffix when invoking bundler

### DIFF
--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -92,7 +92,8 @@ module Cucumber
 
         def cmd
           if use_bundler
-            [ Cucumber::RUBY_BINARY, '-S', 'bundle', 'exec', 'cucumber', @cucumber_opts,
+            bundle_cmd = Gem.default_exec_format % 'bundle'
+            [ Cucumber::RUBY_BINARY, '-S', bundle_cmd, 'exec', 'cucumber', @cucumber_opts,
             @feature_files ].flatten
           else
             [ Cucumber::RUBY_BINARY, '-I', load_path(@libs), quoted_binary(@cucumber_bin),

--- a/spec/cucumber/rake/forked_spec.rb
+++ b/spec/cucumber/rake/forked_spec.rb
@@ -24,9 +24,22 @@ module Cucumber
         end
 
         it "uses bundle exec to find cucumber and libraries" do
+          bundle_cmd = Gem.default_exec_format % 'bundle'
+
           subject.cmd.should == [Cucumber::RUBY_BINARY,
                                  '-S',
-                                 'bundle',
+                                 bundle_cmd,
+                                 'exec',
+                                 'cucumber',
+                                 '--cuke-option'] + feature_files
+        end
+
+        it "obeys program suffix for bundler" do
+          Gem::ConfigMap.stub(:[]).with(:ruby_install_name).and_return('XrubyY')
+
+          subject.cmd.should == [Cucumber::RUBY_BINARY,
+                                 '-S',
+                                 'XbundleY',
                                  'exec',
                                  'cucumber',
                                  '--cuke-option'] + feature_files


### PR DESCRIPTION
If ruby is configured using --program-suffix or --program-prefix the
rake tasks will not be able to launch the correct bundler executable (as
"bundler" may not exist).

This uses Gem.default_exec_format to choose the correct "bundler" to
invoke in the rake task based on how Ruby was configured.
