### PR TITLE
Support embedding data directly in gherkin formatters

### DIFF
--- a/features/json_formatter.feature
+++ b/features/json_formatter.feature
@@ -56,8 +56,8 @@ Feature: JSON output formatter
       end
 
       Given /^I embed data directly/ do
-        data = "abc"
-        embed data, "mime-type"
+        data = "YWJj"
+        embed data, "mime-type;base64"
       end
       """
     And a file named "features/embed.feature" with:

--- a/lib/cucumber/formatter/gherkin_formatter_adapter.rb
+++ b/lib/cucumber/formatter/gherkin_formatter_adapter.rb
@@ -149,7 +149,12 @@ module Cucumber
         if File.file?(file)
           data = File.open(file, 'rb') { |f| f.read }
         else
-          data = file
+          if mime_type =~ /;base64$/
+            mime_type = mime_type[0..-8]
+            data = Base64.decode64(file)
+          else
+            data = file
+          end
         end
         if defined?(JRUBY_VERSION)
           data = data.to_java_bytes


### PR DESCRIPTION
This PR sets out to fix part 1 of #651 ("fix the JSON report formatter").

The idea is to support the following construct in step definitions:

```
encoded_img = @browser.driver.screenshot_as(:base64)
embed("#{encoded_img}",'image/png;base64')
```

The GherkinFormatterAdapter will now check if the first parameter given to the embed method is indeed a file, and if so read the content of the file and send it to the gherkin formatter (for instance the JSON Formatter) as before. When the first parameter given to the embed method is not a file, then the GherkinFormatterAdapter will now assume it is the data to embed, and send that parameter through to the gherkin formatter.
