### PR TITLE
Support building gem and doc locally

### DIFF
--- a/gem_tasks/yard.rake
+++ b/gem_tasks/yard.rake
@@ -30,11 +30,14 @@ namespace :api do
   task :release do
     Dir.chdir(SITE_DIR) do
       sh 'git add .'
-      sh "git commit -m 'Update API docs for Cucumber-Ruby v#{Cucumber::VERSION}'"
+      sh '''git commit -m "Update API docs for Cucumber-Ruby v#{Cucumber::VERSION}"'''
       sh 'git push'
     end
   end
 
   desc "Generate YARD docs for Cucumber's API"
   task :doc => [:yard, :sync_with_git, :copy_to_website, :release]
+  
+  desc "Build cucumber gem and doc locally"
+  task :build => [:yard, :sync_with_git, :copy_to_website]
 end


### PR DESCRIPTION
Since in windows, commit message requires double quote, otherwise, it will throw error.

I'm wondering if it's suggested to build latest cucumber gem locally.
There's no direct way to build gem file locally. So add it.
Please let me know if it's not a good approach.

BTW, I'm thinking where to add 'rake build'. Should it be added in readme or configure file?
Could you kindly give a suggestion.

Thanks!
