### PR TITLE
JSON output format in cucumber 2.0

### DIFF
--- a/features/docs/formatters/json_formatter.feature
+++ b/features/docs/formatters/json_formatter.feature
@@ -1,4 +1,3 @@
-@wip-new-core
 Feature: JSON output formatter
   In order to simplify processing of Cucumber features and results
   Developers should be able to consume features as JSON


### PR DESCRIPTION
Hi there everyone,

I've removed the `@wip-new-core` tag from the first JSON formatter feature and started trying to diagnose what needs to be done to get the feature working.

It appears that the `Cucumber::Formatter::GherkinFormatterAdapter` class does not yet know how to deal with the new AST elements defined in Cucumber::Core::AST (The first failure we encounter is the "Bad type" error raised at `lib/cucumber/formatter/gherkin_formatter_adapter.rb:114`, raised on encountering an instance of `Cucumber::Core::Ast::Scenario`.

Having tentatively fixed this by switching on the `use_legacy` flag passed in the environment in select the class of AST node expected (by looking at the HTML and JUnit formatters and copying what they're doing in an exploratory, cargo-culty way :smile:), it seems apparent that there problem runs a fair bit deeper, and that there's a fairly large mismatch between the interface presented by the legacy AST node classes (and expected by the gherkin formatter adapter) and the new AST node classes in cucumber-core. 

I'm also wondering if this is a bit of a red-herring, given the comment at the top of `gherkin_formatter_adapter.rb` stating that "This class will disappear when cucumber is based upon gherkin's model" - is this a change that is coming in 2.0, and therefore, should I be working to make this class redundant, rather than trying to fix it?

I'd be more than happy to get this feature shipped for you guys, but would really appreciate some pointers about how best to approach the problem - is there an existing formatter in the codebase which shows how you're approaching things in 2.0 that might be instructive for tackling this problem?

Cheers!

Tim
