### PR TITLE
Remove call to rspec-core internals from rspec/doubles.rb

### DIFF
--- a/lib/cucumber/rspec/doubles.rb
+++ b/lib/cucumber/rspec/doubles.rb
@@ -1,7 +1,6 @@
-require 'rspec/core'
+require 'rspec/mocks'
 
-RSpec.configuration.configure_mock_framework
-World(RSpec::Core::MockFrameworkAdapter)
+World(RSpec::Mocks::ExampleMethods)
 
 Before do
   RSpec::Mocks::setup(self)


### PR DESCRIPTION
The way mock frameworks are included in rspec-core is changing in RSpec 3.0. In particular, `RSpec::Core::MockFrameworkAdapter` has been removed. Thus, if I try to use [`cucumber/rspec/doubles.rb`](https://github.com/cucumber/cucumber/blob/4d71770/lib/cucumber/rspec/doubles.rb) in a project which uses RSpec 3.0.0.beta2, I get an error.

```
require 'cucumber/rspec/doubles'
=> uninitialized constant RSpec::Core::MockFrameworkAdapter (NameError)
```

I brought up the issue in rspec/rspec-core#1480, where @myronmarston suggested adding `RSpec::Mocks::ExampleMethods` to `World` instead. This PR is a straight up copy-paste of his code example. 

I don't see the behaviour of `doubles.rb` being tested anywhere, and I'm not quite sure how that should be done. I can confirm that when trying out my fork in a project which requires `doubles.rb`, this fork works as intended together with RSpec 2.14.2.

---

Note: This pull request is not about attaining compatibility with RSpec 3.0, rather its purpose is to avoid calls to internal RSpec parts that were not intended as part of a public API.

To make Cucumber compatible with RSpec 3.0, there is at least one more change needed in `doubles.rb`: `RSpec::Mocks::setup(self)` does not take an argument anymore. If someone has a suggestion on how to change that call depending on the used RSpec version, I'd be happy to submit it in a separate pull request.
