### PR TITLE
Silence warning when AUTOFEATURE is set but false

### DIFF
--- a/lib/autotest/discover.rb
+++ b/lib/autotest/discover.rb
@@ -2,8 +2,7 @@ Autotest.add_discovery do
   if File.directory?('features')
     if ENV['AUTOFEATURE'] =~ /true/i
       "cucumber"
-    elsif
-      ENV['AUTOFEATURE'] =~ /false/i
+    elsif ENV['AUTOFEATURE'] =~ /false/i
     else
       puts "(Not running features.  To run features in autotest, set AUTOFEATURE=true.)"
     end


### PR DESCRIPTION
I would like to get rid of the warning when I start autotest.
With this change I can set AUTOFEATURE to false to silence the warning.
