### PR TITLE
Remove @wip-new-core from passing rerun formatter scenario

### DIFF
--- a/features/docs/formatters/rerun_formatter.feature
+++ b/features/docs/formatters/rerun_formatter.feature
@@ -91,7 +91,6 @@ Feature: Rerun formatter
     features/failing_background.feature:6:9
     """
 
-@wip-new-core
 Scenario: Scenario outlines with expand
   For details see https://github.com/cucumber/cucumber/issues/503
     Given a file named "features/one_passing_one_failing.feature" with:
@@ -99,12 +98,12 @@ Scenario: Scenario outlines with expand
       Feature: One passing example, one failing example
 
         Scenario Outline:
-          Given a <status> step
+          Given this step <status>
 
         Examples:
-          | status  |
-          | passing |
-          | failing |
+          | status |
+          | passes |
+          | fails  |
 
       """
     When I run `cucumber --expand -f rerun`


### PR DESCRIPTION
The scenario "Scenario outlines with expand" in the rerun formatter feature is actually passing (since the --expand options is not really implemented in v2.0), but it has to be updated to be written for the v2.0 step definitions: (`this step passes/fails`) instead of the v1.3.x step definitions (`a passing/failing step`).
