### PR TITLE
Remove unnecessary `multi_test` require

### DIFF
--- a/lib/cucumber/rb_support/rb_language.rb
+++ b/lib/cucumber/rb_support/rb_language.rb
@@ -5,7 +5,6 @@ require 'cucumber/rb_support/rb_step_definition'
 require 'cucumber/rb_support/rb_hook'
 require 'cucumber/rb_support/rb_transform'
 require 'cucumber/rb_support/snippet'
-require 'multi_test'
 
 module Cucumber
   module RbSupport


### PR DESCRIPTION
This is a question in the form of a pull request: is the `require 'multi_test'` in `rb_language.rb` necessary? It already happens in `cucumber.rb` (via [`cucumber/runtime.rb`](https://github.com/cucumber/cucumber/blob/386c7b73523404139a4f35972f78a1261aaaac5c/lib/cucumber/runtime.rb#L4)), so it’s not obvious to me why it should be required here as well.

In an ideal world there’d only be one place where the assertion library is loaded, so I’m just double-checking that this duplication has intentional value.