### PR TITLE
V2.0: Pass output from the step definition on to the gherkin formatters (JSON formatter)

### DIFF
--- a/features/docs/formatters/json_formatter.feature
+++ b/features/docs/formatters/json_formatter.feature
@@ -23,6 +23,10 @@ Feature: JSON output formatter
         File.open("screenshot.png", "w") { |file| file << "foo" }
         embed "screenshot.png", "image/png"
       end
+
+      Given /^I print from step definition/ do
+        puts "from step definition"
+      end
       """
     And a file named "features/embed.feature" with:
       """
@@ -30,6 +34,15 @@ Feature: JSON output formatter
 
         Scenario:
           Given I embed a screenshot
+
+      """
+    And a file named "features/print_from_step_definition.feature" with:
+      """
+      Feature: A print from step definition feature
+
+        Scenario:
+          Given I print from step definition
+          And I print from step definition
 
       """
 
@@ -297,6 +310,65 @@ Feature: JSON output formatter
                 ],
                 "match": {
                   "location": "features/step_definitions/json_steps.rb:1"
+                },
+                "result": {
+                  "status": "passed",
+                  "duration": 1
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+
+    """
+
+  Scenario: print from step definition
+    When I run `cucumber --format json features/print_from_step_definition.feature`
+    Then it should pass with JSON:
+    """
+    [
+      {
+        "uri": "features/print_from_step_definition.feature",
+        "id": "a-print-from-step-definition-feature",
+        "keyword": "Feature",
+        "name": "A print from step definition feature",
+        "line": 1,
+        "description": "",
+        "elements": [
+          {
+            "id": "a-print-from-step-definition-feature;",
+            "keyword": "Scenario",
+            "name": "",
+            "line": 3,
+            "description": "",
+            "type": "scenario",
+            "steps": [
+              {
+                "keyword": "Given ",
+                "name": "I print from step definition",
+                "line": 4,
+                "output": [
+		  "from step definition"
+                ],
+                "match": {
+                  "location": "features/step_definitions/json_steps.rb:6"
+                },
+                "result": {
+                  "status": "passed",
+                  "duration": 1
+                }
+              },
+              {
+                "keyword": "And ",
+                "name": "I print from step definition",
+                "line": 5,
+                "output": [
+		  "from step definition"
+                ],
+                "match": {
+                  "location": "features/step_definitions/json_steps.rb:6"
                 },
                 "result": {
                   "status": "passed",

--- a/lib/cucumber/formatter/gherkin_formatter_adapter.rb
+++ b/lib/cucumber/formatter/gherkin_formatter_adapter.rb
@@ -93,6 +93,10 @@ module Cucumber
           @gf.embedding(mime_type, data)
         end
       end
+
+      def puts(message)
+        @gf.write(message)
+      end
     end
   end
 end


### PR DESCRIPTION
The output from the step definition is not passed on in the GherkinFormatterAdapter, which cases the output to be missing the the generated JSON report.

This RP fixes that. To make it work the legacy_formatter delays the calls to puts from the step definitions until the formatter has been informed of the corresponding step (similar to the handling of embed calls in #705). 

The corresponding PR for v1.3.x is #701
