### PR TITLE
don't require test/unit for compatibility with minitest 5.0

### DIFF
--- a/lib/cucumber/core_ext/disable_mini_and_test_unit_autorun.rb
+++ b/lib/cucumber/core_ext/disable_mini_and_test_unit_autorun.rb
@@ -1,6 +1,4 @@
 begin
-  require 'test/unit'
-
   if defined?(Test::Unit::AutoRunner.need_auto_run?)
     # For test-unit gem >= 2.4.9
     Test::Unit::AutoRunner.need_auto_run = false


### PR DESCRIPTION
  cucumber required test/unit in `disable_mini_and_test_unit_autorun.rb`.
This breaks compatibility with minitest >= 5.0 and leads to the error described in seattlerb/minitest#283

there's an example that demonstrates the incompatibility at https://gist.github.com/levinalex/772817a7d453addf4b91

Why did the `require "test/unit"` exist in the fist place? Removing it does not seem to break any tests.
