### PR TITLE
Feature: Support of relative image sources

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -2,6 +2,7 @@ require 'erb'
 require 'builder'
 require 'cucumber/formatter/duration'
 require 'cucumber/formatter/io'
+require 'pathname'
 
 module Cucumber
   module Formatter
@@ -43,6 +44,9 @@ module Cucumber
       def embed_image(src, label)
         id = "img_#{@img_id}"
         @img_id += 1
+        if @io.respond_to?(:absolute_path) and File.exist?(src)
+          src = Pathname.new(File.absolute_path(src)).relative_path_from(@io.absolute_path)
+        end
         @builder.span(:class => 'embed') do |pre|
           pre << %{<a href="" onclick="img=document.getElementById('#{id}'); img.style.display = (img.style.display == 'none' ? 'block' : 'none');return false">#{label}</a><br>&nbsp;
           <img id="#{id}" style="display: none" src="#{src}"/>}


### PR DESCRIPTION
If an File-based image is not placed correctly, embedding the image will fail. This sanity check creates a relative path to the HTML IO object.

Pre-conditions:
- The image to be embedded must be file based
- The html IO object must be support an absolute_path method (http://www.ruby-doc.org/core-2.1.2/File.html#method-c-absolute_path)
