### PR TITLE
raises exception when remote socket end disconnects

### DIFF
--- a/lib/cucumber/wire_support/connection.rb
+++ b/lib/cucumber/wire_support/connection.rb
@@ -42,6 +42,7 @@ module Cucumber
           else
             Timeout.timeout(timeout) { socket.gets }
           end
+        raise exception({'message' => "Remote Socket with #{@config.host}:#{@config.port} closed."}) if raw_response.nil?
         WirePacket.parse(raw_response)
       end
       

--- a/spec/cucumber/wire_support/connection_spec.rb
+++ b/spec/cucumber/wire_support/connection_spec.rb
@@ -19,6 +19,14 @@ module Cucumber
           return :default_timeout if message.nil?
           @custom_timeout[message] || Configuration::DEFAULT_TIMEOUTS.fetch(message)
         end
+
+        def host
+          'localhost'
+        end
+
+        def port
+          '3902'
+        end
       end
       
       before(:each) do
@@ -38,6 +46,14 @@ module Cucumber
         @socket.stub(:gets => @response)
         handler = mock(:handle_response => :response)
         @connection.call_remote(handler, :foo, []).should == :response
+      end
+
+      it "raises an exception on remote connection closed" do
+        @config.custom_timeout[:foo] = :never
+        @socket.stub(:gets => nil)
+        lambda { 
+          @connection.call_remote(nil, :foo, []) 
+        }.should raise_error(WireException, 'Remote Socket with localhost:3902 closed.')
       end
     end
   end


### PR DESCRIPTION
When using Cucumber Wire Protocol with Cucumber CPP if the WireServer crashes (SEGFAULT) during a step the client is left with a nil message returned (IO.gets Returns nil if called at end of file.). 

I've added a check for nil that raises a WireException in this case indicating that the remote server hung up.

Appropriate test included. 
