### PR TITLE
rescuing argument error on split so cucumber won't stop tests due bad en...

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -603,8 +603,12 @@ module Cucumber
 
         def lines_around(file, line)
           if File.file?(file)
+            begin
             lines = File.open(file).read.split("\n")
-            min = [0, line-3].max
+          rescue ArgumentError
+            return "# Couldn't get snippet for #{file}"
+          end
+          min = [0, line-3].max
             max = [line+1, lines.length-1].min
             selected_lines = []
             selected_lines.join("\n")


### PR DESCRIPTION
I've been getting a few encoding errors lately on my CI server, I can't put the finger on the problem, I cannot get it happen locally either, that's why I haven't added a test for it, but I did this quick fix so it wouldn't impact other work until the root cause is discovered.
I've been running this on the CI server (edited directly on the gem) for 2 days now with no issues.

```
Conn close
invalid byte sequence in US-ASCII (ArgumentError)
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/formatter/html.rb:601:in `split'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/formatter/html.rb:601:in `lines_around'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/formatter/html.rb:593:in `snippet_for'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/formatter/html.rb:583:in `snippet'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/formatter/html.rb:277:in `extra_failure_content'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/formatter/html.rb:404:in `build_exception_detail'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/formatter/html.rb:272:in `exception'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:181:in `block in send_to_all'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:179:in `each'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:179:in `send_to_all'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:173:in `broadcast'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:129:in `visit_exception'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:114:in `block in visit_step_result'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:170:in `broadcast'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:111:in `visit_step_result'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/step_invocation.rb:43:in `visit_step_result'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/step_invocation.rb:39:in `accept'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:106:in `block in visit_step'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:170:in `broadcast'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:105:in `visit_step'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/step_collection.rb:19:in `block in accept'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/step_collection.rb:18:in `each'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/step_collection.rb:18:in `accept'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:100:in `block in visit_steps'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:170:in `broadcast'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:99:in `visit_steps'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:15:in `block in execute'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/runtime.rb:83:in `block (2 levels) in with_hooks'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/runtime.rb:99:in `before_and_after'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/runtime.rb:82:in `block in with_hooks'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/runtime/support_code.rb:120:in `call'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/runtime/support_code.rb:120:in `block (3 levels) in around'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/language_support/language_methods.rb:9:in `block in around'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/language_support/language_methods.rb:97:in `call'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/language_support/language_methods.rb:97:in `execute_around'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/language_support/language_methods.rb:8:in `around'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/runtime/support_code.rb:119:in `block (2 levels) in around'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/runtime/support_code.rb:123:in `call'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/runtime/support_code.rb:123:in `around'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/runtime.rb:94:in `around'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/runtime.rb:81:in `with_hooks'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:13:in `execute'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/scenario.rb:32:in `block in accept'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/scenario.rb:79:in `with_visitor'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/scenario.rb:31:in `accept'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:58:in `block in visit_feature_element'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:170:in `broadcast'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:57:in `visit_feature_element'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/feature.rb:38:in `block in accept'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/feature.rb:37:in `each'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/feature.rb:37:in `accept'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:27:in `block in visit_feature'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:170:in `broadcast'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:26:in `visit_feature'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/features.rb:28:in `block in accept'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/features.rb:17:in `each'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/features.rb:17:in `each'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/features.rb:27:in `accept'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:21:in `block in visit_features'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:170:in `broadcast'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/ast/tree_walker.rb:20:in `visit_features'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/runtime.rb:49:in `run!'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/lib/cucumber/cli/main.rb:47:in `execute!'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/gems/cucumber-1.3.10/bin/cucumber:13:in `<top (required)>'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/bin/cucumber:19:in `load'
/apps/jenkins/.rvm/gems/ruby-2.0.0-p451/bin/cucumber:19:in `<main>'
```
