### PR TITLE
"Multiple formatters" scenario now in new feature

### DIFF
--- a/features/docs/cli/specifying_multiple_formatters.feature
+++ b/features/docs/cli/specifying_multiple_formatters.feature
@@ -1,0 +1,44 @@
+@spawn
+Feature: Running multiple formatters
+
+  When running cucumber, you are able to using multiple different
+  formatters and redirect the output to text files.
+
+  Scenario: Multiple formatters and outputs
+    Given a file named "features/test.feature" with:
+    """
+    Feature: Lots of undefined
+
+      Scenario: Implement me
+        Given it snows in Sahara
+        Given it's 40 degrees in Norway
+        And it's 40 degrees in Norway
+        When I stop procrastinating
+        And there is world peace
+    """
+    When I run `cucumber --no-color --format progress --out progress.txt --format pretty --out pretty.txt --no-source --dry-run --no-snippets features/test.feature`
+    Then the stderr should not contain anything
+    Then the file "progress.txt" should contain:
+      """
+      UUUUU
+
+      1 scenario (1 undefined)
+      5 steps (5 undefined)
+
+      """
+    And the file "pretty.txt" should contain:
+      """
+      Feature: Lots of undefined
+
+        Scenario: Implement me
+          Given it snows in Sahara
+          Given it's 40 degrees in Norway
+          And it's 40 degrees in Norway
+          When I stop procrastinating
+          And there is world peace
+
+      1 scenario (1 undefined)
+      5 steps (5 undefined)
+
+      """
+

--- a/legacy_features/cucumber_cli.feature
+++ b/legacy_features/cucumber_cli.feature
@@ -2,33 +2,6 @@ Feature: Cucumber command line
   In order to write better software
   Developers should be able to execute requirements as tests
 
-  Scenario: Multiple formatters and outputs
-    When I run cucumber --format progress --out tmp/progress.txt --format pretty --out tmp/pretty.txt --no-source --dry-run --no-snippets features/lots_of_undefined.feature
-    Then STDERR should be empty
-    Then "fixtures/self_test/tmp/progress.txt" should contain
-      """
-      UUUUU
-
-      1 scenario (1 undefined)
-      5 steps (5 undefined)
-
-      """
-    And "fixtures/self_test/tmp/pretty.txt" should contain
-      """
-      Feature: Lots of undefined
-
-        Scenario: Implement me
-          Given it snows in Sahara
-          Given it's 40 degrees in Norway
-          And it's 40 degrees in Norway
-          When I stop procrastinating
-          And there is world peace
-      
-      1 scenario (1 undefined)
-      5 steps (5 undefined)
-
-      """
-
   Scenario: Run feature elements which matches a name using --name
     When I run cucumber --name Pisang -q features/
     Then it should pass with


### PR DESCRIPTION
Had to add `@spawn` to allow the `--no-color` not to bleed into the main
cucumber run. We need `--no-color` to do a proper comparison on the output
files.
