### PR TITLE
Baby steps execution refactoring

### DIFF
--- a/lib/cucumber/ast/background.rb
+++ b/lib/cucumber/ast/background.rb
@@ -108,10 +108,28 @@ module Cucumber
         source_tags.map { |tag| tag.name }
       end
 
+      def to_units
+        [BackgroundUnit.new(self)]
+      end
+
       private
 
       def steps
         @steps ||= StepCollection.new(@raw_steps)
+      end
+
+      class BackgroundUnit
+        def initialize(background)
+          @background = background
+        end
+
+        def step_count
+          @background.step_invocations.length
+        end
+
+        def execute(visitor)
+          @background.accept(visitor)
+        end
       end
 
     end

--- a/lib/cucumber/ast/empty_background.rb
+++ b/lib/cucumber/ast/empty_background.rb
@@ -27,6 +27,10 @@ module Cucumber
 
       def accept(visitor)
       end
+
+      def to_units
+        []
+      end
     end
   end
 end

--- a/lib/cucumber/ast/feature.rb
+++ b/lib/cucumber/ast/feature.rb
@@ -26,7 +26,7 @@ module Cucumber
       end
 
       def step_count
-        units.inject(0) { |total, unit| total += unit.step_count }
+        units.inject(0) { |total, unit| total + unit.step_count }
       end
 
       def accept(visitor)
@@ -91,7 +91,10 @@ module Cucumber
       private
 
       def units
-        [FeatureUnit.new(self)]
+        # TODO: here is a conflict between execution's implementation and step_count' implementation
+        # step_count thinks that we call background for every feature element, but in fact we call it only once
+        # per-feature
+        [background.to_units, FeatureUnit.new(self)].flatten
       end
 
       class FeatureUnit
@@ -100,11 +103,10 @@ module Cucumber
         end
 
         def step_count
-          units.inject(0) { |total, unit| total += unit.step_count }
+          units.inject(0) { |total, unit| total + unit.step_count }
         end
 
         def execute(visitor)
-          @feature.background.accept(visitor)
           @feature.feature_elements.each do |feature_element|
             feature_element.accept(visitor)
           end


### PR DESCRIPTION
@mattwynne @tooky as we discussed yesterday here is a PR with some ideas of baby step which can be done in several classes independently.
I've implemented execution in term of units in Feature (using temporary class FeatureUnit) and replaced part of its execution with BackgroundUnit which is temp class unit we implement background execution in term of units.
So, what do you think?

On the way two questions I've got:
- why step_count thinks that we execute background for every scenario, but background is executed only once per-feature
- out current formatter's API provides before/after callback which means that we either need to add separate units for these calls, or units' structure should reflect ast hierarchy (I think we still want to have these callbacks)

Ideas?
