### PR TITLE
Regex matchers simplified

### DIFF
--- a/lib/cucumber/ast/tree_walker.rb
+++ b/lib/cucumber/ast/tree_walker.rb
@@ -51,8 +51,7 @@ module Cucumber
       end
 
       def extract_method_name_from(call_stack_line)
-        matches = call_stack_line.match(/in `(?<method_name>.*)'/)
-        matches[:method_name]
+        call_stack_line.match(/in `(?<method_name>.*)'/)[:method_name]
       end
 
     end


### PR DESCRIPTION
`match.captures[0]` as well as `match[1]` create sort of notional noise IMO, while named groups are self-descriptive and easy to read.
