### PR TITLE
Remove percent i notation

### DIFF
--- a/lib/cucumber/formatter/report_adapter.rb
+++ b/lib/cucumber/formatter/report_adapter.rb
@@ -429,14 +429,14 @@ module Cucumber
           node.describe_to(self)
         end
 
-        %i(background scenario scenario_outline).each do |node_name|
+        [:background, :scenario, :scenario_outline].each do |node_name|
           define_method(node_name) do |node, &descend|
             record_width_of node
             descend.call
           end
         end
 
-        %i(step outline_step).each do |node_name|
+        [:step, :outline_step].each do |node_name|
           define_method(node_name) do |node|
             record_width_of node
           end


### PR DESCRIPTION
Sadly this only works for Ruby 2.0.0 and above. Remove to restore 1.9.3 and below compatibility.
