### PR TITLE
Remove --dotcucumber. No longer generate stepdefs.json.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,5 @@ doc/
 *.tgz
 Gemfile.lock
 tags
-features/.cucumber/stepdefs.json
 .ruby-version
 .project

--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 ## [In Git](https://github.com/cucumber/cucumber/compare/v.2.0.0.beta.2...master)
 
+### Removed Features
+
+  * The `--dotcucumber` option is no longer supported and `stepdefs.json` is no longer written. (Aslak Hellesøy)
+
 ### New Features
 
   * Add TestCase#outline? for conditionals in Before / After hooks ([728](https://github.com/cucumber/cucumber/pull/728) [Erran Carey](https://github.com/erran))

--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -62,10 +62,6 @@ module Cucumber
         @options[:expand]
       end
 
-      def dotcucumber
-        @options[:dotcucumber]
-      end
-
       def snippet_type
         @options[:snippet_type] || :regexp
       end

--- a/lib/cucumber/cli/main.rb
+++ b/lib/cucumber/cli/main.rb
@@ -36,7 +36,6 @@ module Cucumber
         end
 
         runtime.run!
-        runtime.write_stepdefs_json
         failure = runtime.results.failure? || Cucumber.wants_to_quit
         @kernel.exit(failure ? 1 : 0)
       rescue FileNotFoundException => e

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -223,9 +223,6 @@ module Cucumber
           opts.on("-x", "--expand", "Expand Scenario Outline Tables in output.") do
             @options[:expand] = true
           end
-          opts.on("--dotcucumber DIR", "Write metadata to DIR") do |dir|
-            @options[:dotcucumber] = dir
-          end
           opts.on("--order TYPE[:SEED]", "Run examples in the specified order. Available types:",
             *<<-TEXT.split("\n")) do |order|
   [defined]     Run scenarios in the order they were defined (default).

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -157,44 +157,6 @@ module Cucumber
       @support_code.unknown_programming_language?
     end
 
-    # TODO: this code is untested
-    def write_stepdefs_json
-      if(@configuration.dotcucumber)
-        stepdefs = []
-        @support_code.step_definitions.sort{|a,b| a.to_hash['source'] <=> a.to_hash['source']}.each do |stepdef|
-          stepdef_hash = stepdef.to_hash
-          steps = []
-          features.each do |feature|
-            feature.feature_elements.each do |feature_element|
-              feature_element.raw_steps.each do |step|
-                args = stepdef.arguments_from(step.name)
-                if(args)
-                  steps << {
-                    'name' => step.name,
-                    'args' => args.map do |arg|
-                      {
-                        'offset' => arg.offset,
-                        'val' => arg.val
-                      }
-                    end
-                  }
-                end
-              end
-            end
-          end
-          stepdef_hash['file_colon_line'] = stepdef.file_colon_line
-          stepdef_hash['steps'] = steps.uniq.sort {|a,b| a['name'] <=> b['name']}
-          stepdefs << stepdef_hash
-        end
-        if !File.directory?(@configuration.dotcucumber)
-          FileUtils.mkdir_p(@configuration.dotcucumber)
-        end
-        File.open(File.join(@configuration.dotcucumber, 'stepdefs.json'), 'w') do |io|
-          io.write(MultiJson.dump(stepdefs, :pretty => true))
-        end
-      end
-    end
-
     # Returns Ast::DocString for +string_without_triple_quotes+.
     #
     def doc_string(string_without_triple_quotes, content_type='', line_offset=0)


### PR DESCRIPTION
This feature was added a long time ago to support autocomplete in
3rd party tools. The only tool that has used the generated stepdefs.json
file is Cucumber Pro, which recently abandoned it. (Cucumber Pro will
receive the same metadata over an API, via a custom formatter).
