### PR TITLE
Add RSpec 3 Test Double support.

### DIFF
--- a/lib/cucumber/rspec/doubles.rb
+++ b/lib/cucumber/rspec/doubles.rb
@@ -4,16 +4,16 @@ World(RSpec::Mocks::ExampleMethods)
 
 Before do
   if RSpec::Mocks::Version::STRING.split('.').first.to_i > 2
-    RSpec::Mocks::setup
+    RSpec::Mocks.setup
   else
-    RSpec::Mocks::setup(self)
+    RSpec::Mocks.setup(self)
   end
 end
 
 After do
   begin
-    RSpec::Mocks::verify
+    RSpec::Mocks.verify
   ensure
-    RSpec::Mocks::teardown
+    RSpec::Mocks.teardown
   end
 end


### PR DESCRIPTION
I made this change so that the RSpec Test Double support would be compatible
with RSpec 3 as well. This is necessary because they changed the public facing
API in RSpec 3. I didn't see any automated test coverage around this area of the
code. I did manually test it though and it seems to be working correctly.
