### PR TITLE
Fix for bundler path issue in Cucumber Rake task #386

### DIFF
--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -67,7 +67,7 @@ module Cucumber
         end
 
         def load_path(libs)
-          ['"%s"' % @libs.join(File::PATH_SEPARATOR)]
+          ['"%s"' % libs.join(File::PATH_SEPARATOR)]
         end
 
         def quoted_binary(cucumber_bin)
@@ -78,8 +78,9 @@ module Cucumber
           @bundler.nil? ? File.exist?("./Gemfile") && gem_available?("bundler") : @bundler
         end
 
-        def bundle_cmd
-          File.basename( Gem.bin_path('bundler', 'bundle') )
+        def bundler_lib_path
+          spec = Gem::Specification.find_by_name('bundler')
+          File.join(spec.gem_dir , 'lib')
         end
 
         def gem_available?(gemname)
@@ -96,7 +97,7 @@ module Cucumber
 
         def cmd
           if use_bundler
-            [ Cucumber::RUBY_BINARY, '-S', bundle_cmd, 'exec', 'cucumber', @cucumber_opts,
+            [ Cucumber::RUBY_BINARY, '-I', load_path([bundler_lib_path] + @libs), '-rbundler/setup', quoted_binary(@cucumber_bin), @cucumber_opts,
             @feature_files ].flatten
           else
             [ Cucumber::RUBY_BINARY, '-I', load_path(@libs), quoted_binary(@cucumber_bin),
@@ -118,7 +119,7 @@ module Cucumber
 
         def cmd
           if use_bundler
-            [Cucumber::RUBY_BINARY, '-S', bundle_cmd, 'exec', 'rcov', @rcov_opts,
+            [Cucumber::RUBY_BINARY, '-I', load_path([bundler_lib_path] + @libs), '-rbundler/setup', '-S', 'rcov', @rcov_opts,
              quoted_binary(@cucumber_bin), '--', @cucumber_opts, @feature_files].flatten
           else
             [Cucumber::RUBY_BINARY, '-I', load_path(@libs), '-S', 'rcov', @rcov_opts,

--- a/spec/cucumber/rake/forked_spec.rb
+++ b/spec/cucumber/rake/forked_spec.rb
@@ -15,6 +15,8 @@ module Cucumber
       context "when running with bundler" do
 
         let(:bundler) { true }
+        let(:bundler_lib_dir) { File.join(Gem.dir, 'gems', 'bundler-1.2.3', 'lib') }
+        let(:bundler_spec) { Gem::Specification.new 'bundler', '1.2.3' }
 
         subject { Task::ForkedCucumberRunner.new(
             libs, binary, cucumber_opts, bundler, feature_files) }
@@ -23,25 +25,14 @@ module Cucumber
           subject.use_bundler.should be_true
         end
 
-        it "uses bundle exec to find cucumber and libraries" do
-          Gem.stub(:bin_path).with('bundler','bundle').and_return('/path/to/bundle')
+        it "uses bundler to find cucumber and libraries" do
+          Gem::Specification.should_receive(:find_by_name).with('bundler').and_return(bundler_spec)
 
           subject.cmd.should == [Cucumber::RUBY_BINARY,
-                                 '-S',
-                                 'bundle',
-                                 'exec',
-                                 'cucumber',
-                                 '--cuke-option'] + feature_files
-        end
-
-        it "obeys program suffix for bundler" do
-          Gem.stub(:bin_path).with('bundler','bundle').and_return('/path/to/XbundleY')
-
-          subject.cmd.should == [Cucumber::RUBY_BINARY,
-                                 '-S',
-                                 'XbundleY',
-                                 'exec',
-                                 'cucumber',
+                                 '-I',
+                                 '"%s"' % ([bundler_lib_dir]+libs).join(File::PATH_SEPARATOR),
+                                 '-rbundler/setup',
+                                 "\"#{Cucumber::BINARY }\"",
                                  '--cuke-option'] + feature_files
         end
 

--- a/spec/cucumber/rake/rcov_spec.rb
+++ b/spec/cucumber/rake/rcov_spec.rb
@@ -17,6 +17,8 @@ module Cucumber
       context "when running with bundler" do
 
         let(:bundler) { true }
+        let(:bundler_lib_dir) { File.join(Gem.dir, 'gems', 'bundler-1.2.3', 'lib') }
+        let(:bundler_spec) { Gem::Specification.new 'bundler', '1.2.3' }
 
         subject { Task::RCovCucumberRunner.new(
             libs, binary, cucumber_opts, bundler, feature_files, rcov_opts) }
@@ -25,26 +27,14 @@ module Cucumber
           subject.use_bundler.should be_true
         end
 
-        it "uses bundle exec to find cucumber and libraries" do
-          Gem.stub(:bin_path).with('bundler','bundle').and_return('/path/to/bundle')
-          subject.cmd.should == [Cucumber::RUBY_BINARY,
-                                 '-S',
-                                 'bundle',
-                                 'exec',
-                                 'rcov',
-                                 '--rcov-option',
-                                 "\"#{Cucumber::BINARY }\"",
-                                 '--',
-                                 '--cuke-option'] + feature_files
-        end
-
-        it "obeys program suffix for bundler" do
-          Gem.stub(:bin_path).with('bundler','bundle').and_return('/path/to/XbundleY')
+        it "uses bundler to find cucumber and libraries" do
+          Gem::Specification.should_receive(:find_by_name).with('bundler').and_return(bundler_spec)
 
           subject.cmd.should == [Cucumber::RUBY_BINARY,
+                                 '-I',
+                                 '"%s"' % ([bundler_lib_dir]+libs).join(File::PATH_SEPARATOR),
+                                 '-rbundler/setup',
                                  '-S',
-                                 'XbundleY',
-                                 'exec',
                                  'rcov',
                                  '--rcov-option',
                                  "\"#{Cucumber::BINARY }\"",


### PR DESCRIPTION
This is a fix for #386.

It changes the method to obtain the `bundle` command name from
`Gem.default_exec_format % 'bundle'` to `File.basename( Gem.bin_path('bundler', 'bundle') )` when building the command line in Cucumber Rake task.
