### PR TITLE
Add explicit ruby 2.1 support

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -13,6 +13,7 @@ jruby_win:   <%= std_opts %> --tags ~@wire CUCUMBER_FORWARD_SLASH_PATHS=true
 windows_mri: <%= std_opts %> --tags ~@jruby --tags ~@wire --tags ~@needs-many-fonts CUCUMBER_FORWARD_SLASH_PATHS=true
 ruby_1_9:    <%= std_opts %> --tags ~@jruby
 ruby_2_0:    <%= std_opts %> --tags ~@jruby
+ruby_2_1:    <%= std_opts %> --tags ~@jruby
 wip:         --wip <%= wip_opts %> features
 none:        --format pretty
 rerun:       <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip --tag ~@wip-new-core

--- a/gem_tasks/cucumber.rake
+++ b/gem_tasks/cucumber.rake
@@ -11,6 +11,9 @@ class Cucumber::Rake::Task
       'ruby_1_9'
     elsif Cucumber::RUBY_2_0
       'ruby_2_0'
+    elsif Cucumber::RUBY_2_1
+      'ruby_2_1'
+    end
     end
   end
 end

--- a/lib/cucumber/core_ext/instance_exec.rb
+++ b/lib/cucumber/core_ext/instance_exec.rb
@@ -47,7 +47,7 @@ class Object #:nodoc:
     end
   end
 
-  INSTANCE_EXEC_OFFSET = (Cucumber::RUBY_2_0 || Cucumber::RUBY_1_9 || Cucumber::JRUBY) ? -3 : -4
+  INSTANCE_EXEC_OFFSET = (Cucumber::RUBY_2_1 || Cucumber::RUBY_2_0 || Cucumber::RUBY_1_9 || Cucumber::JRUBY) ? -3 : -4
 
   def replace_instance_exec_invocation_line!(backtrace, instance_exec_invocation_line, pseudo_method)
     return if Cucumber.use_full_backtrace

--- a/lib/cucumber/platform.rb
+++ b/lib/cucumber/platform.rb
@@ -14,6 +14,7 @@ module Cucumber
     WINDOWS_MRI   = WINDOWS && !JRUBY && !IRONRUBY
     RAILS         = defined?(Rails)
     RUBY_BINARY   = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
+    RUBY_2_1      = RUBY_VERSION =~ /^2\.1/
     RUBY_2_0      = RUBY_VERSION =~ /^2\.0/
     RUBY_1_9      = RUBY_VERSION =~ /^1\.9/
 


### PR DESCRIPTION
The backtrace rewriting code requires an explicit version of Ruby to be set, which requires hard coding for every minor Ruby release.

Going forward we should reverse the check in `instance_exec.rb` to target older ruby versions not newer ones.

Part of an effort to get Ruby 2.1+ working: see #636.
