### PR TITLE
v1.3.x: Let the rerun formatter handle outlines with the expand option

### DIFF
--- a/features/rerun_formatter.feature
+++ b/features/rerun_formatter.feature
@@ -73,6 +73,13 @@ Feature: Rerun formatter
     features/one_passing_one_failing.feature:9
     """
 
+  Scenario: Handle examples using expand with the rerun formatter
+    When I run `cucumber features/one_passing_one_failing.feature --expand -r features -f rerun`
+    Then it should fail with:
+    """
+    features/one_passing_one_failing.feature:9
+    """
+
   Scenario: Handle scenario outline with passing example
     When I run `cucumber features/passing_outline.feature -r features -f rerun`
     Then it should pass

--- a/lib/cucumber/formatter/rerun.rb
+++ b/lib/cucumber/formatter/rerun.rb
@@ -67,10 +67,14 @@ module Cucumber
       def before_examples(*args)
         @header_row = true
         @in_examples = true
+        @current_example_line = nil
       end
 
       def after_examples(*args)
         @in_examples = false
+        if @current_example_line and @rerun
+          @lines << @current_example_line
+        end
       end
 
       def before_table_row(table_row)
@@ -79,6 +83,15 @@ module Cucumber
 
       def step_name(keyword, step_match, status, source_indent, background, file_colon_line)
         @rerun = true if [:failed, :pending, :undefined].index(status)
+      end
+
+      def scenario_name(keyword, name, file_colon_line, source_indent)
+        return unless @in_examples
+        if @current_example_line and @rerun
+          @lines << @current_example_line
+        end
+        @rerun = false
+        @current_example_line = file_colon_line.split(':')[1]
       end
 
     private


### PR DESCRIPTION
I think that #503 and #504 were intended to be targeted to the v1.3.x-bugfix branch, rather than the master/v2.0 branch. The scenario in #504 is passing in v2.0, if it is just updated to use the v2.0 step definitions, see #709.

This PR adds the corresponding scenario to the rerun formatter feature also in v1.3.x, and updates the rerun formatter so this scenario passes.
