### PR TITLE
Fix the HTML formatters handling of output from hooks

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -179,11 +179,16 @@ module Cucumber
         @scenario_red = false
         css_class = AST_CLASSES[feature_element.class]
         @builder << "<div class='#{css_class}'>"
+        @in_scenario_outline = feature_element.class == Cucumber::Core::Ast::ScenarioOutline
       end
 
       def after_feature_element(feature_element)
+        unless @in_scenario_outline
+          print_messages
+          @builder << '</ol>'
+        end
         @builder << '</div>'
-        @open_step_list = true
+        @in_scenario_outline = nil
       end
 
       def scenario_name(keyword, name, file_colon_line, source_indent)
@@ -211,7 +216,7 @@ module Cucumber
       end
 
       def before_examples(examples)
-         @builder << '<div class="examples">'
+        @builder << '<div class="examples">'
       end
 
       def after_examples(examples)
@@ -231,10 +236,12 @@ module Cucumber
       end
 
       def after_steps(steps)
-        @builder << '</ol>'
+        print_messages
+        @builder << '</ol>' if @in_background or @in_scenario_outline
       end
 
       def before_step(step)
+        print_messages
         @step_id = step.dom_id
         @step_number += 1
         @step = step
@@ -290,6 +297,7 @@ module Cucumber
 
       def exception(exception, status)
         return if @hide_this_step
+        print_messages
         build_exception_detail(exception)
       end
 

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -313,6 +313,59 @@ module Cucumber
 
           it { expect(@doc.css('pre').map { |pre| /^(Given|And)/.match(pre.text)[1] }).to eq ["Given", "Given"] }
         end
+
+        describe "with a output from hooks" do
+          describe "in a scenario" do
+            define_feature <<-FEATURE
+          Feature:
+            Scenario:
+              Given this step passes
+            FEATURE
+
+            define_steps do
+              Before do
+                puts "Before hook"
+              end
+              AfterStep do
+                puts "AfterStep hook"
+              end
+              After do
+                puts "After hook"
+              end
+              Given(/^this step passes$/) {}
+            end
+
+            it { expect(@doc).to have_css_node('.step.message', /Before hook/) }
+            it { expect(@doc).to have_css_node('.step.message', /AfterStep hook/) }
+            it { expect(@doc).to have_css_node('.step.message', /After hook/) }
+          end
+
+          describe "in a scenario outline" do
+            define_feature <<-FEATURE
+          Feature:
+            Scenario Outline:
+              Given this step <status>
+              Examples:
+              | status |
+              | passes |
+            FEATURE
+
+            define_steps do
+              Before do
+                puts "Before hook"
+              end
+              AfterStep do
+                puts "AfterStep hook"
+              end
+              After do
+                puts "After hook"
+              end
+              Given(/^this step passes$/) {}
+            end
+
+            it { expect(@doc).to have_css_node('.message', /Before hook, AfterStep hook, After hook/) }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
In v1.3.x the HTML formatter delays the output from the Before hook until after the first step, and delays the output from the After hooks to until after the first step in the next Scenario:
![html_output_v1_3_x](https://cloud.githubusercontent.com/assets/2105308/4324703/5450b78a-3f5d-11e4-9c68-9dcbdf1dc99e.png)

In v2.0.0.beta.1 the output from AfterStep and After hooks was not printed at all. With the changes in #732 and #738, the handling of hook output was brought up to the same behaviour as v1.3.x. This PR fixes the remaining issues with respect to the HTML formatters handling of hook output, resulting in this behaviour:
![html_out_v2_0](https://cloud.githubusercontent.com/assets/2105308/4324789/fbbe94e2-3f5d-11e4-9d1f-b29af36c975d.png)

Fixes #731.
