### PR TITLE
Remove .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-spec/cucumber/treetop_parser/test_dos.feature -crlf


### PR DESCRIPTION
This ensures that CRLF line endings are used for a file that doesn't exist
anymore.
