### PR TITLE
Cache step_match results.

### DIFF
--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -130,14 +130,22 @@ module Cucumber
       end
     
       def step_match(step_name, name_to_report=nil) #:nodoc:
+        @match_cache ||= {}
+
+        match = @match_cache[[step_name, name_to_report]]
+        return match if match
+
+        @match_cache[[step_name, name_to_report]] = step_match_without_cache(step_name, name_to_report)
+      end
+    
+    private
+      def step_match_without_cache(step_name, name_to_report=nil)
         matches = matches(step_name, name_to_report)
         raise Undefined.new(step_name) if matches.empty?
         matches = best_matches(step_name, matches) if matches.size > 1 && guess_step_matches?
         raise Ambiguous.new(step_name, matches, guess_step_matches?) if matches.size > 1
         matches[0]
       end
-    
-    private
   
       def guess_step_matches?
         @configuration.guess?

--- a/spec/cucumber/runtime/support_code_spec.rb
+++ b/spec/cucumber/runtime/support_code_spec.rb
@@ -17,7 +17,18 @@ module Cucumber
       format = subject.step_match("it snows in april").format_args("[%s]")
       format.should == "it [snows] in [april]"
     end
-    
+
+    it "should cache step match results" do
+      dsl.Given(/it (.*) in (.*)/) { |what, month| }
+
+      step_match = subject.step_match("it snows in april")
+
+      @rb.should_not_receive :step_matches
+      second_step_match = subject.step_match("it snows in april")
+
+      step_match.should equal(second_step_match)
+    end
+
     describe "resolving step defintion matches" do
 
       it "should raise Ambiguous error with guess hint when multiple step definitions match" do


### PR DESCRIPTION
This offers a large speedup in larger test suites in which there are many
steps and some steps are reused many times.
