### PR TITLE
Errors in formatters and LegacyApi can give weird error symptoms

### DIFF
--- a/lib/cucumber/formatter/legacy_api/ast.rb
+++ b/lib/cucumber/formatter/legacy_api/ast.rb
@@ -216,6 +216,7 @@ module Cucumber
 
           def accept(formatter)
             formatter.before_table_row(self)
+            raise "Error raised in Cucumber::Formatter::LegacyApi::Ast"
             values.each do |value|
               formatter.before_table_cell(value)
               formatter.table_cell_value(value, status)


### PR DESCRIPTION
To illustrate this a added the explicit raising of an exception in Cucumber::Formatter::LegacyApi::Ast. The errors from one spec (junit_spec.rb) pinpoint this, but the errors from another (pretty_spec.rb) instead point to:
```
       undefined method `custom_profiles' for {}:Hash
     # ./lib/cucumber/formatter/console.rb:82:in `print_stats'
```

I guess that #831 is an expression of this too. The error that triggered the stacktrace of #831 is somewhere completely unrelated to the information in that stacktrace.