### PR TITLE
Acceptance test for customer formatter using new API

### DIFF
--- a/features/docs/extending_cucumber/custom_formatter.feature
+++ b/features/docs/extending_cucumber/custom_formatter.feature
@@ -10,10 +10,19 @@ Feature: Custom Formatter
     And the standard step definitions
 
   Scenario: Use the new API
+    While we transition to a new API, it's neccesary to explicity opt-in by responding to
+    the 'formatter_api_shim' method.
+
+    Legacy methods will be ignored.
+
     Given a file named "features/support/custom_formatter.rb" with:
       """
       module MyCustom
         class Formatter
+          def self.formatter_api_shim
+            Cucumber::Formatter::Shim::None
+          end
+
           def initialize(runtime, io, options)
             @io = io
           end
@@ -21,6 +30,10 @@ Feature: Custom Formatter
           def before_test_case(test_case)
             @io.puts test_case.feature.short_name.upcase
             @io.puts "  #{test_case.source.scenario.name.upcase}"
+          end
+
+          def before_feature(feature)
+            @io.puts "THIS SHOULD NOT APPEAR"
           end
         end
       end
@@ -34,6 +47,8 @@ Feature: Custom Formatter
       """
 
   Scenario: Use the legacy API
+    The legacy API is the default, for now.
+
     Given a file named "features/support/custom_legacy_formatter.rb" with:
       """
       module MyCustom
@@ -49,10 +64,47 @@ Feature: Custom Formatter
           def scenario_name(keyword, name, file_colon_line, source_indent)
             @io.puts "  #{name.upcase}"
           end
+
+          def before_test_case(test_case)
+            @io.puts "THIS SHOULD NOT APPEAR"
+          end
         end
       end
       """
     When I run `cucumber features/f.feature --format MyCustom::LegacyFormatter`
