### PR TITLE
add unix domain socket support (wire protocol)

### DIFF
--- a/lib/cucumber/wire_support/configuration.rb
+++ b/lib/cucumber/wire_support/configuration.rb
@@ -4,17 +4,27 @@ require 'erb'
 module Cucumber
   module WireSupport
     class Configuration
-      attr_reader :host, :port
+      attr_reader :host, :port, :unix
 
-      def initialize(wire_file)
-        params = YAML.load(ERB.new(File.read(wire_file)).result)
-        @host = params['host']
-        @port = params['port']
-        @timeouts = DEFAULT_TIMEOUTS.merge(params['timeout'] || {})
+      def self.from_file(wire_file)
+        settings = YAML.load(ERB.new(File.read(wire_file)).result)
+        new(settings)
+      end
+
+      def initialize(args)
+        @host = args['host']
+        @port = args['port']
+        @unix = args['unix'] if RUBY_PLATFORM !~ /mingw|mswin/
+        @timeouts = DEFAULT_TIMEOUTS.merge(args['timeout'] || {})
       end
 
       def timeout(message = nil)
         return @timeouts[message.to_s] || 3
+      end
+
+      def to_s
+        return @unix if @unix
+        "#{@host}:#{@port}"
       end
 
       DEFAULT_TIMEOUTS = {

--- a/lib/cucumber/wire_support/connection.rb
+++ b/lib/cucumber/wire_support/connection.rb
@@ -26,7 +26,7 @@ module Cucumber
       end
 
       def exception(params)
-        WireException.new(params, @config.host, @config.port)
+        WireException.new(params, @config)
       end
 
       private
@@ -47,9 +47,14 @@ module Cucumber
       end
 
       def socket
-        @socket ||= TCPSocket.new(@config.host, @config.port)
+        return @socket if @socket
+        if @config.unix
+          @socket = UNIXSocket.new(@config.unix)
+        else
+          @socket = TCPSocket.new(@config.host, @config.port)
+        end
       rescue Errno::ECONNREFUSED => exception
-        raise(ConnectionError, "Unable to contact the wire server at #{@config.host}:#{@config.port}. Is it up?")
+        raise(ConnectionError, "Unable to contact the wire server at #{@config}. Is it up?")
       end
     end
   end

--- a/lib/cucumber/wire_support/wire_exception.rb
+++ b/lib/cucumber/wire_support/wire_exception.rb
@@ -9,11 +9,11 @@ module Cucumber
         end
       end
 
-      def initialize(args, host, port)
+      def initialize(args, config)
         super args['message']
         if args['exception']
           self.class.extend(CanSetName)
-          self.class.exception_name = "#{args['exception']} from #{host}:#{port}"
+          self.class.exception_name = "#{args['exception']} from #{config}"
         end
         if args['backtrace']
           @backtrace = if args['backtrace'].is_a?(String)

--- a/lib/cucumber/wire_support/wire_language.rb
+++ b/lib/cucumber/wire_support/wire_language.rb
@@ -22,7 +22,7 @@ module Cucumber
       end
 
       def load_code_file(wire_file)
-        config = Configuration.new(wire_file)
+        config = Configuration.from_file(wire_file)
         @connections << Connection.new(config)
       end
 

--- a/spec/cucumber/wire_support/configuration_spec.rb
+++ b/spec/cucumber/wire_support/configuration_spec.rb
@@ -6,7 +6,7 @@ module Cucumber
   module WireSupport
     describe Configuration do
       let(:wire_file) { Tempfile.new('wire') }
-      let(:config) { Configuration.new(wire_file.path) }
+      let(:config) { Configuration.from_file(wire_file.path) }
 
       def write_wire_file(contents)
         wire_file << contents

--- a/spec/cucumber/wire_support/wire_exception_spec.rb
+++ b/spec/cucumber/wire_support/wire_exception_spec.rb
@@ -5,10 +5,10 @@ module Cucumber
   module WireSupport
     describe WireException do
       before(:each) do
-        @host, @port = 'localhost', '54321'
+        @config = Configuration.new('host' => 'localhost', 'port' => 54321)
       end
       def exception
-        WireException.new(@data, @host, @port)
+        WireException.new(@data, @config)
       end
       describe "with just a message" do
         before(:each) do

--- a/spec/cucumber/wire_support/wire_language_spec.rb
+++ b/spec/cucumber/wire_support/wire_language_spec.rb
@@ -5,7 +5,7 @@ module Cucumber
   module WireSupport
     describe WireLanguage do
       def stub_wire_file!(filename, config)
-        Configuration.stub!(:new).with(filename).and_return config
+        Configuration.stub!(:from_file).with(filename).and_return config
       end
 
       describe "#load_code_file" do


### PR DESCRIPTION
Hello, this adds a `:unix` configuration option to the .wire files so that unix domain sockets can be used instead of TCP. It checks the OS if configured so that you can use the same .wire file (e.g., if it's a shared file on a mounted volume) on windows.

(Unix domain sockets are significantly faster and don't have firewall issues, so whenever they're available, they're much better to use for local services)

Thanks!
