### PR TITLE
rake tasks are broken with latest rubygem versions (v. 2 or later)

### DIFF
--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -73,7 +73,7 @@ module Cucumber
         end
 
         def gem_available?(gemname)
-          if Gem::Specification.respond_to?(:find_all_by_name) 
+          if Gem::Specification.respond_to?(:find_all_by_name)
             gem_available_new_rubygems?(gemname)
           else
             gem_available_old_rubygems?(gemname)


### PR DESCRIPTION
Method `ForkedCucumberRunner#gem_available?` caused an error in rake with
the message _'undefined method `available?` for Gem:Module'_.
This occurred when rubygems could not find a gem, then the method falled back to a legacy call to the `Gem::Module#available?` that doesn't exist anymore in rubygems 2 and
above. The fix consists in avoiding to call the obsolete method when Rubygems has version 2 or above.
