### PR TITLE
Scope formatter classes to Cucumber::Formatter

### DIFF
--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -72,7 +72,7 @@ module Cucumber
 
       def formatter_class(format)
         if(builtin = Options::BUILTIN_FORMATS[format])
-          constantize(builtin[0])
+          constantize("Cucumber::Formatter::#{builtin[0]}")
         else
           constantize(format)
         end


### PR DESCRIPTION
This means that projects that implement their own `Progress` class don't have their cucumber tests output break.
