### PR TITLE
Fix #660 and let the rerun formatter include all examples rows when the background fails

### DIFF
--- a/features/.cucumber/stepdefs.json
+++ b/features/.cucumber/stepdefs.json
@@ -150,6 +150,15 @@
         ]
       },
       {
+        "name": "I run `cucumber features/failing_background_outline.feature -r features -f rerun`",
+        "args": [
+          {
+            "offset": 7,
+            "val": "cucumber features/failing_background_outline.feature -r features -f rerun"
+          }
+        ]
+      },
+      {
         "name": "I run `cucumber features/one_passing_one_failing.feature -r features -f rerun`",
         "args": [
           {

--- a/features/rerun_formatter.feature
+++ b/features/rerun_formatter.feature
@@ -40,6 +40,21 @@ Feature: Rerun formatter
         Scenario: another failing background
           Then a passing step
       """
+    And a file named "features/failing_background_outline.feature" with:
+      """
+      Feature: Failing background sample with scenario outline
+
+        Background:
+          Given a failing step
+
+        Scenario Outline:
+          Then a <certain> step
+
+        Examples:
+          |certain|
+          |passing|
+          |passing|
+      """
     And a file named "features/step_definitions/steps.rb" with:
       """
       Given /a passing step/ do
@@ -67,4 +82,11 @@ Feature: Rerun formatter
     Then it should fail with:
     """
     features/failing_background.feature:6:9
+    """
+
+  Scenario: Failing background with scenario outline
+    When I run `cucumber features/failing_background_outline.feature -r features -f rerun`
+    Then it should fail with:
+    """
+    features/failing_background_outline.feature:11:12
     """

--- a/lib/cucumber/formatter/rerun.rb
+++ b/lib/cucumber/formatter/rerun.rb
@@ -55,7 +55,7 @@ module Cucumber
       def after_table_row(table_row)
         return unless @in_examples and Cucumber::Ast::OutlineTable::ExampleRow === table_row
         unless @header_row
-          if table_row.failed?
+          if table_row.failed? || table_row.status == :skipped
             @rerun = true
             @lines << table_row.line
           end


### PR DESCRIPTION
Fixes #660. The rerun formatter should check for Cucumber:Ast:ScenarioOutline before calling the status method, not after status already has been called.

The rerun formatter is updated to include all example row from example tables when the background fails.
