### PR TITLE
Clean up 'Work in Progress' Feature

### DIFF
--- a/features/docs/work_in_progress.feature
+++ b/features/docs/work_in_progress.feature
@@ -1,3 +1,4 @@
+@spawn
 Feature: Cucumber --work-in-progress switch
   In order to ensure that feature scenarios do not pass until they are expected to
   Developers should be able to run cucumber in a mode that


### PR DESCRIPTION
I moved worked_in_progress.feature from the legacy_features directory to the features directory. Then I updated the steps to be Aruba steps, and finally I made the Scenarios pass again.

The Scenarios failed because they now contain time output. I worked around that by moving the output after the time output into their own step.

Let me know if you have any remarks!
