### PR TITLE
Each time a step_match is invoked it uses the same object as the step argument

### DIFF
--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -12,7 +12,7 @@ module Cucumber
     end
 
     def args
-      @step_arguments.map{|g| g.val.freeze }
+      @step_arguments.map{|g| g.val }
     end
 
     def name
@@ -20,7 +20,7 @@ module Cucumber
     end
 
     def invoke(multiline_arg)
-      all_args = args.dup
+      all_args = deep_clone_args
       multiline_arg.append_to(all_args)
       @step_definition.invoke(all_args)
     end
@@ -79,6 +79,11 @@ module Cucumber
 
     def inspect #:nodoc:
       sprintf("#<%s:0x%x>", self.class, self.object_id)
+    end
+
+    private
+    def deep_clone_args
+      Marshal.load( Marshal.dump( args ) )
     end
   end
 

--- a/spec/cucumber/rb_support/rb_step_definition_spec.rb
+++ b/spec/cucumber/rb_support/rb_step_definition_spec.rb
@@ -18,7 +18,11 @@ module Cucumber
       end
 
       def run_step(text)
-        support_code.step_match(text).invoke(MultilineArgument::None.new)
+        step_match(text).invoke(MultilineArgument::None.new)
+      end
+
+      def step_match(text)
+        support_code.step_match(text)
       end
 
       it "allows calling of other steps" do
@@ -111,14 +115,17 @@ module Cucumber
         }).to raise_error(Cucumber::ArityMismatchError)
       end
 
-      it "does not allow modification of args since it messes up pretty formatting" do
+      it "does not modify the step_match arg when arg is modified in a step" do
         dsl.Given(/My car is (.*)/) do |colour|
           colour << "xxx"
         end
 
+        step_name = "My car is white"
+        step_args = step_match(step_name).args
+
         expect(-> {
-          run_step "My car is white"
-        }).to raise_error(RuntimeError, /can't modify frozen String/i)
+          run_step step_name
+        }).not_to change{ step_args.first }
       end
 
       it "allows puts" do


### PR DESCRIPTION
As reported by [Daniel Esponda on the ML](https://groups.google.com/forum/#!topic/cukes/66-hQThZpMU)

I've created an [example of this for cucumber 2.0](https://github.com/tooky/cucumber-reuse-params).

Cucumber 2.0 is different because the step arguments are frozen, but I do think its unexpected that we get the same `===` object each time a particular step match is invoked. Is it also slightly problematic if users can't modify step arguments because they are frozen?
