### PR TITLE
support embed plain/text in html report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ Gemfile.lock
 tags
 features/.cucumber/stepdefs.json
 .ruby-version
+.project

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -30,6 +30,7 @@ module Cucumber
         @header_red = nil
         @delayed_messages = []
         @img_id = 0
+        @text_id = 0
         @inside_outline = false
       end
 
@@ -37,6 +38,8 @@ module Cucumber
         case(mime_type)
         when /^image\/(png|gif|jpg|jpeg)/
           embed_image(src, label)
+        when /^text\/plain/
+          embed_text(src, label)
         end
       end
 
@@ -46,6 +49,14 @@ module Cucumber
         @builder.span(:class => 'embed') do |pre|
           pre << %{<a href="" onclick="img=document.getElementById('#{id}'); img.style.display = (img.style.display == 'none' ? 'block' : 'none');return false">#{label}</a><br>&nbsp;
           <img id="#{id}" style="display: none" src="#{src}"/>}
+        end
+      end
+
+      def embed_text(src, label)
+        id = "text_#{@text_id}"
+        @text_id += 1
+        @builder.span(:class => 'embed') do |pre|
+          pre << %{<a id="#{id}" href="#{src}" title="#{label}">#{label}</a>}
         end
       end
 

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -256,6 +256,20 @@ module Cucumber
 
           it { expect(@doc.css('.embed img').first.attributes['src'].to_s).to eq "snapshot.jpeg" }
         end
+        
+        describe "with a step that embeds a text" do
+          define_steps do
+            Given(/log/) { embed('log.txt', 'text/plain') }
+          end
+
+          define_feature(<<-FEATURE)
+          Feature:
+            Scenario:
+              Given log
+            FEATURE
+
+          it { expect(@doc.at('a#text_0')['href'].to_s).to eq "log.txt" }
+        end
 
         describe "with an undefined Given step then an undefined And step" do
           define_feature(<<-FEATURE)


### PR DESCRIPTION
We have a project and we will generate a log file when something failed.
Currently we have to attach it to report as fake image.
But we prefer to add it as 'text/plain' mime type.

Could you support this feature? Thanks!
Link is here: https://github.com/cucumber/cucumber/issues/711
