### PR TITLE
Update json formatter for append images embedding

### DIFF
--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -11,7 +11,12 @@ module Cucumber
 
       def initialize(runtime, io, options)
         @io = ensure_io(io, "json")
-        super(Gherkin::Formatter::JSONFormatter.new(@io), false)
+        @formatter = Gherkin::Formatter::JSONFormatter.new(@io)
+        super(@formatter, false)
+      end
+
+      def embed(src, mime_type, label)
+        @formatter.embedding(mime_type, {'label' => label, 'src' => src}.to_json)
       end
     end
   end


### PR DESCRIPTION
Before fix, code like this does not append embedding info to json. I fixed it.
Code example:
    page.driver.browser.save_screenshot("report/#{scenario.**id**}.png")
    embed("#{scenario.**id**}.png", "image/png", "SCREENSHOT")
