### PR TITLE
Set run mode to `:dry_run` when `--dry-run` is used.

### DIFF
--- a/features/docs/wire_protocol.feature
+++ b/features/docs/wire_protocol.feature
@@ -82,7 +82,6 @@ Feature: Wire Protocol
   #            is simply used for the wire server's own reference.
   #   * args - any argument values as captured by the wire end's own regular
   #            expression (or other argument matching) process.
-  @wip
   Scenario: Dry run finds a step match
     Given there is a wire server running on port 54321 which understands the following protocol:
       | request                                              | response                            |

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -61,7 +61,7 @@ module Cucumber
       fire_after_configuration_hook
       self.visitor = report
 
-      execute features, mappings, report, filters
+      execute features, mappings, report, filters, run_options
       report.after_suite
     end
 
@@ -267,6 +267,12 @@ module Cucumber
         [Cucumber::Core::Test::LocationsFilter, [filespecs.locations]],
         [Quit, []],
       ]
+    end
+
+    def run_options
+      {}.tap do |run_options|
+        run_options[:run_mode] = :dry_run if @configuration.dry_run?
+      end
     end
 
     class Quit


### PR DESCRIPTION
This PR will not pass until https://github.com/cucumber/cucumber-ruby-core/pull/42 has been merged.

This passes the a run option of `:dry_run` to `Cucumber::Core::Test:Runner` when
the `--dry-run` cli argument is used.
