### PR TITLE
puts in an After hook does not output anything

### DIFF
--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -303,6 +303,27 @@ module Cucumber
           it { expect(@doc.css('.embed img').first.attributes['src'].to_s).to eq "data:image/png;base64,YWJj" }
         end
 
+        describe "printing messages" do
+          define_steps do
+            After { puts "before hook" }
+            Given(/pass/) { puts "in step" }
+            After { puts "after hook" }
+          end
+
+          define_feature(<<-FEATURE)
+          Feature:
+            Scenario:
+              Given passing
+            FEATURE
+
+          it "prints from before hooks, steps and after hooks" do
+            expect(@doc.css('.message').length).to eq 3
+            expect(@doc.css('.message')[0].text).to eq "before hook"
+            expect(@doc.css('.message')[1].text).to eq "in step"
+            expect(@doc.css('.message')[2].text).to eq "after hook"
+          end
+        end
+
         describe "with an undefined Given step then an undefined And step" do
           define_feature(<<-FEATURE)
           Feature:


### PR DESCRIPTION
Per [this stackoverflow answer](http://stackoverflow.com/questions/10526894/cucumber-puts-in-after-hook-not-outputting-anything)

```
After do
  puts "hello"
end
```

does not actually write out anything.  If there's another scenario in the file, the 1st scenario's After-hook output will appear in the 2nd scenario's flow.

I'm trying to write an `After` hook that will allow me to check why a scenario failed, and if it was a particular exception, output some useful text to tell the person how to get past it (which is unfortunately a manual step, but I'd like to be more friendly than a stack-trace).
