### PR TITLE
Initialize Pretty formatter with output stream when autoformatting

### DIFF
--- a/features/autoformat_profile_output.feature
+++ b/features/autoformat_profile_output.feature
@@ -1,0 +1,23 @@
+Feature: Autoformat profile output
+
+  Background:
+    Given a file named "features/autoformat_output_has_profile_info.feature" with:
+      """
+      Feature:
+
+        Scenario: Passing
+          Given passing
+      """
+
+  Scenario: when using a profile the output should include 'Using the default profile...'
+    And a file named "cucumber.yml" with:
+    """
+      default: -r features
+    """
+    When I run `cucumber --profile default --autoformat tmp`
+    Then it should pass
+    And the output should contain:
+    """
+    Using the default profile...
+    """
+

--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -172,7 +172,7 @@ module Cucumber
         # can be done with the gherkin CLI.
         if @options[:autoformat]
           require 'cucumber/formatter/pretty'
-          return [Formatter::Pretty.new(runtime, nil, @options)]
+          return [Formatter::Pretty.new(runtime, out_stream, @options)]
         end
 
         @options[:formats].map do |format_and_out|


### PR DESCRIPTION
System: Win 7 Ultimate x64
Console: MsysGit (bash)
Ruby: ruby 1.9.3p392 (2013-02-22) [i386-mingw32]

Does NOT occur before v1.3.0. Tested on 1.2.5, 1.3.0, 1.3.9.

```
c:/opt/bin/Ruby193/bin/ruby -S bundle exec cucumber features/blah/blagh.feature -a tmp/pretty
private method `puts' called for nil:NilClass (NoMethodError)
c:/opt/bin/Ruby193/lib/ruby/gems/1.9.1/gems/cucumber-1.3.9/lib/cucumber/formatter/console.rb:202:in `print_profile_information'
```

From what I can see, nil is passed (as the IO object) to `Formatter::Pretty.new` when autoformat is used (in Configuration#formatters).
The crash happens when `@IO.puts` is called with `@IO == nil`.

The workaround I've found is to specify the `--no-profile` (`-P`) flag when using `--autoformat`. If there's no profile, print_profile_information exits early and puts is not called.
