### PR TITLE
Html formatter failing with undefined steps

### DIFF
--- a/features/html_formatter.feature
+++ b/features/html_formatter.feature
@@ -1,0 +1,19 @@
+Feature: HTML output formatter
+
+  Background:
+    Given a file named "features/scenario_outline_with_undefined_steps.feature" with:
+      """
+      Feature:
+
+        Scenario Outline:
+          Given an undefined step
+        
+        Examples:
+          |foo|
+          |bar|
+      """
+
+  Scenario: an scenario outline, one undefined step, one random example, expand flag on
+    When I run cucumber "features/scenario_outline_with_undefined_steps.feature --format html --expand "
+    Then it should pass
+

--- a/features/step_definitions/cucumber_steps.rb
+++ b/features/step_definitions/cucumber_steps.rb
@@ -16,6 +16,10 @@ Then /^it should (pass|fail) with JSON:$/ do |pass_fail, json|
   assert_success(pass_fail == 'pass')
 end
 
+Then /^it should (pass|fail)$/ do |expectation|
+  assert_success(expectation == 'pass')
+end
+
 Given /^a directory without standard Cucumber project directory structure$/ do
   in_current_dir do
     FileUtils.rm_rf 'features' if File.directory?('features')

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -245,9 +245,10 @@ module Cucumber
         return if @hide_this_step
         # print snippet for undefined steps
         if status == :undefined
+          keyword = @step.actual_keyword if @step.respond_to?(:actual_keyword)
           step_multiline_class = @step.multiline_arg ? @step.multiline_arg.class : nil
           @builder.pre do |pre|
-            pre << @step_mother.snippet_text(@step.actual_keyword,step_match.instance_variable_get("@name") || '',step_multiline_class)
+            pre << @step_mother.snippet_text(keyword,step_match.instance_variable_get("@name") || '',step_multiline_class)
           end
         end
         @builder << '</li>'


### PR DESCRIPTION
Having an scenario outline with undefined steps, and using the `--expand` option cause the html formatter to fail. 

```
undefined method `actual_keyword' for #<Cucumber::Ast::Step:0x96985e4> (NoMethodError)
```

 Turns out that `after_step_result` is called for every `Cucumber::Ast::StepInvocation`and every `Cucumber::Ast::Step`. While the former support the `actual_keyword` method the later does not. 

The change will make use of the `actual_keyword`, only of the step class supports it, and default to the keyword, that comes as a param, if not. 

---

```
 Feature:

    Scenario Outline:
      Given an undefined step

    Examples:
      |foo|
      |bar|
```

`$ cucumber --format html --expand`

`undefined method `actual_keyword' for #<Cucumber::Ast::Step:0x8b29f78> (NoMethodError)`
