### PR TITLE
Adapt legacy_formatter.hook signature to the use in cucumber-ruby-core

### DIFF
--- a/lib/cucumber/reports/legacy_formatter.rb
+++ b/lib/cucumber/reports/legacy_formatter.rb
@@ -93,7 +93,7 @@ module Cucumber
           self
         end
 
-        def hook(result)
+        def hook(location, result)
           LegacyResultBuilder.new(result).describe_exception_to(formatter)
         end
 


### PR DESCRIPTION
The call to legacy_formatter.hook in cucumber-ruby-core::hooks.describe_to_source has been changed in https://github.com/cucumber/cucumber-ruby-core/commit/a86f16f3585d674050ace4558a80c34810f99d65 so the master branch of cucumber get the following build error:

```
ArgumentError:
wrong number of arguments (2 for 1)
# ./lib/cucumber/reports/legacy_formatter.rb:96:in `hook'
```
