### PR TITLE
Specify Nokogiri version less precisely

### DIFF
--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'aruba', '~> 0.5.3'
   s.add_development_dependency 'json', '~> 1.7'
-  s.add_development_dependency 'nokogiri', '~> 1.5.2'
+  s.add_development_dependency 'nokogiri', '~> 1.5'
   s.add_development_dependency 'rake', '>= 0.9.2'
   s.add_development_dependency 'rspec', '>= 2.13'
   s.add_development_dependency 'simplecov', '>= 0.6.2'


### PR DESCRIPTION
Nokogiri 1.6 doesn't require to install system libraries
