### PR TITLE
Re-implement "Failing scenarios" output

### DIFF
--- a/lib/cucumber/formatter/console.rb
+++ b/lib/cucumber/formatter/console.rb
@@ -77,17 +77,9 @@ module Cucumber
       end
 
       def print_stats(features, options)
-        @failures = runtime.scenarios(:failed).select { |s| s.is_a?(Cucumber::Ast::Scenario) || s.is_a?(Cucumber::Ast::OutlineTable::ExampleRow) }
-        @failures.collect! { |s| (s.is_a?(Cucumber::Ast::OutlineTable::ExampleRow)) ? s.scenario_outline : s }
-
-        if !@failures.empty?
-          @io.puts format_string("Failing Scenarios:", :failed)
-          @failures.each do |failure|
-            profiles_string = options.custom_profiles.empty? ? '' : (options.custom_profiles.map{|profile| "-p #{profile}" }).join(' ') + ' '
-            source = options[:source] ? format_string(" # Scenario: " + failure.name, :comment) : ''
-            @io.puts format_string("cucumber #{profiles_string}" + failure.file_colon_line, :failed) + source
-          end
-          @io.puts
+        failures = collect_failing_scenarios(runtime)
+        if !failures.empty?
+          print_failing_scenarios(failures, options.custom_profiles, options[:source])
         end
 
         @io.puts scenario_summary(runtime) {|status_count, status| format_string(status_count, status)}
@@ -96,6 +88,27 @@ module Cucumber
         @io.puts(format_duration(features.duration)) if features && features.duration
 
         @io.flush
+      end
+
+      def collect_failing_scenarios(runtime)
+        scenario_class = Cucumber::Formatter::LegacyResultBuilder::LegacyScenario
+        example_table_class = Cucumber::Ast::OutlineTable::ExampleRow
+
+        runtime.scenarios(:failed).select do |s|
+          [scenario_class, example_table_class].include?(s.class)
+        end.map do |s|
+          s.is_a?(example_table_class)? s.scenario_outline : s
+        end
+      end
+
+      def print_failing_scenarios(failures, custom_profiles, given_source)
+        @io.puts format_string("Failing Scenarios:", :failed)
+        failures.each do |failure|
+          profiles_string = custom_profiles.empty? ? '' : (custom_profiles.map{|profile| "-p #{profile}" }).join(' ') + ' '
+          source = given_source ? format_string(" # Scenario: " + failure.name, :comment) : ''
+          @io.puts format_string("cucumber #{profiles_string}" + failure.location, :failed) + source
+        end
+        @io.puts
       end
 
       def print_exception(e, status, indent)

--- a/lib/cucumber/formatter/report_adapter.rb
+++ b/lib/cucumber/formatter/report_adapter.rb
@@ -30,7 +30,7 @@ module Cucumber
       end
 
       def after_test_case(test_case, result)
-        record_test_case_result(result)
+        record_test_case_result(test_case, result)
       end
 
       def after_suite
@@ -43,8 +43,8 @@ module Cucumber
         @printer ||= FeaturesPrinter.new(formatter, runtime).before
       end
 
-      def record_test_case_result(result)
-        scenario = LegacyResultBuilder.new(result).scenario
+      def record_test_case_result(test_case, result)
+        scenario = LegacyResultBuilder.new(result).scenario(test_case.name, test_case.location.to_s)
         runtime.record_result(scenario)
         yield scenario if block_given?
       end
@@ -640,11 +640,11 @@ module Cucumber
           Ast::StepResult.new(:keyword, step_match, :multiline_arg, @status, @exception, :source_indent, background, :file_colon_line)
         end
 
-        def scenario
-          LegacyScenario.new(@status)
+        def scenario(name, location)
+          LegacyScenario.new(@status, name, location)
         end
 
-        LegacyScenario = Struct.new(:status)
+        LegacyScenario = Struct.new(:status, :name, :location)
       end
 
     end


### PR DESCRIPTION
I've added a little more detail to the `LegacyScenario` to capture the name
and location, so that we can use them to print out a meaningful set of
failures. Also took the opportunity to clean the `print_stats` code by
extracting a few methods.
