### PR TITLE
[Christopher] FIX: If background fails, rerun just runs the first scenario and skips other scenarios

### DIFF
--- a/lib/cucumber/formatter/rerun.rb
+++ b/lib/cucumber/formatter/rerun.rb
@@ -32,8 +32,13 @@ module Cucumber
           after_first_time do
             @io.print ' '
           end
-          @io.print "#{@file}:#{@lines.join(':')}"
+          if @in_background
+            @io.print @file
+          else
+            @io.print "#{@file}:#{@lines.join(':')}"
+          end
           @io.flush
+          @in_background = false
         end
       end
 
@@ -77,6 +82,7 @@ module Cucumber
       end
 
       def step_name(keyword, step_match, status, source_indent, background, file_colon_line)
+        @in_background = true if status == :failed && background
         @rerun = true if [:failed, :pending, :undefined].index(status)
       end
 


### PR DESCRIPTION
On a feature execution, if the background fails, the rerun.txt file records the feature along with the line number of first scenario. Consequently during rerun only this scenario runs and all other scenarios in the feature file are ignored.

The fix is to capture just the feature file name WITHOUT any line numbers in rerun.txt if background fails. This results in rerunning the entire feature file with all scenarios.
