### PR TITLE
Expect table row line number for failing scenario from outline

### DIFF
--- a/features/docs/gherkin/outlines.feature
+++ b/features/docs/gherkin/outlines.feature
@@ -70,7 +70,7 @@ Feature: Scenario outlines
             | passing | passing     |
 
       Failing Scenarios:
-      cucumber features/outline_sample.feature:5
+      cucumber features/outline_sample.feature:12
 
       5 scenarios (1 failed, 1 undefined, 3 passed)
       8 steps (1 failed, 2 skipped, 1 undefined, 4 passed)
@@ -100,7 +100,7 @@ Feature: Scenario outlines
             | passing | passing     |
 
       Failing Scenarios:
-      cucumber features/outline_sample.feature:5
+      cucumber features/outline_sample.feature:12
 
       4 scenarios (1 failed, 1 undefined, 2 passed)
       8 steps (1 failed, 2 skipped, 1 undefined, 4 passed)
@@ -125,7 +125,7 @@ Feature: Scenario outlines
             features/outline_sample.feature:6:in `Given <state> without a table'
 
       Failing Scenarios:
-      cucumber features/outline_sample.feature:5
+      cucumber features/outline_sample.feature:12
 
       1 scenario (1 failed)
       2 steps (1 failed, 1 skipped)
@@ -147,7 +147,7 @@ Feature: Scenario outlines
       features/outline_sample.feature:6:in `Given <state> without a table'
 
       Failing Scenarios:
-      cucumber features/outline_sample.feature:5
+      cucumber features/outline_sample.feature:12
 
       5 scenarios (1 failed, 1 undefined, 3 passed)
       8 steps (1 failed, 2 skipped, 1 undefined, 4 passed)


### PR DESCRIPTION
In v1.3.x the listing of failed scenarios use the line number for the scenario outline for when a outline example fails. This is inconsistent with what the rerun formatter output, where the line number of the example row is used. If the intention is that the listing of failed scenarios shall define commands that can be used to run the failed scenarios, the line number for the scenario outline works, but is a bit overkill, since using that line number will execute all examples for the scenario outline.

Currently the behaviour on v2.0 branch is to instead use the line number of the example row in the listing of the failed scenarios. This is both consistent with the rerun formatter output, and gives a more specific command to rerun the failed scenario.

Therefore I propose to "fix" the issue by changing the expected output in the outlines.feature (which still will be tagged `@wip-new-core` due to other remaining issues).
