### PR TITLE
Trying to fix the failing JRuby builds on Travis

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -2,7 +2,7 @@
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format progress features" : "--format pretty #{rerun}"
 std_opts = "--format progress features --tags ~@wip --tag ~@wip-new-core -r features --strict"
-std_opts << " --tags ~@drb" if defined?(JRUBY_VERSION)
+std_opts << " --tags ~@drb --tags ~@wip-jruby" if defined?(JRUBY_VERSION)
 begin
   require 'rspec/expectations'
   std_opts << ' --tags ~@rspec1'


### PR DESCRIPTION
The Travis builds for JRuby have been failing for a while because a scenario tagged @wip-jruby fails there. To me it seems like the options "--tags ~@wip-jruby" should be used for the JRuby build. Therefore that option need to be added to std_opts in cucumber.yml on JRuby.
The wip_opts for JRuby in cucumber.yml looks broken ",@wip-jruby" cannot be added to a string ending with "-r features". It first caught my eye in cucumber.yml, therefore I fixed that first (thinking that it should fix the JRuby build).
