### PR TITLE
Fixed #522: Do not print superfluous and badly formatted backtrace when ...

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -268,6 +268,7 @@ module Cucumber
       end
 
       def exception(exception, status)
+        return if @hide_this_step
         build_exception_detail(exception)
       end
 

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -211,7 +211,7 @@ module Cucumber
           it { @doc.should have_css_node('.feature .scenario .step.failed .message', /StandardError/) }
         end
 
-        describe "with a step that fails in the backgound" do
+        describe "with a step that fails in the background" do
           define_steps do
             Given(/boo/) { raise 'eek' }
           end
@@ -227,6 +227,8 @@ module Cucumber
           it { @doc.should have_css_node('.feature .background .step.failed', /eek/) }
           it { @doc.should_not have_css_node('.feature .scenario .step.failed', //) }
           it { @doc.should have_css_node('.feature .scenario .step.undefined', /yay/) }
+          it { @doc.should have_css_node('.feature .background .backtrace', //) }
+          it { @doc.should_not have_css_node('.feature .scenario .backtrace', //) }
         end
 
         describe "with a step that embeds a snapshot" do


### PR DESCRIPTION
...failing step is a background step
