### PR TITLE
Filter new backtrace paths for Ruby 2.1+

### DIFF
--- a/lib/cucumber/reports/legacy_formatter.rb
+++ b/lib/cucumber/reports/legacy_formatter.rb
@@ -794,7 +794,7 @@ module Cucumber
 
           private
 
-          BACKTRACE_FILTER_PATTERNS = [/vendor\/rails|lib\/cucumber|bin\/cucumber:|lib\/rspec|gems\/|minitest|test\/unit|.gem\/ruby/]
+          BACKTRACE_FILTER_PATTERNS = [/vendor\/rails|lib\/cucumber|bin\/cucumber:|lib\/rspec|gems\/|minitest|test\/unit|.gem\/ruby|lib\/ruby/]
           if(Cucumber::JRUBY)
             BACKTRACE_FILTER_PATTERNS << /org\/jruby/
           end


### PR DESCRIPTION
With Ruby 2.1+ the timeout code has changed, so you get additional
lines appearing when Cucumber features fail due to a timeout exception:

``` ruby
Timed out calling wire server with message 'invoke' (Timeout::Error)
/Users/chris/.rbenv/versions/2.1.0/lib/ruby/2.1.0/timeout.rb:82:in `block in timeout'
/Users/chris/.rbenv/versions/2.1.0/lib/ruby/2.1.0/timeout.rb:70:in `catch'
/Users/chris/.rbenv/versions/2.1.0/lib/ruby/2.1.0/timeout.rb:70:in `timeout'
```

This change adds `lib/ruby` to the list of filtered backtraces to
prevent this showing, which should only ever target system code.

Part of a set of changes designed to get Ruby 2.1+ working: see #636.
