### PR TITLE
fixed an incorrect assumption about instance of IO

### DIFF
--- a/lib/cucumber/formatter/io.rb
+++ b/lib/cucumber/formatter/io.rb
@@ -4,6 +4,7 @@ module Cucumber
       def ensure_io(path_or_io, name)
         return nil if path_or_io.nil?
         [IO, StringIO].each { |obj| return path_or_io if path_or_io.kind_of?(obj) }
+
         file = File.open(path_or_io, Cucumber.file_mode('w'))
         at_exit do
           unless file.closed?


### PR DESCRIPTION
Symptom is an absence of output files. 
Found when tested the following code with SikuliX IDE

``` ruby
    out_html = 'cucumber_result.html'
    args = [
      '--format', 'pretty',
      '--format', 'html',
      '--out', out_html
    ]
    require 'cucumber/rspec/disable_option_parser'
    require 'cucumber/cli/main'
    Cucumber::Cli::Main.new(args).execute!
```

Reason:

``` ruby
str = '123'
p str.respond_to? :write  
# => false

Object.send('define_method', 'write'){  puts '***' }

p str.respond_to? :write  
# => true!!!
```
