### PR TITLE
Misplaced rows in table diff.

### DIFF
--- a/spec/cucumber/ast/table_spec.rb
+++ b/spec/cucumber/ast/table_spec.rb
@@ -446,11 +446,9 @@ module Cucumber
               | four  | 4     |
               | five  | 5     |
             }, __FILE__, __LINE__)
+            
             lambda { t1.dup.diff!(t2) }.should raise_error
-
-            pending "https://github.com/cucumber/cucumber/issues/220" do
-              lambda { t1.dup.diff!(t2, :surplus_row => false) }.should_not raise_error
-            end
+            lambda { t1.dup.diff!(t2, :surplus_row => false) }.should_not raise_error
           end
 
           it "should raise on missing columns" do


### PR DESCRIPTION
This pull request is centered around fixing https://github.com/cucumber/cucumber/issues/220

I recently discovered this exact problem and thought I'd give fixing it a shot...

I guess the real "issue" here is the LCS algorithm - Longest Common Sequence. Sequence, or order, being the operative word. 

Once a table is out of sequence, Diff:LCS.diff will report a bunch of diffs. It's the way the diffs are handled as surplus or missing that could be an issue here...

The attempt with this patch is to post-process these diffs and try to remove any complementary rows (identical row marked as added and missing)

I think there could be complications/issues in reporting the diffs - but all the specs pass... Could someone take a quick look at the two lines commented out? If I leave them in, I get failure in the complex diff spec.
