### PR TITLE
Move Report feature from legacy folder to features folder

### DIFF
--- a/features/docs/report_called_undefined_steps.feature
+++ b/features/docs/report_called_undefined_steps.feature
@@ -47,13 +47,10 @@ Feature: Cucumber command line
       """
     And the output should contain:
       """
-
       You can implement step definitions for undefined steps with these snippets:
 
       Given(/^this does not exist$/) do
         pending # express the regexp above with the code you wish you had
       end
 
-
       """
-


### PR DESCRIPTION
I moved some file creation steps into the Feature file. I thought it would be more convenient for when you have to revisit this feature later, also we do this in different feature files as well.
