### PR TITLE
Loosen rspec development dependency to '~> 2.11'

### DIFF
--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'aruba', '~> 0.4.11'
   s.add_development_dependency 'rake', '>= 0.9.2'
-  s.add_development_dependency 'rspec', '~> 2.11.0'
+  s.add_development_dependency 'rspec', '~> 2.11'
   s.add_development_dependency 'nokogiri', '>= 1.5.2'
   s.add_development_dependency 'syntax', '>= 1.0.0'
   s.add_development_dependency 'spork', '>= 1.0.0.rc2'


### PR DESCRIPTION
This allows the latest version of `rspec` until version 3.0 is released.
