### PR TITLE
Overriding a profile's features to run (previously a @wip scenario)

### DIFF
--- a/features/docs/profiles.feature
+++ b/features/docs/profiles.feature
@@ -85,7 +85,6 @@ Feature: Profiles
     Given a file named "features/another.feature" with:
       """
       Feature: Just this one should be ran
-        Scenario: this is a test
       """
     When I run `cucumber -p default features/another.feature`
     Then exactly these features should be ran: features/another.feature

--- a/features/lib/step_definitions/profile_steps.rb
+++ b/features/lib/step_definitions/profile_steps.rb
@@ -11,5 +11,5 @@ Then /^exactly these files should be loaded:\s*(.*)$/ do |files|
 end
 
 Then /^exactly these features should be ran:\s*(.*)$/ do |files|
-  all_stdout.scan(/^.* (.*\.feature).*$/).flatten.uniq.should == files.split(/,\s+/)
+  all_stdout.scan(/^  \* (.*\.feature)$/).flatten.should == files.split(/,\s+/)
 end

--- a/lib/cucumber/file_specs.rb
+++ b/lib/cucumber/file_specs.rb
@@ -4,7 +4,9 @@ module Cucumber
     FILE_COLON_LINE_PATTERN = /^([\w\W]*?)(?::([\d:]+))?$/ #:nodoc:
 
     def initialize(file_specs)
+      Cucumber.logger.debug("Features:\n")
       @file_specs = file_specs.map { |s| FileSpec.new(s) }
+      Cucumber.logger.debug("\n")
     end
 
     def locations
@@ -18,6 +20,7 @@ module Cucumber
     class FileSpec
       def initialize(s)
         @file, @lines = *FILE_COLON_LINE_PATTERN.match(s).captures
+        Cucumber.logger.debug("  * #{@file}\n")
         @lines = String(@lines).split(':').map { |line| Integer(line) }
       end
 


### PR DESCRIPTION
Scenario: Overriding the profile's features to run (a @wip scenario).  The "Then" step definition is looking for the standard output to have " \* features/another.feature".  However, the output was:

```
Code:
  * features/support/env.rb

Using the default profile...
0 scenarios
0 steps
0m0.000s
```

So the "Then" step definition cannot find a matching output.  I modified the content of the `another.feature` to generate output:

```
Code:
  * features/support/env.rb

Using the default profile...
Feature: Just this one should be ran

  Scenario: this is a test # features/another.feature:2

1 scenario (1 passed)
0 steps
0m0.000s
```

This allows the output to have one (and potentially more than one) "features/another.feature".  In order to keep only unique files, I also changed the corresponding step definition accordingly.
First time contributing, feedback appreciated!
