### PR TITLE
Support embedding images directly in html files

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -29,7 +29,8 @@ module Cucumber
         case(mime_type)
         when /^image\/(png|gif|jpg|jpeg)/
           unless File.file?(src) or src =~ /^data:image\/(png|gif|jpg|jpeg);base64,/
-            src = "data:" + mime_type + ";base64," + src
+            type = mime_type =~ /;base[0-9]+$/ ? mime_type : mime_type + ";base64"
+            src = "data:" + type + "," + src
           end
           embed_image(src, label)
         end

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -266,7 +266,7 @@ module Cucumber
 
         describe "with a step that embeds a snapshot content" do
           define_steps do
-            Given(/snap/) { embed('YWJj', 'image/png') }
+            Given(/snap/) { embed('YWJj', 'image/png;base64') }
           end
 
           define_feature(<<-FEATURE)


### PR DESCRIPTION
This PR sets out to fix part 2 of #651 ("some kind of official option on embed images [using the HTML formatter]"), or at least it does remove the need to prefix the image data with `"data:image/<format>;base64,`, manually (a prefix that is not relevant for files produces by other formatters, like the JSON formatter).

The idea is to support the following construct in step definitions:

```
encoded_img = @browser.driver.screenshot_as(:base64)
embed("#{encoded_img}",'image/png;base64')
```

The HTML formatter will now check whether the first argument to the embed method is a file, or if it starts with the image embedding directive (`"data:image/<format>;base64,`), and if so insert the first argument as is in the src attribute of the HTML image element. Otherwise it will insert the image embedding directive first in the content of the first argument to the embed method, and insert the result as is in the src attribute of the HTML image element.
