### PR TITLE
undefined method `to_json' for ["begin_scenario"]:Array when running cucumber-cpp

### DIFF
--- a/lib/cucumber/wire_support/connection.rb
+++ b/lib/cucumber/wire_support/connection.rb
@@ -1,4 +1,5 @@
 require 'timeout'
+require 'multi_json'
 require 'cucumber/wire_support/wire_protocol'
 
 module Cucumber


### PR DESCRIPTION
I'm not sure, whether this is the problem with my configuration or not, but I guess,  the require statement will not hurt. At least then, I can run my wire steps. 

```
# language: en
Feature: Table
  In order to explain how to use tagbles
  I have to make this silly example

  Scenario: No tag   # features\table.feature:6
undefined method `to_json' for ["begin_scenario"]:Array (NoMethodError)
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/wire_support/wire_packet.rb:26:in `to_json'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/wire_support/connection.rb:20:in `call_remote'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/wire_support/request_handler.rb:10:in `execute'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/wire_support/wire_protocol/requests.rb:111:in `execute'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/wire_support/wire_protocol.rb:33:in `begin_scenario'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/wire_support/wire_language.rb:43:in `block in begin_scenario'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/wire_support/wire_language.rb:43:in `each'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/wire_support/wire_language.rb:43:in `begin_scenario'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/language_support/language_methods.rb:14:in `before'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime/support_code.rb:112:in `block in fire_hook'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime/support_code.rb:111:in `each'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime/support_code.rb:111:in `fire_hook'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime.rb:106:in `before'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime.rb:97:in `before_and_after'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime.rb:81:in `block in with_hooks'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime/support_code.rb:120:in `call'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime/support_code.rb:120:in `block (3 levels) in around'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/language_support/language_methods.rb:9:in `block in around'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/language_support/language_methods.rb:91:in `call'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/language_support/language_methods.rb:91:in `execute_around'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/language_support/language_methods.rb:8:in `around'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime/support_code.rb:119:in `block (2 levels) in around'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime/support_code.rb:117:in `call'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime/support_code.rb:117:in `around'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime.rb:93:in `around'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime.rb:80:in `with_hooks'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/tree_walker.rb:13:in `execute'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/scenario.rb:32:in `block in accept'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/scenario.rb:79:in `with_visitor'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/scenario.rb:31:in `accept'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/tree_walker.rb:58:in `block in visit_feature_element'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/tree_walker.rb:170:in `broadcast'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/tree_walker.rb:57:in `visit_feature_element'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/feature.rb:38:in `block in accept'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/feature.rb:37:in `each'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/feature.rb:37:in `accept'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/tree_walker.rb:27:in `block in visit_feature'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/tree_walker.rb:170:in `broadcast'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/tree_walker.rb:26:in `visit_feature'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/features.rb:28:in `block in accept'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/features.rb:17:in `each'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/features.rb:17:in `each'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/features.rb:27:in `accept'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/tree_walker.rb:21:in `block in visit_features'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/tree_walker.rb:170:in `broadcast'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/ast/tree_walker.rb:20:in `visit_features'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/runtime.rb:48:in `run!'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/lib/cucumber/cli/main.rb:47:in `execute!'
d:/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.8/bin/cucumber:13:in `<top (required)>'
d:/Ruby193/bin/cucumber:23:in `load'
d:/Ruby193/bin/cucumber:23:in `<main>'
```
