### PR TITLE
failure scenario with --strict. previously marked with @wip

### DIFF
--- a/features/docs/cli/strict_mode.feature
+++ b/features/docs/cli/strict_mode.feature
@@ -11,7 +11,6 @@ Feature: Strict mode
         Given this step passes
     """
 
-  @wip-new-core
   Scenario: Fail with --strict
     When I run `cucumber -q features/missing.feature --strict`
     Then it should fail with:

--- a/lib/cucumber/reports/legacy_formatter.rb
+++ b/lib/cucumber/reports/legacy_formatter.rb
@@ -279,7 +279,8 @@ module Cucumber
         def step(step, result)
           @child ||= StepsPrinter.new(formatter).before
           @last_step_result = result
-          step_invocation = LegacyResultBuilder.new(result).step_invocation(step_match(step), step, indent, background = nil)
+          legacy_result_builder = LegacyResultBuilder.new(result)
+          step_invocation = legacy_result_builder.step_invocation(step_match(step, legacy_result_builder), step, indent, background = nil)
           runtime.step_visited step_invocation
           @child.step_invocation step_invocation, runtime
         end
@@ -299,9 +300,10 @@ module Cucumber
           @last_step_result || Core::Test::Result::Unknown.new
         end
 
-        def step_match(step)
+        def step_match(step, legacy_result_builder)
           runtime.step_match(step.name)
-        rescue Cucumber::Undefined
+        rescue Cucumber::Undefined => e
+          legacy_result_builder.exception(e) if runtime.strict?
           NoStepMatch.new(step, step.name)
         end
 

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -195,6 +195,10 @@ module Cucumber
       Core::Ast::DocString.new(string_without_triple_quotes, content_type, location)
     end
 
+    def strict?
+      @configuration.strict?
+    end
+
   private
 
     def fire_after_configuration_hook #:nodoc


### PR DESCRIPTION
This @wip is a scenario in `strict_mode.feature`, which fails because the code doesn't produce the following expected output:

```
Undefined step: "this step passes" (Cucumber::Undefined)
features/missing.feature:3:in `Given this step passes'
```

The relevant implementation in the old core is in `step_invocation.rb`.  In the new implementation, the `Undefined` class in cucumber-ruby-core's `result.rb` doesn't inherit from `StandardError`, so `LegacyResultBuilder`'s `@exception` needed to be set explicitly.  In addition, the configuration `--strict` also need to be made available to the `ScenarioPrinter`.  I chose to expose that via `runtime` (not sure if this is appropriate, or maybe there are better ways to do this?).  Feedback appreciated.
