### PR TITLE
Rewrite the Json Formatter to use the new formatter api 

### DIFF
--- a/features/docs/formatters/json_formatter.feature
+++ b/features/docs/formatters/json_formatter.feature
@@ -132,6 +132,10 @@ Feature: JSON output formatter
               "description": "",
               "tags": [
                 {
+                  "name": "@a",
+                  "line": 1
+                },
+                {
                   "name": "@b",
                   "line": 4
                 }
@@ -159,6 +163,10 @@ Feature: JSON output formatter
               "line": 9,
               "description": "",
               "tags": [
+                {
+                  "name": "@a",
+                  "line": 1
+                },
                 {
                   "name": "@c",
                   "line": 8
@@ -215,6 +223,10 @@ Feature: JSON output formatter
               "description": "",
               "tags": [
                 {
+                  "name": "@a",
+                  "line": 1
+                },
+                {
                   "name": "@b",
                   "line": 4
                 }
@@ -243,6 +255,10 @@ Feature: JSON output formatter
               "description": "",
               "tags": [
                 {
+                  "name": "@a",
+                  "line": 1
+                },
+                {
                   "name": "@c",
                   "line": 8
                 }
@@ -270,7 +286,7 @@ Feature: JSON output formatter
 
       """
 
-  @spawn @wip-jruby
+  @spawn
   Scenario: DocString
     Given a file named "features/doc_string.feature" with:
       """
@@ -285,7 +301,7 @@ Feature: JSON output formatter
     And a file named "features/step_definitions/steps.rb" with:
       """
       Then /I should fail with/ do |s|
-        raise s
+        raise RuntimeError, s
       end
       """
     When I run `cucumber --format json features/doc_string.feature`
@@ -333,7 +349,7 @@ Feature: JSON output formatter
       ]
       """
 
-  @spawn 
+  @spawn
   Scenario: embedding screenshot
     When I run `cucumber -b --format json features/embed.feature`
     Then it should pass with JSON:
@@ -381,6 +397,7 @@ Feature: JSON output formatter
 
     """
 
+  @spawn
   Scenario: scenario outline
     When I run `cucumber --format json features/outline.feature`
     Then it should fail with JSON:
@@ -395,75 +412,69 @@ Feature: JSON output formatter
         "description": "",
         "elements": [
           {
-            "id": "an-outline-feature;outline",
+            "id": "an-outline-feature;outline;examples1;2",
             "keyword": "Scenario Outline",
             "name": "outline",
-            "line": 3,
             "description": "",
-            "type": "scenario_outline",
+            "line": 8,
+            "type": "scenario",
             "steps": [
               {
                 "keyword": "Given ",
-                "name": "this step <status>",
-                "line": 4,
+                "name": "this step passes",
+                "line": 8,
                 "match": {
-                  "location": "features/outline.feature:4"
+                  "location": "features/step_definitions/steps.rb:1"
+                },
+                "result": {
+                  "status": "passed",
+                  "duration": 1
                 }
               }
-            ],
-            "examples": [
+            ]
+          },
+          {
+            "id": "an-outline-feature;outline;examples1;3",
+            "keyword": "Scenario Outline",
+            "name": "outline",
+            "description": "",
+            "line": 9,
+            "type": "scenario",
+            "steps": [
               {
-                "keyword": "Examples", 
-                "name": "examples1", 
-                "line": 6, 
-                "description": "", 
-                "id": "an-outline-feature;outline;examples1", 
-                "rows": [
-                  {
-                    "cells": [
-                      "status"
-                     ], 
-                     "line": 7, 
-                     "id": "an-outline-feature;outline;examples1;1"
-                  }, 
-                  {
-                    "cells": [
-                      "passes"
-                    ], 
-                    "line": 8, 
-                    "id": "an-outline-feature;outline;examples1;2"
-                  }, 
-                  {
-                    "cells": [
-                      "fails"
-                    ], 
-                    "line": 9, 
-                    "id": "an-outline-feature;outline;examples1;3"
-                  }
-                ]
-              },
+                "keyword": "Given ",
+                "name": "this step fails",
+                "line": 9,
+                "match": {
+                  "location": "features/step_definitions/steps.rb:4"
+                },
+                "result": {
+                  "status": "failed",
+                  "error_message": " (RuntimeError)\n./features/step_definitions/steps.rb:4:in `/^this step fails$/'\nfeatures/outline.feature:9:in `Given this step fails'\nfeatures/outline.feature:4:in `Given this step <status>'",
+                  "duration": 1
+                }
+              }
+            ]
+          },
+          {
+            "id": "an-outline-feature;outline;examples2;2",
+            "keyword": "Scenario Outline",
+            "name": "outline",
+            "description": "",
+            "line": 13,
+            "type": "scenario",
+            "steps": [
               {
-                "keyword": "Examples", 
-                "name": "examples2", 
-                "line": 11, 
-                "description": "", 
-                "id": "an-outline-feature;outline;examples2", 
-                "rows": [
-                  {
-                    "cells": [
-                      "status"
-                     ], 
-                     "line": 12, 
-                     "id": "an-outline-feature;outline;examples2;1"
-                  }, 
-                  {
-                    "cells": [
-                      "passes"
-                    ], 
-                    "line": 13, 
-                    "id": "an-outline-feature;outline;examples2;2"
-                  }
-                ]
+                "keyword": "Given ",
+                "name": "this step passes",
+                "line": 13,
+                "match": {
+                  "location": "features/step_definitions/steps.rb:1"
+                },
+                "result": {
+                  "status": "passed",
+                  "duration": 1
+                }
               }
             ]
           }
@@ -735,7 +746,7 @@ Feature: JSON output formatter
         puts "Before hook 2"
         embed "src", "mime_type", "label"
       end
- 
+
       AfterStep do
         puts "AfterStep hook 1"
         embed "src", "mime_type", "label"

--- a/features/lib/support/normalise_output.rb
+++ b/features/lib/support/normalise_output.rb
@@ -19,15 +19,32 @@ module NormaliseArubaOutput
       elements = feature.fetch('elements') { [] }
       elements.each do |scenario|
         scenario['steps'].each do |step|
-          if step['result']
-            expect(step['result']['duration']).to be >= 0
-            step['result']['duration'] = 1
+          ['steps', 'before', 'after'].each do |type|
+            if scenario[type]
+              scenario[type].each do |step_or_hook|
+                normalise_json_step_or_hook(step_or_hook)
+                if step_or_hook['after']
+                  step_or_hook['after'].each do |hook|
+                    normalise_json_step_or_hook(hook)
+                  end
+                end
+              end
+            end
           end
         end
       end
     end
   end
+
+  def normalise_json_step_or_hook(step_or_hook)
+    if step_or_hook['result']
+      if step_or_hook['result']['duration']
+        expect(step_or_hook['result']['duration']).to be >= 0
+        step_or_hook['result']['duration'] = 1
+      end
+    end
+  end
+
 end
 
 World(NormaliseArubaOutput)
-

--- a/lib/cucumber/filters/prepare_world.rb
+++ b/lib/cucumber/filters/prepare_world.rb
@@ -24,9 +24,8 @@ module Cucumber
           end
           around_hooks = [init_scenario] + @original_test_case.around_hooks
 
-          default_hook = Cucumber::Hooks.before_hook(@original_test_case.source) do
-            #no op - legacy format adapter expects a before hooks
-          end
+          empty_hook = proc {} #no op - legacy format adapter expects a before hooks
+          default_hook = Cucumber::Hooks.before_hook(@original_test_case.source, Cucumber::Hooks.location(empty_hook), &empty_hook)
           steps = [default_hook] + @original_test_case.test_steps
 
           @original_test_case.with_around_hooks(around_hooks).with_steps(steps)

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -1,19 +1,300 @@
-require 'cucumber/formatter/gherkin_formatter_adapter'
+require 'multi_json'
+require 'base64'
 require 'cucumber/formatter/io'
-require 'gherkin/formatter/argument'
-require 'gherkin/formatter/json_formatter'
 
 module Cucumber
   module Formatter
     # The formatter used for <tt>--format json</tt>
-    class Json < GherkinFormatterAdapter
+    class Json
       include Io
 
-      def initialize(runtime, io, options)
-        @io = ensure_io(io, "json")
-        super(Gherkin::Formatter::JSONFormatter.new(@io), false, options)
+      def initialize(runtime, io, _options)
+        @runtime = runtime
+        @io = ensure_io(io, 'json')
+        @feature_hashes = []
       end
+
+      def before_test_case(test_case)
+        builder = Builder.new(test_case)
+        unless same_feature_as_previous_test_case?(test_case.feature)
+          @feature_hash = builder.feature_hash
+          @feature_hashes << @feature_hash
+        end
+        @test_case_hash = builder.test_case_hash
+        if builder.background?
+          feature_elements << builder.background_hash
+          @element_hash = builder.background_hash
+        else
+          feature_elements << @test_case_hash
+          @element_hash = @test_case_hash
+        end
+      end
+
+      def before_test_step(test_step)
+        return if internal_hook?(test_step)
+        if hook?(test_step)
+          @step_or_hook_hash = {}
+          hooks_of_type(test_step) << @step_or_hook_hash
+          return
+        end
+        if first_step_after_background?(test_step)
+          feature_elements << @test_case_hash
+          @element_hash = @test_case_hash
+        end
+        @step_or_hook_hash = create_step_hash(test_step.source.last)
+        steps << @step_or_hook_hash
+        @step_hash = @step_or_hook_hash
+      end
+
+      def after_test_step(test_step, result)
+        return if internal_hook?(test_step)
+        add_match_and_result(test_step, result)
+      end
+
+      def done
+        @io.write(MultiJson.dump(@feature_hashes, pretty: true))
+      end
+
+      def puts(message)
+        test_step_output << message
+      end
+
+      def embed(src, mime_type, _label)
+        if File.file?(src)
+          content = File.open(src, 'rb') { |f| f.read }
+          data = encode64(content)
+        else
+          if mime_type =~ /;base64$/
+            mime_type = mime_type[0..-8]
+            data = src
+          else
+            data = encode64(src)
+          end
+        end
+        test_step_embeddings << { mime_type: mime_type, data: data }
+      end
+
+      private
+
+      def same_feature_as_previous_test_case?(feature)
+        current_feature[:uri] == feature.file && current_feature[:line] == feature.location.line
+      end
+
+      def first_step_after_background?(test_step)
+        test_step.source[1].name != @element_hash[:name]
+      end
+
+      def internal_hook?(test_step)
+        test_step.source.last.location.file.include?('lib/cucumber/')
+      end
+
+      def hook?(test_step)
+        ['Before hook', 'After hook', 'AfterStep hook'].include? test_step.source.last.name
+      end
+
+      def current_feature
+        @feature_hash ||= {}
+      end
+
+      def feature_elements
+        @feature_hash[:elements] ||= []
+      end
+
+      def steps
+        @element_hash[:steps] ||= []
+      end
+
+      def hooks_of_type(test_step)
+        name = test_step.source.last.name
+        if name == 'Before hook'
+          return before_hooks
+        elsif name == 'After hook'
+          return after_hooks
+        elsif name == 'AfterStep hook'
+          return after_step_hooks
+        else
+          fail 'Unkown hook type ' + name
+        end
+      end
+
+      def before_hooks
+        @element_hash[:before] ||= []
+      end
+
+      def after_hooks
+        @element_hash[:after] ||= []
+      end
+
+      def after_step_hooks
+        @step_hash[:after] ||= []
+      end
+
+      def test_step_output
+        @step_or_hook_hash[:output] ||= []
+      end
+
+      def test_step_embeddings
+        @step_or_hook_hash[:embeddings] ||= []
+      end
+
+      def create_step_hash(step_source)
+        step_hash = {
+          keyword: step_source.keyword,
+          name: step_source.name,
+          line: step_source.location.line
+        }
+        step_hash[:comments] = Formatter.create_comments_array(step_source.comments) unless step_source.comments.empty?
+        step_hash[:doc_string] = create_doc_string_hash(step_source.multiline_arg) if step_source.multiline_arg.doc_string?
+        step_hash
+      end
+
+      def create_doc_string_hash(doc_string)
+        {
+          value: doc_string.content,
+          content_type: doc_string.content_type,
+          line: doc_string.location.line
+        }
+      end
+
+      def add_match_and_result(test_step, result)
+        @step_or_hook_hash[:match] = create_match_hash(test_step, result)
+        @step_or_hook_hash[:result] = create_result_hash(result)
+      end
+
+      def create_match_hash(test_step, result)
+        { location: test_step.action_location }
+      end
+
+      def create_result_hash(result)
+        result_hash = {
+          status: result.to_sym
+        }
+        result_hash[:error_message] = create_error_message(result) if result.failed? || result.pending?
+        result.duration.tap { |duration| result_hash[:duration] = duration.nanoseconds }
+        result_hash
+      end
+
+      def create_error_message(result)
+        message_element = result.failed? ? result.exception : result
+        message = "#{message_element.message} (#{message_element.class})"
+        ([message] + message_element.backtrace).join("\n")
+      end
+
+      def encode64(data)
+        # strip newlines from the encoded data
+        Base64.encode64(data).gsub(/\n/, '')
+      end
+
+      class Builder
+        attr_reader :feature_hash, :background_hash, :test_case_hash
+
+        def initialize(test_case)
+          @background_hash = nil
+          test_case.describe_source_to(self)
+          test_case.feature.background.describe_to(self)
+        end
+
+        def background?
+          @background_hash != nil
+        end
+
+        def feature(feature)
+          @feature_hash = {
+            uri: feature.file,
+            id: create_id(feature),
+            keyword: feature.keyword,
+            name: feature.name,
+            description: feature.description,
+            line: feature.location.line
+          }
+          unless feature.tags.empty?
+            @feature_hash[:tags] = create_tags_array(feature.tags)
+            if @test_case_hash[:tags]
+              @test_case_hash[:tags] = @feature_hash[:tags] + @test_case_hash[:tags]
+            else
+              @test_case_hash[:tags] = @feature_hash[:tags]
+            end
+          end
+          @feature_hash[:comments] = Formatter.create_comments_array(feature.comments) unless feature.comments.empty?
+          @test_case_hash[:id].insert(0, @feature_hash[:id] + ';')
+        end
+
+        def background(background)
+          @background_hash = {
+            keyword: background.keyword,
+            name: background.name,
+            description: background.description,
+            line: background.location.line,
+            type: 'background'
+          }
+          @background_hash[:comments] = Formatter.create_comments_array(background.comments) unless background.comments.empty?
+        end
+
+        def scenario(scenario)
+          @test_case_hash = {
+            id: create_id(scenario),
+            keyword: scenario.keyword,
+            name: scenario.name,
+            description: scenario.description,
+            line: scenario.location.line,
+            type: 'scenario'
+          }
+          @test_case_hash[:tags] = create_tags_array(scenario.tags) unless scenario.tags.empty?
+          @test_case_hash[:comments] = Formatter.create_comments_array(scenario.comments) unless scenario.comments.empty?
+        end
+
+        def scenario_outline(scenario)
+          @test_case_hash = {
+            id: create_id(scenario) + ';' + @example_id,
+            keyword: scenario.keyword,
+            name: scenario.name,
+            description: scenario.description,
+            line: @row.location.line,
+            type: 'scenario'
+          }
+          tags = []
+          tags += create_tags_array(scenario.tags) unless scenario.tags.empty?
+          tags += @examples_table_tags if @examples_table_tags
+          @test_case_hash[:tags] = tags unless tags.empty?
+          comments = []
+          comments += Formatter.create_comments_array(scenario.comments) unless scenario.comments.empty?
+          comments += @examples_table_comments if @examples_table_comments
+          comments += @row_comments if @row_comments
+          @test_case_hash[:comments] =  comments unless comments.empty?
+        end
+
+        def examples_table(examples_table)
+          # the json file have traditionally used the header row as row 1,
+          # wheras cucumber-ruby-core used the first example row as row 1.
+          @example_id = create_id(examples_table) + ";#{@row.number + 1}"
+
+          @examples_table_tags = create_tags_array(examples_table.tags) unless examples_table.tags.empty?
+          @examples_table_comments = Formatter.create_comments_array(examples_table.comments) unless examples_table.comments.empty?
+        end
+
+        def examples_table_row(row)
+          @row = row
+          @row_comments = Formatter.create_comments_array(row.comments) unless row.comments.empty?
+        end
+
+        private
+
+        def create_id(element)
+          element.name.downcase.gsub(/ /, '-')
+        end
+
+        def create_tags_array(tags)
+          tags_array = []
+          tags.each { |tag| tags_array << { name: tag.name, line: tag.location.line } }
+          tags_array
+        end
+      end
+    end
+
+    def self.create_comments_array(comments)
+      comments_array = []
+      comments.each { |comment| comments_array << { value: comment.to_s.strip, line: comment.location.line } }
+      comments_array
     end
   end
 end
-

--- a/lib/cucumber/rb_support/rb_hook.rb
+++ b/lib/cucumber/rb_support/rb_hook.rb
@@ -10,6 +10,10 @@ module Cucumber
         @proc = proc
       end
 
+      def source_location
+        @proc.source_location
+      end
+
       def invoke(pseudo_method, arguments, &block)
         @rb_language.current_world.cucumber_instance_exec(false, pseudo_method, *[arguments, block].compact, &@proc)
       end

--- a/lib/cucumber/runtime/after_hooks.rb
+++ b/lib/cucumber/runtime/after_hooks.rb
@@ -1,8 +1,9 @@
 module Cucumber
   class Runtime
     class AfterHooks
-      def initialize(action_blocks)
-        @action_blocks = action_blocks
+      def initialize(hooks, scenario)
+        @hooks = hooks
+        @scenario = scenario
       end
 
       def apply_to(test_case)
@@ -14,11 +15,11 @@ module Cucumber
       private
 
       def after_hooks(source)
-        @action_blocks.map do |action_block|
-          Hooks.after_hook(source, &action_block)
-        end
+        @hooks.map do |hook|
+          action = ->(result) { hook.invoke('After', @scenario.with_result(result)) }
+          Hooks.after_hook(source, Hooks.location(hook), &action)
+        end          
       end
     end
   end
 end
-

--- a/lib/cucumber/runtime/before_hooks.rb
+++ b/lib/cucumber/runtime/before_hooks.rb
@@ -1,8 +1,11 @@
+require 'cucumber/hooks'
+
 module Cucumber
   class Runtime
     class BeforeHooks
-      def initialize(action_blocks)
-        @action_blocks = action_blocks
+      def initialize(hooks, scenario)
+        @hooks = hooks
+        @scenario = scenario
       end
 
       def apply_to(test_case)
@@ -14,8 +17,9 @@ module Cucumber
       private
 
       def before_hooks(source)
-        @action_blocks.map do |action_block|
-          Hooks.before_hook(source, &action_block)
+        @hooks.map do |hook|
+          action_block = ->(result) { hook.invoke('Before', @scenario.with_result(result)) }
+          Hooks.before_hook(source, Hooks.location(hook), &action_block)
         end
       end
     end

--- a/lib/cucumber/runtime/step_hooks.rb
+++ b/lib/cucumber/runtime/step_hooks.rb
@@ -1,8 +1,8 @@
 module Cucumber
   class Runtime
     class StepHooks
-      def initialize(after)
-        @after = after
+      def initialize(hooks)
+        @hooks = hooks
       end
 
       def apply(test_steps)
@@ -13,8 +13,9 @@ module Cucumber
 
       private
       def after_step_hooks(test_step)
-        @after.map do |action_block|
-          Hooks.after_step_hook(test_step.source, &action_block)
+        @hooks.map do |hook|
+          action = ->(*args) { hook.invoke('AfterStep', args) }
+          Hooks.after_step_hook(test_step.source, Hooks.location(hook), &action)
         end
       end
     end

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -148,31 +148,22 @@ module Cucumber
       def find_after_step_hooks(test_case)
         ruby = load_programming_language('rb')
         scenario = RunningTestCase.new(test_case)
-
-        action_blocks = ruby.hooks_for(:after_step, scenario).map do |hook|
-          ->(*args) { hook.invoke('AfterStep', args) }
-        end
-        StepHooks.new action_blocks
+        hooks = ruby.hooks_for(:after_step, scenario)
+        StepHooks.new hooks
       end
 
       def apply_before_hooks(test_case)
         ruby = load_programming_language('rb')
         scenario = RunningTestCase.new(test_case)
-
-        action_blocks = ruby.hooks_for(:before, scenario).map do |hook|
-          ->(result) { hook.invoke('Before', scenario.with_result(result)) }
-        end
-        BeforeHooks.new(action_blocks).apply_to(test_case)
+        hooks = ruby.hooks_for(:before, scenario)
+        BeforeHooks.new(hooks, scenario).apply_to(test_case)
       end
 
       def apply_after_hooks(test_case)
         ruby = load_programming_language('rb')
         scenario = RunningTestCase.new(test_case)
-
-        action_blocks = ruby.hooks_for(:after, scenario).map do |hook|
-          ->(result) { hook.invoke('After', scenario.with_result(result)) }
-        end
-        AfterHooks.new(action_blocks).apply_to(test_case)
+        hooks = ruby.hooks_for(:after, scenario)
+        AfterHooks.new(hooks, scenario).apply_to(test_case)
       end
 
       def find_around_hooks(test_case)

--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -22,7 +22,7 @@ module Cucumber
     end
 
     def activate(test_step)
-      test_step.with_action do
+      test_step.with_action(@step_definition.file_colon_line) do
         invoke(MultilineArgument.from_core(test_step.source.last.multiline_arg))
       end
     end

--- a/spec/cucumber/formatter/json_spec.rb
+++ b/spec/cucumber/formatter/json_spec.rb
@@ -1,0 +1,757 @@
+require 'spec_helper'
+require 'cucumber/formatter/spec_helper'
+require 'cucumber/formatter/json'
+require 'cucumber/cli/options'
+require 'multi_json'
+
+module Cucumber
+  module Formatter
+    describe Json do
+      extend SpecHelperDsl
+      include SpecHelper
+
+      context "Given a single feature" do
+        before(:each) do
+          @out = StringIO.new
+          @formatter = Json.new(runtime, @out, {})
+          run_defined_feature
+        end
+
+        describe "with a scenario with no steps" do
+          define_feature <<-FEATURE
+          Feature: Banana party
+
+            Scenario: Monkey eats bananas
+            FEATURE
+
+          it "outputs the json data" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 1,
+                "description": "",
+                "elements":
+                 [{"id": "banana-party;monkey-eats-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats bananas",
+                   "line": 3,
+                   "description": "",
+                   "type": "scenario"}]}]})
+          end
+        end
+
+        describe "with a scenario with an undefined step" do
+          define_feature <<-FEATURE
+          Feature: Banana party
+
+            Scenario: Monkey eats bananas
+              Given there are bananas
+            FEATURE
+
+          it "outputs the json data" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 1,
+                "description": "",
+                "elements":
+                 [{"id": "banana-party;monkey-eats-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats bananas",
+                   "line": 3,
+                   "description": "",
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 4,
+                      "match": {"location": "spec.feature:4"},
+                      "result": {"status": "undefined"}}]}]}]})
+          end
+        end
+
+        describe "with a scenario with a passed step" do
+          define_feature <<-FEATURE
+          Feature: Banana party
+
+            Scenario: Monkey eats bananas
+              Given there are bananas
+            FEATURE
+
+          define_steps do
+            Given(/^there are bananas$/) {}
+          end
+
+          it "outputs the json data" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 1,
+                "description": "",
+                "elements":
+                 [{"id": "banana-party;monkey-eats-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats bananas",
+                   "line": 3,
+                   "description": "",
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 4,
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:86"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}]}]}]})
+          end
+        end
+
+        describe "with a scenario with a failed step" do
+          define_feature <<-FEATURE
+          Feature: Banana party
+
+            Scenario: Monkey eats bananas
+              Given there are bananas
+            FEATURE
+
+          define_steps do
+            Given(/^there are bananas$/) { raise "no bananas" }
+          end
+
+          it "outputs the json data" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 1,
+                "description": "",
+                "elements":
+                 [{"id": "banana-party;monkey-eats-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats bananas",
+                   "line": 3,
+                   "description": "",
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 4,
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:123"},
+                      "result": {"status": "failed",
+                                 "error_message": "no bananas (RuntimeError)\\n./spec/cucumber/formatter/json_spec.rb:123:in `/^there are bananas$/'\\nspec.feature:4:in `Given there are bananas'",
+                                 "duration": 1}}]}]}]})
+          end
+        end
+
+        describe "with a scenario with a pending step" do
+          define_feature <<-FEATURE
+          Feature: Banana party
+
+            Scenario: Monkey eats bananas
+              Given there are bananas
+            FEATURE
+
+          define_steps do
+            Given(/^there are bananas$/) { pending }
+          end
+
+          it "outputs the json data" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 1,
+                "description": "",
+                "elements":
+                 [{"id": "banana-party;monkey-eats-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats bananas",
+                   "line": 3,
+                   "description": "",
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 4,
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:161"},
+                      "result": {"status": "pending",
+                                 "error_message": "TODO (Cucumber::Pending)\\n./spec/cucumber/formatter/json_spec.rb:161:in `/^there are bananas$/'\\nspec.feature:4:in `Given there are bananas'",
+                                 "duration": 1}}]}]}]})
+          end
+        end
+
+        describe "with a scenario outline with one example" do
+          define_feature <<-FEATURE
+          Feature: Banana party
+
+            Scenario Outline: Monkey eats bananas
+              Given there are <fruit>
+
+              Examples: Fruit Table
+              |  fruit  |
+              | bananas |
+            FEATURE
+
+          define_steps do
+            Given(/^there are bananas$/) {}
+          end
+
+          it "outputs the json data" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 1,
+                "description": "",
+                "elements":
+                 [{"id": "banana-party;monkey-eats-bananas;fruit-table;2",
+                   "keyword": "Scenario Outline",
+                   "name": "Monkey eats bananas",
+                   "line": 8,
+                   "description": "",
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 8,
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:203"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}]}]}]})
+          end
+        end
+
+        describe "with tags in the feature file" do
+          define_feature <<-FEATURE
+          @f
+          Feature: Banana party
+
+            @s
+            Scenario: Monkey eats bananas
+              Given there are bananas
+
+            @so
+            Scenario Outline: Monkey eats bananas
+              Given there are <fruit>
+
+              @ex
+              Examples: Fruit Table
+              |  fruit  |
+              | bananas |
+            FEATURE
+
+          define_steps do
+            Given(/^there are bananas$/) {}
+          end
+
+          it "the tags are included in the json data" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 2,
+                "description": "",
+                "tags": [{"name": "@f",
+                          "line": 1}],
+                "elements":
+                 [{"id": "banana-party;monkey-eats-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats bananas",
+                   "line": 5,
+                   "description": "",
+                   "tags": [{"name": "@f",
+                             "line": 1},
+                            {"name": "@s",
+                             "line": 4}],
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 6,
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:251"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}]},
+                   {"id": "banana-party;monkey-eats-bananas;fruit-table;2",
+                   "keyword": "Scenario Outline",
+                   "name": "Monkey eats bananas",
+                   "line": 15,
+                   "description": "",
+                   "tags": [{"name": "@f",
+                             "line": 1},
+                            {"name": "@so",
+                             "line": 8},
+                            {"name": "@ex",
+                             "line": 12}],
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 15,
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:251"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}]}]}]})
+          end
+        end
+
+        describe "with comments in the feature file" do
+          define_feature <<-FEATURE
+          #feature comment
+          Feature: Banana party
+
+            #background comment
+            Background: There are bananas
+              Given there are bananas
+
+            #scenario comment
+            Scenario: Monkey eats bananas
+              #step comment1
+              Then the monkey eats bananas
+
+            #scenario outline comment
+            Scenario Outline: Monkey eats bananas
+              #step comment2
+              Then the monkey eats <fruit>
+
+              #examples table comment
+              Examples: Fruit Table
+              |  fruit  |
+              #examples table row comment
+              | bananas |
+            FEATURE
+
+          define_steps do
+            Given(/^there are bananas$/) {}
+            Then(/^the monkey eats bananas$/) {}
+          end
+
+          it "the comments are included in the json data" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 2,
+                "description": "",
+                "comments": [{"value": "#feature comment",
+                              "line": 1}],
+                "elements":
+                 [{"keyword": "Background",
+                   "name": "There are bananas",
+                   "line": 5,
+                   "description": "",
+                   "comments": [{"value": "#background comment",
+                                 "line": 4}],
+                   "type": "background",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 6,
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:331"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}]},
+                  {"id": "banana-party;monkey-eats-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats bananas",
+                   "line": 9,
+                   "description": "",
+                   "comments": [{"value": "#scenario comment",
+                                 "line": 8}],
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Then ",
+                      "name": "the monkey eats bananas",
+                      "line": 11,
+                      "comments": [{"value": "#step comment1",
+                                    "line": 10}],
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:332"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}]},
+                  {"keyword": "Background",
+                   "name": "There are bananas",
+                   "line": 5,
+                   "description": "",
+                   "comments": [{"value": "#background comment",
+                                 "line": 4}],
+                   "type": "background",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 6,
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:331"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}]},
+                   {"id": "banana-party;monkey-eats-bananas;fruit-table;2",
+                   "keyword": "Scenario Outline",
+                   "name": "Monkey eats bananas",
+                   "line": 22,
+                   "description": "",
+                   "comments": [{"value": "#scenario outline comment",
+                                 "line": 13},
+                                {"value": "#examples table comment",
+                                 "line": 18},
+                                {"value": "#examples table row comment",
+                                 "line": 21}],
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Then ",
+                      "name": "the monkey eats bananas",
+                      "line": 22,
+                      "comments": [{"value": "#step comment2",
+                                    "line": 15}],
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:332"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}]}]}]})
+          end
+        end
+
+        describe "with a scenario with a step with a doc string" do
+          define_feature <<-FEATURE
+          Feature: Banana party
+
+            Scenario: Monkey eats bananas
+              Given there are bananas
+                """
+                the doc string
+                """
+            FEATURE
+
+          define_steps do
+            Given(/^there are bananas$/) { |s| s }
+          end
+
+          it "includes the doc string in the json data" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 1,
+                "description": "",
+                "elements":
+                 [{"id": "banana-party;monkey-eats-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats bananas",
+                   "line": 3,
+                   "description": "",
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 4,
+                      "doc_string": {"value": "the doc string",
+                                     "content_type": "",
+                                     "line": 5},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:427"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}]}]}]})
+          end
+        end
+
+        describe "with a scenario with a step that use puts" do
+          define_feature <<-FEATURE
+          Feature: Banana party
+
+            Scenario: Monkey eats bananas
+              Given there are bananas
+            FEATURE
+
+          define_steps do
+            Given(/^there are bananas$/) { puts "from step" }
+          end
+
+          it "includes the output from the step in the json data" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 1,
+                "description": "",
+                "elements":
+                 [{"id": "banana-party;monkey-eats-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats bananas",
+                   "line": 3,
+                   "description": "",
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 4,
+                      "output": ["from step"],
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:467"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}]}]}]})
+          end
+        end
+
+        describe "with a background" do
+          define_feature <<-FEATURE
+          Feature: Banana party
+
+            Background: There are bananas
+              Given there are bananas
+
+            Scenario: Monkey eats bananas
+              Then the monkey eats bananas
+
+            Scenario: Monkey eats more bananas
+              Then the monkey eats more bananas
+            FEATURE
+
+          it "includes the background in the json data each time it is executed" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 1,
+                "description": "",
+                "elements":
+                 [{"keyword": "Background",
+                   "name": "There are bananas",
+                   "line": 3,
+                   "description": "",
+                   "type": "background",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 4,
+                      "match": {"location": "spec.feature:4"},
+                      "result": {"status": "undefined"}}]},
+                  {"id": "banana-party;monkey-eats-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats bananas",
+                   "line": 6,
+                   "description": "",
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Then ",
+                      "name": "the monkey eats bananas",
+                      "line": 7,
+                      "match": {"location": "spec.feature:7"},
+                      "result": {"status": "undefined"}}]},
+                  {"keyword": "Background",
+                   "name": "There are bananas",
+                   "line": 3,
+                   "description": "",
+                   "type": "background",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 4,
+                      "match": {"location": "spec.feature:4"},
+                      "result": {"status": "undefined"}}]},
+                  {"id": "banana-party;monkey-eats-more-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats more bananas",
+                   "line": 9,
+                   "description": "",
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Then ",
+                      "name": "the monkey eats more bananas",
+                      "line": 10,
+                      "match": {"location": "spec.feature:10"},
+                      "result": {"status": "undefined"}}]}]}]})
+          end
+        end
+
+        describe "with a scenario with a step that embeds data directly" do
+          define_feature <<-FEATURE
+          Feature: Banana party
+
+            Scenario: Monkey eats bananas
+              Given there are bananas
+            FEATURE
+
+          define_steps do
+            Given(/^there are bananas$/) { data = "YWJj"
+              embed data, "mime-type;base64" }
+          end
+
+          it "includes the data from the step in the json data" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 1,
+                "description": "",
+                "elements":
+                 [{"id": "banana-party;monkey-eats-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats bananas",
+                   "line": 3,
+                   "description": "",
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 4,
+                      "embeddings": [{"mime_type": "mime-type",
+                                      "data": "YWJj"}],
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:577"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}]}]}]})
+          end
+        end
+
+        describe "with a scenario with a step that embeds a file" do
+          define_feature <<-FEATURE
+          Feature: Banana party
+
+            Scenario: Monkey eats bananas
+              Given there are bananas
+            FEATURE
+
+          define_steps do
+            Given(/^there are bananas$/) {
+              RSpec::Mocks.allow_message(File, :file?) { true }
+              f1 = RSpec::Mocks::Double.new
+              RSpec::Mocks.allow_message(File, :open)  { |&block| block.call(f1) }
+              RSpec::Mocks.allow_message(f1, :read)  { "foo" }
+              embed('out/snapshot.jpeg', 'image/png')
+            }
+          end
+
+          it "includes the file content in the json data" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 1,
+                "description": "",
+                "elements":
+                 [{"id": "banana-party;monkey-eats-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats bananas",
+                   "line": 3,
+                   "description": "",
+                   "type": "scenario",
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 4,
+                      "embeddings": [{"mime_type": "image/png",
+                                      "data": "Zm9v"}],
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:617"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}]}]}]})
+          end
+        end
+
+        describe "with a scenario with hooks" do
+          define_feature <<-FEATURE
+          Feature: Banana party
+
+            Scenario: Monkey eats bananas
+              Given there are bananas
+            FEATURE
+
+          define_steps do
+            Before() {}
+            Before() {}
+            After() {}
+            After() {}
+            AfterStep() {}
+            AfterStep() {}
+            Around() { |scenario, block| block.call }
+            Given(/^there are bananas$/) {}
+          end
+
+          it "includes all hooks except the around hook in the json data" do
+            expect(load_normalised_json(@out)).to eq MultiJson.load(%{
+              [{"id": "banana-party",
+                "uri": "spec.feature",
+                "keyword": "Feature",
+                "name": "Banana party",
+                "line": 1,
+                "description": "",
+                "elements":
+                 [{"id": "banana-party;monkey-eats-bananas",
+                   "keyword": "Scenario",
+                   "name": "Monkey eats bananas",
+                   "line": 3,
+                   "description": "",
+                   "type": "scenario",
+                   "before":
+                    [{"match": {"location": "spec/cucumber/formatter/json_spec.rb:662"},
+                      "result": {"status": "passed",
+                                 "duration": 1}},
+                     {"match": {"location": "spec/cucumber/formatter/json_spec.rb:663"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}],
+                   "steps":
+                    [{"keyword": "Given ",
+                      "name": "there are bananas",
+                      "line": 4,
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:669"},
+                      "result": {"status": "passed",
+                                 "duration": 1},
+                      "after":
+                       [{"match": {"location": "spec/cucumber/formatter/json_spec.rb:666"},
+                         "result": {"status": "passed",
+                                    "duration": 1}},
+                        {"match": {"location": "spec/cucumber/formatter/json_spec.rb:667"},
+                         "result": {"status": "passed",
+                                    "duration": 1}}]}],
+                   "after":
+                    [{"match": {"location": "spec/cucumber/formatter/json_spec.rb:665"},
+                      "result": {"status": "passed",
+                                 "duration": 1}},
+                     {"match": {"location": "spec/cucumber/formatter/json_spec.rb:664"},
+                      "result": {"status": "passed",
+                                 "duration": 1}}]}]}]})
+          end
+        end
+
+      end
+
+      def load_normalised_json(out)
+        normalise_json(MultiJson.load(out.string))
+      end
+
+      def normalise_json(json)
+        #make sure duration was captured (should be >= 0)
+        #then set it to what is "expected" since duration is dynamic
+        json.each do |feature|
+          elements = feature.fetch('elements') { [] }
+          elements.each do |scenario|
+            ['steps', 'before', 'after'].each do |type|
+              if scenario[type]
+                scenario[type].each do |step_or_hook|
+                  normalise_json_step_or_hook(step_or_hook)
+                  if step_or_hook['after']
+                    step_or_hook['after'].each do |hook|
+                      normalise_json_step_or_hook(hook)
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      def normalise_json_step_or_hook(step_or_hook)
+        if step_or_hook['result']
+          if step_or_hook['result']['duration']
+            expect(step_or_hook['result']['duration']).to be >= 0
+            step_or_hook['result']['duration'] = 1
+          end
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
The main behavioural goal of the PR is to included results for test cases from Scenario Outlines also when the `--expand` option is not used (currently the `--expand` option is need to usable data when using Scenario Outlines).

A secondary behavioural goal is to align the produced Json file with what Cucumber-JVM produces, for the benefit of people that develop third party tools to be used together with the Cucumber version. The first tools that comes to mind are [the Masterthought tools](http://www.masterthought.net/section/cucumber-reporting) and [the Bamboo plugin](https://marketplace.atlassian.com/plugins/com.hindsighttesting.behave.cucumber-bamboo-plugin). This means that:
 * results for all executed steps are included (that means the Background steps are included each time they are executed), and
 * the executed hooks are reported (except for Around hooks, which does not seem to be included in the test case steps).

To get the location of the step definitions and hooks was somewhat challenging since the location of the Cucumber::Core::Test::Action is where the action block is create (in Cucumber::Runtime::SupportCode) and not the location hook/step definition itself). The Hooks are changed to hold the location of the hook method. In case of step definitions, the Json Formatter queries the Runtime for the location instead (same as the LegacyAdapter).

An additional benefit of this rewrite is that the Json Formatter now is independent of the Gherkin2 library.

Related to #839.