### PR TITLE
FIX: No links to lines in backtrace under TextMate.

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -536,7 +536,7 @@ module Cucumber
       end
 
       def backtrace_line(line)
-        line.gsub(/\A([^:]*\.(?:rb|feature|haml)):(\d*).*\z/) do
+        line.gsub(/^([^:]*\.(?:rb|feature|haml)):(\d*).*$/) do
           if ENV['TM_PROJECT_DIRECTORY']
             "<a href=\"txmt://open?url=file://#{File.expand_path($1)}&line=#{$2}\">#{$1}:#{$2}</a> "
           else


### PR DESCRIPTION
When scenario fails under TextMate, it shows line information in the backtrace but they aren't clickable. It's because 'line' contains multiple lines while gsub expects just one (\A ... \z as opposed to ^ ... $).
