### PR TITLE
Localize the Scenario keyword with the --expand option

### DIFF
--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -728,7 +728,7 @@ module Cucumber
           end
 
           def legacy_table_row
-            Ast::ExampleTableRow.new(exception, @status, node.values, node.location)
+            Ast::ExampleTableRow.new(exception, @status, node.values, node.location, node.language)
           end
 
           def exception
@@ -738,6 +738,10 @@ module Cucumber
         end
 
         class HeaderTableRowPrinter < TableRowPrinterBase
+          def legacy_table_row
+            Ast::ExampleTableRow.new(exception, @status, node.values, node.location, Ast::NullLanguage.new)
+          end
+
           def before
             formatter.before_table_row(node)
             self

--- a/lib/cucumber/formatter/legacy_api/ast.rb
+++ b/lib/cucumber/formatter/legacy_api/ast.rb
@@ -18,6 +18,19 @@ module Cucumber
           private :node
         end
 
+        # Null object for HeaderRow language.
+        # ExampleTableRow#keyword is never called on them,
+        # but this will pass silently if it happens anyway
+        class NullLanguage
+          def method_missing(*args, &block)
+            self
+          end
+
+          def to_ary
+            ['']
+          end
+        end
+
         class HookResultCollection
           def initialize
             @children = []
@@ -219,7 +232,7 @@ module Cucumber
           private :values, :line
         end
 
-        ExampleTableRow = Struct.new(:exception, :status, :cells, :location) do
+        ExampleTableRow = Struct.new(:exception, :status, :cells, :location, :language) do
           def name
             '| ' + cells.join(' | ') + ' |'
           end
@@ -235,7 +248,7 @@ module Cucumber
           def keyword
             # This method is only called when used for the scenario name line with
             # the expand option, and on that line the keyword is "Scenario"
-            "Scenario"
+            language.keywords('scenario')[0]
           end
         end
 

--- a/spec/cucumber/formatter/pretty_spec.rb
+++ b/spec/cucumber/formatter/pretty_spec.rb
@@ -581,6 +581,44 @@ OUTPUT
               end
             end
           end
+
+          describe "with a scenario outline in en-lol" do
+            define_feature <<-FEATURE
+          # language: en-lol
+          OH HAI: STUFFING
+
+            MISHUN SRSLY: CUCUMBR
+              I CAN HAZ IN TEH BEGINNIN <BEGINNIN> CUCUMBRZ
+              WEN I EAT <EAT> CUCUMBRZ
+              DEN I HAS <EAT> CUCUMBERZ IN MAH BELLY
+              AN IN TEH END <KTHXBAI> CUCUMBRZ KTHXBAI
+
+              EXAMPLZ:
+               | BEGINNIN | EAT | KTHXBAI |
+               |    3     |  2  |    1    |
+            FEATURE
+
+            it "outputs localized text" do
+              lines = <<-OUTPUT
+          OH HAI: STUFFING
+
+            MISHUN SRSLY: CUCUMBR
+              I CAN HAZ IN TEH BEGINNIN <BEGINNIN> CUCUMBRZ
+              WEN I EAT <EAT> CUCUMBRZ
+              DEN I HAS <EAT> CUCUMBERZ IN MAH BELLY
+              AN IN TEH END <KTHXBAI> CUCUMBRZ KTHXBAI
+              EXAMPLZ:
+                MISHUN: | 3 | 2 | 1 |
+                  I CAN HAZ IN TEH BEGINNIN 3 CUCUMBRZ
+                  WEN I EAT 2 CUCUMBRZ
+                  DEN I HAS 2 CUCUMBERZ IN MAH BELLY
+                  AN IN TEH END 1 CUCUMBRZ KTHXBAI
+              OUTPUT
+              lines.split("\n").each do |line|
+                expect(@out.string).to include line.strip
+              end
+            end
+          end
         end
       end
 


### PR DESCRIPTION
As noted in https://github.com/cucumber/cucumber/issues/762#issuecomment-60314887 the Scenario keyword, in the scenarios expanded from a Scenario Outline with the `--expand` option, is not localized. This PR fixed that. It depend on https://github.com/cucumber/cucumber-ruby-core/commit/e745cc9d6b8a4ae32c99a7ee18624f6c04854528 so that the Cucumber::Core::Ast::ExampleTable::Row knows the language of the feature file.
