### PR TITLE
Use pure Ruby Markdown parser for JRuby compatibility

### DIFF
--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   # For Documentation:
   s.add_development_dependency('yard', '~> 0.8.0')
-  s.add_development_dependency('rdiscount', '~> 1.6.8') unless defined?(JRUBY_VERSION)
+  s.add_development_dependency('kramdown', '~> 0.14')
   s.add_development_dependency('bcat', '~> 0.6.2')
 
   # Needed for examples (rake examples)


### PR DESCRIPTION
When generating documentation, use `kramdown` instead of `rdiscount` to parse Markdown. It is implemented in pure Ruby (no C extensions) so it is compatible with JRuby and other Ruby interpreters. It is somewhat slower on MRI but still reasonably fast.
