### PR TITLE
explicitly require 'json' from WireSupport::Connection

### DIFF
--- a/lib/cucumber/wire_support/wire_packet.rb
+++ b/lib/cucumber/wire_support/wire_packet.rb
@@ -23,7 +23,7 @@ module Cucumber
       def to_json
         packet = [@message]
         packet << @params if @params
-        packet.to_json
+        MultiJson.dump(packet)
       end
 
       def handle_with(handler)


### PR DESCRIPTION
specs failed on undefined method `Array#to_json` when run directly with

```
rspec spec/cucumber/wire_support/connection_spec.rb
```