+    Then it should pass with exactly:
+      """
+      I'LL USE MY OWN
+        JUST PRINT ME
+
+      """
+
+  Scenario: Use both
+    You can use a specific shim to opt-in to both APIs at once.
+
+    Given a file named "features/support/custom_mixed_formatter.rb" with:
+      """
+      module MyCustom
+        class MixedFormatter
+          def self.formatter_api_shim
+            Cucumber::Formatter::Shim::Mixed
+          end
+
+          def initialize(runtime, io, options)
+            @io = io
+          end
+
+          def before_test_case(test_case)
+            @io.puts test_case.feature.short_name.upcase
+          end
+
+          def scenario_name(keyword, name, file_colon_line, source_indent)
+            @io.puts "  #{name.upcase}"
+          end
+        end
+      end
+      """
+    When I run `cucumber features/f.feature --format MyCustom::MixedFormatter`
     Then it should pass with exactly:
       """
       I'LL USE MY OWN

--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -165,7 +165,7 @@ module Cucumber
         @options[:paths]
       end
 
-      def formatter_factories
+      def map_formatter_factories
         @options[:formats].map do |format_and_out|
           format = format_and_out[0]
           path_or_io = format_and_out[1]

--- a/lib/cucumber/formatter/fanout.rb
+++ b/lib/cucumber/formatter/fanout.rb
@@ -11,10 +11,14 @@ module Cucumber
         @recipients = recipients
       end
 
-      def method_missing(message, *args)
+      def send(message, *args)
         recipients.each do |recipient|
           recipient.send(message, *args) if recipient.respond_to?(message)
         end
+      end
+
+      def method_missing(message, *args)
+        send(message, *args)
       end
 
       def respond_to_missing?(name, include_private = false)

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -12,29 +12,22 @@ module Cucumber
         extend Forwardable
 
         def_delegators :formatter,
-          :ask
+          :ask, :embed
 
         def before_test_case(test_case)
-          formatter.before_test_case test_case
           printer.before_test_case test_case
         end
 
         def before_test_step(test_step)
-          formatter.before_test_step test_step
+          p test_step
           printer.before_test_step test_step
         end
 
         def after_test_step(test_step, result)
-          formatter.after_test_test test_step, result
           printer.after_test_step test_step, result
         end
 
-        def embed(*args)
-          formatter.embed *args
-        end
-
         def after_test_case(test_case, result)
-          formatter.after_test_case test_case, result
           record_test_case_result test_case, result
           printer.after_test_case test_case, result
         end

--- a/lib/cucumber/formatter/shim.rb
+++ b/lib/cucumber/formatter/shim.rb
@@ -1,0 +1,38 @@
+require 'cucumber/formatter/fanout'
+
+module Cucumber
+  module Formatter
+    module Shim
+
+      def self.for(factory)
+        return Legacy unless factory.respond_to?(:formatter_api_shim)
+        factory.formatter_api_shim
+      end
+
+      class Legacy
+        def self.wrap(formatter, results, support_code, configuration)
+          LegacyApi::Adapter.new(
+            Formatter::IgnoreMissingMessages.new(formatter),
+            results, support_code, configuration)
+        end
+      end
+
+      class Mixed
+        def self.wrap(formatter, results, support_code, configuration)
+          Fanout.new(
+            [
+              formatter,
+              Legacy.wrap(formatter, results, support_code, configuration)
+            ]
+          )
+        end
+      end
+
+      class None
+        def self.wrap(formatter, results, support_code, configuration)
+          formatter
+        end
+      end
+    end
+  end
+end

--- a/spec/cucumber/formatter/fanout_spec.rb
+++ b/spec/cucumber/formatter/fanout_spec.rb
@@ -1,0 +1,34 @@
+require 'cucumber/formatter/fanout'
+
+module Cucumber::Formatter
+  describe Fanout do
+    class DoesRespond
+      def baz
+        @called = true
+      end
+
+      def called?
+        @called
+      end
+    end
+
+    class DoesNotRespond
+    end
+
+    it "sends out messages to all recipients who can receive that message" do
+      foo = DoesRespond.new
+      bar = DoesNotRespond.new
+      fanout = Fanout.new([foo, bar])
+      fanout.baz
+      expect(foo).to be_called
+    end
+
+    it "works with send" do
+      foo = DoesRespond.new
+      bar = DoesNotRespond.new
+      fanout = Fanout.new([foo, bar])
+      fanout.send :baz
+      expect(foo).to be_called
+    end
+  end
+end

--- a/spec/cucumber/formatter/pretty_spec.rb
+++ b/spec/cucumber/formatter/pretty_spec.rb
@@ -267,16 +267,12 @@ OUTPUT
             end
           end
 
-          describe "with output from hooks" do
+          describe "scenario with output from hooks" do
             define_feature <<-FEATURE
           Feature:
+
             Scenario:
               Given this step passes
-            Scenario Outline:
-              Given this step <status>
-              Examples:
-              | status |
-              | passes  |
             FEATURE
 
             define_steps do
@@ -293,7 +289,7 @@ OUTPUT
             end
 
             it "displays hook output appropriately " do
-              expect( @out.string ).to include <<OUTPUT
+              expect( @out.string.gsub(/0m0\.\d+s/,'') ).to eq <<OUTPUT
 Feature: 
 
   Scenario: 
@@ -302,6 +298,41 @@ Feature:
       AfterStep hook
       After hook
 
+1 scenario (1 passed)
+1 step (1 passed)
+OUTPUT
+            end
+          end
+
+          describe "scenario outline with output from hooks" do
+            define_feature <<-FEATURE
+          Feature:
+
+            Scenario Outline:
+              Given this step <status>
+
+              Examples:
+                | status |
+                | passes |
+            FEATURE
+
+            define_steps do
+              Before do
+                puts "Before hook"
+              end
+              AfterStep do
+                puts "AfterStep hook"
+              end
+              After do
+                puts "After hook"
+              end
+              Given(/^this step passes$/) {}
+            end
+
+            it "displays hook output appropriately " do
+              expect( @out.string.gsub(/0m0\.\d+s/,'') ).to eq <<OUTPUT
+Feature: 
+
   Scenario Outline: 
     Given this step <status>
 
@@ -309,8 +340,8 @@ Feature:
       | status |
       | passes |  Before hook, AfterStep hook, After hook
 
-2 scenarios (2 passed)
-2 steps (2 passed)
+1 scenario (1 passed)
+1 step (1 passed)
 OUTPUT
             end
           end

--- a/spec/cucumber/formatter/spec_helper.rb
+++ b/spec/cucumber/formatter/spec_helper.rb
@@ -30,11 +30,8 @@ module Cucumber
 
       require 'cucumber/formatter/legacy_api/adapter'
       def report
-        @report ||= LegacyApi::Adapter.new(
-          Fanout.new([@formatter]),
-          runtime.results,
-          runtime.support_code,
-          runtime.configuration)
+        @report ||= Formatter::Shim.for(@formatter.class).
+          wrap(@formatter, runtime.results, runtime.support_code, runtime.configuration)
       end
 
       require 'cucumber/core/gherkin/document'


### PR DESCRIPTION
Requires https://github.com/cucumber/cucumber-ruby-core/pull/76

I'm not keen on the existing constructor arguments, particularly the runtime, and also the assumption of an IO object. Do we try to break away from this now, or leave it for a later release? I'm inclined toward later.
