### PR TITLE
Fall back on Test::Unit::Assertions if rspec-expectations is missing

### DIFF
--- a/features/assertions.feature
+++ b/features/assertions.feature
@@ -1,0 +1,68 @@
+Feature: Assertions
+  In order to get started quickly
+  As a new Cucumber user
+  I want to use a familiar assertion library
+
+  Background:
+    Given a file named "features/assert.feature" with:
+       """
+       Feature: Assert
+         Scenario: Passing
+           Then it should pass
+       """
+
+    Given a file named "without_rspec.rb" with:
+    """
+    require 'rspec/expectations'
+
+    module RSpec
+      remove_const :Matchers rescue nil
+      remove_const :Expectations rescue nil
+    end
+
+    module Spec
+      remove_const :Expectations rescue nil
+    end
+    """
+
+  Scenario: Test::Unit
+    Given a file named "features/step_definitions/assert_steps.rb" with:
+      """
+      Then /^it should pass$/ do
+        assert(2 + 2 == 4)
+      end
+      """
+    When I run `ruby -r./without_rspec -S cucumber`
+    Then it should pass with exactly:
+      """
+      Feature: Assert
+
+        Scenario: Passing     # features/assert.feature:2
+          Then it should pass # features/step_definitions/assert_steps.rb:1
+
+      1 scenario (1 passed)
+      1 step (1 passed)
+      0m0.012s
+
+      """
+
+  Scenario: RSpec
+    Given a file named "features/step_definitions/assert_steps.rb" with:
+      """
+      Then /^it should pass$/ do
+        (2 + 2).should == 4
+      end
+      """
+    When I run `cucumber`
+    Then it should pass with exactly:
+      """
+      Feature: Assert
+
+        Scenario: Passing     # features/assert.feature:2
+          Then it should pass # features/step_definitions/assert_steps.rb:1
+
+      1 scenario (1 passed)
+      1 step (1 passed)
+      0m0.012s
+
+      """

--- a/lib/cucumber/rb_support/rb_language.rb
+++ b/lib/cucumber/rb_support/rb_language.rb
@@ -5,6 +5,18 @@ require 'cucumber/rb_support/rb_step_definition'
 require 'cucumber/rb_support/rb_hook'
 require 'cucumber/rb_support/rb_transform'
 
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  begin
+    require 'spec/expectations'
+    require 'spec/runner/differs/default'
+    require 'ostruct'
+  rescue LoadError
+    require 'test/unit/assertions'
+  end
+end
+
 module Cucumber
   module RbSupport
     # Raised if a World block returns Nil.
@@ -49,21 +61,16 @@ module Cucumber
       def enable_rspec_expectations_if_available
         begin
           # RSpec >=2.0
-          require 'rspec/expectations'
           @assertions_module = ::RSpec::Matchers
-        rescue LoadError => try_rspec_1_2_4_or_higher
+        rescue NameError
+          # RSpec >=1.2.4
           begin
-            require 'spec/expectations'
-            require 'spec/runner/differs/default'
-            require 'ostruct'
             options = OpenStruct.new(:diff_format => :unified, :context_lines => 3)
             Spec::Expectations.differ = Spec::Expectations::Differs::Default.new(options)
             @assertions_module = ::Spec::Matchers
-          rescue LoadError => try_test_unit
-            require 'test/unit/assertions'
+          rescue NameError
+            # Test::Unit
             @assertions_module = ::Test::Unit::Assertions
-          rescue LoadError => give_up
-            @assertions_module = Module.new{}
           end
         end
       end


### PR DESCRIPTION
Currently, users who don't want to use rspec-expectations have to do a little extra setup in their env.rb to use Test::Unit.  Since Test::Unit ships with Ruby (albeit as a wrapper in 1.9), it makes sense to look
for this library as a fallback.  This lowers the barrier even further for users who want to jump straight into Cucumber with minimal dependencies.
