### PR TITLE
Use Gherkin3 instead of Gherkin2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ unless ENV['CUCUMBER_USE_RELEASED_CORE']
   if File.exist?(core_path) && !ENV['CUCUMBER_USE_GIT_CORE']
     gem 'cucumber-core', :path => core_path
   else
-    gem 'cucumber-core', :git => "git://github.com/cucumber/cucumber-ruby-core.git"
+    gem 'cucumber-core', :git => "git://github.com/cucumber/cucumber-ruby-core.git", branch: "integrate-gherkin3-parser"
   end
   gem 'gherkin3', github: "cucumber/gherkin3", branch: "integrate-ruby-core"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,4 @@ unless ENV['CUCUMBER_USE_RELEASED_CORE']
   else
     gem 'cucumber-core', :git => "git://github.com/cucumber/cucumber-ruby-core.git", branch: "integrate-gherkin3-parser"
   end
-  gem 'gherkin3', github: "cucumber/gherkin3", branch: "integrate-ruby-core"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ unless ENV['CUCUMBER_USE_RELEASED_CORE']
   else
     gem 'cucumber-core', :git => "git://github.com/cucumber/cucumber-ruby-core.git"
   end
+  gem 'gherkin3', github: "cucumber/gherkin3", branch: "integrate-ruby-core"
 end

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cucumber-core', '~> 1.2.0'
   s.add_dependency 'builder', '>= 2.1.2'
   s.add_dependency 'diff-lcs', '>= 1.1.3'
-  s.add_dependency 'gherkin3', '~> 3.0.0'
+  s.add_dependency 'gherkin3', '~> 3.1.0'
   s.add_dependency 'multi_json', '>= 1.7.5', '< 2.0'
   s.add_dependency 'multi_test', '>= 0.1.2'
 

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cucumber-core', '~> 1.2.0'
   s.add_dependency 'builder', '>= 2.1.2'
   s.add_dependency 'diff-lcs', '>= 1.1.3'
-  s.add_dependency 'gherkin', '~> 2.12'
+  s.add_dependency 'gherkin3', '~> 3.0.0.alpha.1'
   s.add_dependency 'multi_json', '>= 1.7.5', '< 2.0'
   s.add_dependency 'multi_test', '>= 0.1.2'
 

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cucumber-core', '~> 1.2.0'
   s.add_dependency 'builder', '>= 2.1.2'
   s.add_dependency 'diff-lcs', '>= 1.1.3'
-  s.add_dependency 'gherkin3', '~> 3.0.0.alpha.1'
+  s.add_dependency 'gherkin3', '~> 3.0.0'
   s.add_dependency 'multi_json', '>= 1.7.5', '< 2.0'
   s.add_dependency 'multi_test', '>= 0.1.2'
 

--- a/features/docs/gherkin/language_help.feature
+++ b/features/docs/gherkin/language_help.feature
@@ -14,21 +14,21 @@ Feature: Language help
     When I run `cucumber --i18n pt help`
     Then it should pass with:
       """
-            | feature          | "Funcionalidade", "Característica", "Caracteristica"                                         |
-            | background       | "Contexto", "Cenário de Fundo", "Cenario de Fundo", "Fundo"                                  |
-            | scenario         | "Cenário", "Cenario"                                                                         |
-            | scenario_outline | "Esquema do Cenário", "Esquema do Cenario", "Delineação do Cenário", "Delineacao do Cenario" |
-            | examples         | "Exemplos", "Cenários", "Cenarios"                                                           |
-            | given            | "* ", "Dado ", "Dada ", "Dados ", "Dadas "                                                   |
-            | when             | "* ", "Quando "                                                                              |
-            | then             | "* ", "Então ", "Entao "                                                                     |
-            | and              | "* ", "E "                                                                                   |
-            | but              | "* ", "Mas "                                                                                 |
-            | given (code)     | "Dado", "Dada", "Dados", "Dadas"                                                             |
-            | when (code)      | "Quando"                                                                                     |
-            | then (code)      | "Então", "Entao"                                                                             |
-            | and (code)       | "E"                                                                                          |
-            | but (code)       | "Mas"                                                                                        |
+        | feature          | "Funcionalidade", "Característica", "Caracteristica"                                         |
+        | background       | "Contexto", "Cenário de Fundo", "Cenario de Fundo", "Fundo"                                  |
+        | scenario         | "Cenário", "Cenario"                                                                         |
+        | scenario_outline | "Esquema do Cenário", "Esquema do Cenario", "Delineação do Cenário", "Delineacao do Cenario" |
+        | examples         | "Exemplos", "Cenários", "Cenarios"                                                           |
+        | given            | "* ", "Dado ", "Dada ", "Dados ", "Dadas "                                                   |
+        | when             | "* ", "Quando "                                                                              |
+        | then             | "* ", "Então ", "Entao "                                                                     |
+        | and              | "* ", "E "                                                                                   |
+        | but              | "* ", "Mas "                                                                                 |
+        | given (code)     | "Dado", "Dada", "Dados", "Dadas"                                                             |
+        | when (code)      | "Quando"                                                                                     |
+        | then (code)      | "Então", "Entao"                                                                             |
+        | and (code)       | "E"                                                                                          |
+        | but (code)       | "Mas"                                                                                        |
 
       """
 

--- a/features/docs/gherkin/using_descriptions.feature
+++ b/features/docs/gherkin/using_descriptions.feature
@@ -54,28 +54,23 @@ Feature: Using descriptions to give features context
     Then it should pass with exactly:
     """
     Feature: descriptions everywhere
-      
       We can put a useful description here of the feature, which can
       span multiple lines.
 
       Background: 
-        
         We can also put in descriptions showing what the background is
         doing.
         Given this step passes
 
       Scenario: I'm a scenario with a description
-        
         You can also put descriptions in front of individual scenarios.
         Given this step passes
 
       Scenario Outline: I'm a scenario outline with a description
-        
         Scenario outlines can have descriptions.
         Given this step <state>
 
         Examples: Examples
-          
           Specific examples for an outline are allowed to have
           descriptions, too.
           | state  |

--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -2,7 +2,7 @@ require 'logger'
 require 'cucumber/cli/options'
 require 'cucumber/cli/rerun_file'
 require 'cucumber/constantize'
-require 'gherkin/tag_expression'
+require 'cucumber/core/gherkin/tag_expression'
 
 module Cucumber
   module Cli
@@ -27,7 +27,7 @@ module Cucumber
         arrange_formats
         raise("You can't use both --strict and --wip") if strict? && wip?
         # todo: remove
-        @options[:tag_expression] = Gherkin::TagExpression.new(@options[:tag_expressions])
+        @options[:tag_expression] = Cucumber::Core::Gherkin::TagExpression.new(@options[:tag_expressions])
         set_environment_variables
       end
 
@@ -81,7 +81,7 @@ module Cucumber
 
       # todo: remove
       def tag_expression
-        Gherkin::TagExpression.new(@options[:tag_expressions])
+        Cucumber::Core::Gherkin::TagExpression.new(@options[:tag_expressions])
       end
 
       def tag_limits

--- a/lib/cucumber/cli/main.rb
+++ b/lib/cucumber/cli/main.rb
@@ -1,9 +1,3 @@
-begin
-  require 'gherkin'
-rescue LoadError
-  require 'rubygems'
-  require 'gherkin'
-end
 require 'optparse'
 require 'cucumber'
 require 'logger'

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -400,21 +400,21 @@ TEXT
         require 'gherkin3/dialect'
         language = ::Gherkin3::Dialect.for(lang)
         data = Cucumber::MultilineArgument::DataTable.from(
-          [["feature", to_keywords_string(language.feature)],
-          ["background", to_keywords_string(language.background)],
-          ["scenario", to_keywords_string(language.scenario)],
-          ["scenario_outline", to_keywords_string(language.scenario_outline)],
-          ["examples", to_keywords_string(language.examples)],
-          ["given", to_keywords_string(language.given)],
-          ["when", to_keywords_string(language.when)],
-          ["then", to_keywords_string(language.then)],
-          ["and", to_keywords_string(language.and)],
-          ["but", to_keywords_string(language.but)],
-          ["given (code)", to_code_keywords_string(language.given)],
-          ["when (code)", to_code_keywords_string(language.when)],
-          ["then (code)", to_code_keywords_string(language.then)],
-          ["and (code)", to_code_keywords_string(language.and)],
-          ["but (code)", to_code_keywords_string(language.but)]])
+          [["feature", to_keywords_string(language.feature_keywords)],
+          ["background", to_keywords_string(language.background_keywords)],
+          ["scenario", to_keywords_string(language.scenario_keywords)],
+          ["scenario_outline", to_keywords_string(language.scenario_outline_keywords)],
+          ["examples", to_keywords_string(language.examples_keywords)],
+          ["given", to_keywords_string(language.given_keywords)],
+          ["when", to_keywords_string(language.when_keywords)],
+          ["then", to_keywords_string(language.then_keywords)],
+          ["and", to_keywords_string(language.and_keywords)],
+          ["but", to_keywords_string(language.but_keywords)],
+          ["given (code)", to_code_keywords_string(language.given_keywords)],
+          ["when (code)", to_code_keywords_string(language.when_keywords)],
+          ["then (code)", to_code_keywords_string(language.then_keywords)],
+          ["and (code)", to_code_keywords_string(language.and_keywords)],
+          ["but (code)", to_code_keywords_string(language.but_keywords)]])
         @out_stream.write(data.to_s({ color: false, prefixes: Hash.new('') }))
         Kernel.exit(0)
       end
@@ -423,8 +423,7 @@ TEXT
         require 'gherkin3/dialect'
         data = Cucumber::MultilineArgument::DataTable.from(
           ::Gherkin3::DIALECTS.keys.map do |key|
-            language = ::Gherkin3::Dialect.for(key)
-            [key, language.name, language.native]
+            [key, ::Gherkin3::DIALECTS[key].fetch('name'), ::Gherkin3::DIALECTS[key].fetch('native')]
           end)
         @out_stream.write(data.to_s({ color: false, prefixes: Hash.new('') }))
         Kernel.exit(0)

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -1,8 +1,8 @@
 require 'cucumber/constantize'
 require 'cucumber/cli/rerun_file'
 require 'cucumber/events'
-require 'gherkin/tag_expression'
 require 'forwardable'
+require 'cucumber/core/gherkin/tag_expression'
 
 module Cucumber
   # The base class for configuring settings for a Cucumber run.
@@ -105,7 +105,7 @@ module Cucumber
 
     # todo: remove
     def tag_expression
-      Gherkin::TagExpression.new(@options[:tag_expressions])
+      Cucumber::Core::Gherkin::TagExpression.new(@options[:tag_expressions])
     end
 
     def tag_limits

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -207,7 +207,8 @@ module Cucumber
 
           def before
             formatter.before_feature(node)
-            Ast::Comments.new(node.comments).accept(formatter)
+            language_comment = node.language.iso_code != 'en' ? ["# language: #{node.language.iso_code}"] : []
+            Ast::Comments.new(language_comment + node.comments).accept(formatter)
             Ast::Tags.new(node.tags).accept(formatter)
             formatter.feature_name node.keyword, node.legacy_conflated_name_and_description
             @delayed_messages = []

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -749,9 +749,9 @@ module Cucumber
               max_width.result
             end
 
-            require 'gherkin/formatter/escaping'
+            require 'cucumber/gherkin/formatter/escaping'
             FindMaxWidth = Struct.new(:index) do
-              include ::Gherkin::Formatter::Escaping
+              include ::Cucumber::Gherkin::Formatter::Escaping
 
               def examples_table(table, &descend)
                 @result = char_length_of(table.header.values[index])

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -209,7 +209,7 @@ module Cucumber
             formatter.before_feature(node)
             Ast::Comments.new(node.comments).accept(formatter)
             Ast::Tags.new(node.tags).accept(formatter)
-            formatter.feature_name node.keyword, indented(node.legacy_conflated_name_and_description)
+            formatter.feature_name node.keyword, node.legacy_conflated_name_and_description
             @delayed_messages = []
             @delayed_embeddings = []
             self
@@ -411,15 +411,6 @@ module Cucumber
 
           def to_scenario_outline(to)
             to.class.name == ScenarioOutlinePrinter.name
-          end
-
-          def indented(nasty_old_conflation_of_name_and_description)
-            indent = ""
-            nasty_old_conflation_of_name_and_description.split("\n").map do |l|
-              s = "#{indent}#{l}"
-              indent = "  "
-              s
-            end.join("\n")
           end
 
         end

--- a/lib/cucumber/formatter/legacy_api/ast.rb
+++ b/lib/cucumber/formatter/legacy_api/ast.rb
@@ -252,7 +252,7 @@ module Cucumber
           def keyword
             # This method is only called when used for the scenario name line with
             # the expand option, and on that line the keyword is "Scenario"
-            language.scenario[0]
+            language.scenario_keywords[0]
           end
         end
 

--- a/lib/cucumber/formatter/legacy_api/ast.rb
+++ b/lib/cucumber/formatter/legacy_api/ast.rb
@@ -104,7 +104,7 @@ module Cucumber
                                     :embeddings) do
           extend Forwardable
 
-          def_delegators :step, :keyword, :name, :multiline_arg, :location, :gherkin_statement
+          def_delegators :step, :keyword, :name, :multiline_arg, :location
 
           def accept(formatter)
             formatter.before_step(self)
@@ -252,7 +252,7 @@ module Cucumber
           def keyword
             # This method is only called when used for the scenario name line with
             # the expand option, and on that line the keyword is "Scenario"
-            language.keywords('scenario')[0]
+            language.scenario[0]
           end
         end
 

--- a/lib/cucumber/formatter/legacy_api/runtime_facade.rb
+++ b/lib/cucumber/formatter/legacy_api/runtime_facade.rb
@@ -1,3 +1,5 @@
+require 'cucumber/gherkin/i18n'
+
 module Cucumber
   module Formatter
     module LegacyApi
@@ -9,7 +11,7 @@ module Cucumber
         end
 
         def snippet_text(step_keyword, step_name, multiline_arg) #:nodoc:
-          support_code.snippet_text(::Gherkin::I18n.code_keyword_for(step_keyword), step_name, multiline_arg)
+          support_code.snippet_text(Cucumber::Gherkin::I18n.code_keyword_for(step_keyword).strip, step_name, multiline_arg)
         end
 
         def unknown_programming_language?

--- a/lib/cucumber/formatter/pretty.rb
+++ b/lib/cucumber/formatter/pretty.rb
@@ -105,9 +105,7 @@ module Cucumber
       def examples_name(keyword, name)
         @io.puts unless @visiting_first_example_name
         @visiting_first_example_name = false
-        names = name.strip.empty? ? [name.strip] : name.split("\n")
-        @io.puts("    #{keyword}: #{names[0]}")
-        names[1..-1].each {|s| @io.puts "      #{s}" } unless names.empty?
+        @io.puts("    #{keyword}: #{name}")
         @io.flush
         @indent = 6
         @scenario_indent = 6
@@ -231,7 +229,7 @@ module Cucumber
           @io.print(format_string(line_comment, :comment))
         end
         @io.puts
-        names[1..-1].each {|s| @io.puts "    #{s}"}
+        names[1..-1].each {|s| @io.puts "#{s}"}
         @io.flush
       end
 

--- a/lib/cucumber/formatter/pretty.rb
+++ b/lib/cucumber/formatter/pretty.rb
@@ -1,7 +1,7 @@
 require 'fileutils'
 require 'cucumber/formatter/console'
 require 'cucumber/formatter/io'
-require 'gherkin/formatter/escaping'
+require 'cucumber/gherkin/formatter/escaping'
 
 module Cucumber
   module Formatter
@@ -16,7 +16,7 @@ module Cucumber
       include FileUtils
       include Console
       include Io
-      include Gherkin::Formatter::Escaping
+      include Cucumber::Gherkin::Formatter::Escaping
       attr_writer :indent
       attr_reader :runtime
 

--- a/lib/cucumber/gherkin/data_table_parser.rb
+++ b/lib/cucumber/gherkin/data_table_parser.rb
@@ -1,0 +1,23 @@
+require 'gherkin3/token_scanner'
+require 'gherkin3/token_matcher'
+
+module Cucumber
+  module Gherkin
+    class DataTableParser
+      def initialize(builder)
+        @builder = builder
+      end
+      def parse(text)
+        scanner = ::Gherkin3::TokenScanner.new(text)
+        matcher = ::Gherkin3::TokenMatcher.new
+        token = scanner.read
+        until matcher.match_EOF(token) do
+          if matcher.match_TableRow(token)
+            @builder.row(token.matched_items.map { |cell_item| cell_item.text })
+          end
+          token = scanner.read
+        end
+      end
+    end
+  end
+end

--- a/lib/cucumber/gherkin/formatter/ansi_escapes.rb
+++ b/lib/cucumber/gherkin/formatter/ansi_escapes.rb
@@ -1,0 +1,99 @@
+module Cucumber
+module Gherkin
+  module Formatter
+    # Defines aliases for ANSI coloured output. Default colours can be overridden by defining
+    # a <tt>GHERKIN_COLORS</tt> variable in your shell, very much like how you can
+    # tweak the familiar POSIX command <tt>ls</tt> with
+    # $LSCOLORS: http://linux-sxs.org/housekeeping/lscolors.html
+    #
+    # The colours that you can change are:
+    #
+    # <tt>undefined</tt>::     defaults to <tt>yellow</tt>
+    # <tt>pending</tt>::       defaults to <tt>yellow</tt>
+    # <tt>pending_arg</tt>::   defaults to <tt>yellow,bold</tt>
+    # <tt>executing</tt>::     defaults to <tt>grey</tt>
+    # <tt>executing_arg</tt>:: defaults to <tt>grey,bold</tt>
+    # <tt>failed</tt>::        defaults to <tt>red</tt>
+    # <tt>failed_arg</tt>::    defaults to <tt>red,bold</tt>
+    # <tt>passed</tt>::        defaults to <tt>green</tt>
+    # <tt>passed_arg</tt>::    defaults to <tt>green,bold</tt>
+    # <tt>outline</tt>::       defaults to <tt>cyan</tt>
+    # <tt>outline_arg</tt>::   defaults to <tt>cyan,bold</tt>
+    # <tt>skipped</tt>::       defaults to <tt>cyan</tt>
+    # <tt>skipped_arg</tt>::   defaults to <tt>cyan,bold</tt>
+    # <tt>comment</tt>::       defaults to <tt>grey</tt>
+    # <tt>tag</tt>::           defaults to <tt>cyan</tt>
+    #
+    # For instance, if your shell has a black background and a green font (like the
+    # "Homebrew" settings for OS X' Terminal.app), you may want to override passed
+    # steps to be white instead of green. Examples:
+    #
+    #   export GHERKIN_COLORS="passed=white"
+    #   export GHERKIN_COLORS="passed=white,bold:passed_arg=white,bold,underline"
+    #
+    # (If you're on Windows, use SET instead of export).
+    # To see what colours and effects are available, just run this in your shell:
+    #
+    #   ruby -e "require 'rubygems'; require 'term/ansicolor'; puts Term::ANSIColor.attributes"
+    #
+    # Although not listed, you can also use <tt>grey</tt>
+    module AnsiEscapes
+      COLORS = {
+        'black'   => "\e[30m",
+        'red'     => "\e[31m",
+        'green'   => "\e[32m",
+        'yellow'  => "\e[33m",
+        'blue'    => "\e[34m",
+        'magenta' => "\e[35m",
+        'cyan'    => "\e[36m",
+        'white'   => "\e[37m",
+        'grey'    => "\e[90m",
+        'bold'    => "\e[1m"
+      }
+
+      ALIASES = Hash.new do |h,k|
+        if k.to_s =~ /(.*)_arg/
+          h[$1] + ',bold'
+        end
+      end.merge({
+        'undefined' => 'yellow',
+        'pending'   => 'yellow',
+        'executing' => 'grey',
+        'failed'    => 'red',
+        'passed'    => 'green',
+        'outline'   => 'cyan',
+        'skipped'   => 'cyan',
+        'comments'  => 'grey',
+        'tag'       => 'cyan'
+      })
+
+      if ENV['GHERKIN_COLORS'] # Example: export GHERKIN_COLORS="passed=red:failed=yellow"
+        ENV['GHERKIN_COLORS'].split(':').each do |pair|
+          a = pair.split('=')
+          ALIASES[a[0]] = a[1]
+        end
+      end
+
+      ALIASES.keys.each do |key|
+        define_method(key) do
+          ALIASES[key].split(',').map{|color| COLORS[color]}.join('')
+        end
+
+        define_method("#{key}_arg") do
+          ALIASES["#{key}_arg"].split(',').map{|color| COLORS[color]}.join('')
+        end
+      end
+      
+      def reset
+        "\e[0m"
+      end
+
+      def up(n)
+        "\e[#{n}A"
+      end
+
+      extend self
+    end
+  end
+end
+end

--- a/lib/cucumber/gherkin/formatter/argument.rb
+++ b/lib/cucumber/gherkin/formatter/argument.rb
@@ -1,0 +1,17 @@
+require 'cucumber/gherkin/formatter/hashable'
+
+module Cucumber
+module Gherkin
+  module Formatter
+    class Argument < Hashable
+      #native_impl('gherkin')
+      attr_reader :offset, :val
+
+      # Creates a new Argument that starts at character offset +offset+ with value +val+
+      def initialize(offset, val)
+        @offset, @val = offset, val
+      end
+    end
+  end
+end
+end

--- a/lib/cucumber/gherkin/formatter/escaping.rb
+++ b/lib/cucumber/gherkin/formatter/escaping.rb
@@ -1,0 +1,17 @@
+module Cucumber
+module Gherkin
+  module Formatter
+    module Escaping
+      # Escapes a pipes and backslashes:
+      #
+      # * | becomes \|
+      # * \ becomes \\
+      #
+      # This is used in the pretty formatter.
+      def escape_cell(s)
+        s.gsub(/\\(?!\|)/, "\\\\\\\\").gsub(/\n/, "\\n").gsub(/\|/, "\\|")
+      end
+    end
+  end
+end
+end

--- a/lib/cucumber/gherkin/formatter/hashable.rb
+++ b/lib/cucumber/gherkin/formatter/hashable.rb
@@ -1,0 +1,27 @@
+module Cucumber
+module Gherkin
+  module Formatter
+    class Hashable
+      def to_hash
+        ivars = instance_variables
+        # When tests are runn with therubyracer (JavaScript), an extra field might
+        # exist - added by Ref::WeakReference
+        # https://github.com/bdurand/ref/blob/master/lib/ref/weak_reference/pure_ruby.rb
+        # Remove it - we don't want it in the JSON.
+        ivars.delete(:@__weak_backreferences__)
+        ivars.inject({}) do |hash, ivar|
+          value = instance_variable_get(ivar)
+          value = value.to_hash if value.respond_to?(:to_hash)
+          if Array === value
+            value = value.map do |e|
+              e.respond_to?(:to_hash) ? e.to_hash : e
+            end
+          end
+          hash[ivar[1..-1]] = value unless [[], nil].index(value)
+          hash
+        end
+      end
+    end
+  end
+end
+end

--- a/lib/cucumber/gherkin/i18n.rb
+++ b/lib/cucumber/gherkin/i18n.rb
@@ -5,6 +5,10 @@ module Cucumber
         def code_keyword_for(gherkin_keyword)
           gherkin_keyword.gsub(/[\s',!]/, '').strip
         end
+
+        def code_keywords_for(gherkin_keywords)
+          gherkin_keywords.reject { |kw| kw == '* ' }.map { |kw| code_keyword_for(kw) }
+        end
       end
     end
   end

--- a/lib/cucumber/gherkin/i18n.rb
+++ b/lib/cucumber/gherkin/i18n.rb
@@ -1,0 +1,11 @@
+module Cucumber
+  module Gherkin
+    module I18n
+      class << self
+        def code_keyword_for(gherkin_keyword)
+          gherkin_keyword.gsub(/[\s',!]/, '').strip
+        end
+      end
+    end
+  end
+end

--- a/lib/cucumber/gherkin/steps_parser.rb
+++ b/lib/cucumber/gherkin/steps_parser.rb
@@ -12,14 +12,15 @@ module Cucumber
       end
       def parse(text)
         ast_builder = ::Gherkin3::AstBuilder.new
+        token_matcher = ::Gherkin3::TokenMatcher.new
+        token_matcher.send(:change_dialect, @language, nil) unless @language == 'en'
         context = ::Gherkin3::ParserContext.new(
           ::Gherkin3::TokenScanner.new(text),
-          ast_builder,
-          ::Gherkin3::TokenMatcher.new(@language),
+          token_matcher,
           [],
           []
           )
-        parser = ::Gherkin3::Parser.new
+        parser = ::Gherkin3::Parser.new(ast_builder)
 
         parser.start_rule(context, :ScenarioDefinition)
         parser.start_rule(context, :Scenario)

--- a/lib/cucumber/gherkin/steps_parser.rb
+++ b/lib/cucumber/gherkin/steps_parser.rb
@@ -1,0 +1,40 @@
+require 'gherkin3/token_scanner'
+require 'gherkin3/token_matcher'
+require 'gherkin3/ast_builder'
+require 'gherkin3/parser'
+
+module Cucumber
+  module Gherkin
+    class StepsParser
+      def initialize(builder, language)
+        @builder = builder
+        @language = language
+      end
+      def parse(text)
+        ast_builder = ::Gherkin3::AstBuilder.new
+        context = ::Gherkin3::ParserContext.new(
+          ::Gherkin3::TokenScanner.new(text),
+          ast_builder,
+          ::Gherkin3::TokenMatcher.new(@language),
+          [],
+          []
+          )
+        parser = ::Gherkin3::Parser.new
+
+        parser.start_rule(context, :ScenarioDefinition)
+        parser.start_rule(context, :Scenario)
+        scenario = ast_builder.current_node
+        state = 12
+        token = nil
+        begin
+          token = parser.read_token(context)
+          state = parser.match_token(state, token, context)
+        end until(token.eof?)
+
+        raise CompositeParserException.new(context.errors) if context.errors.any?
+
+        @builder.steps(ast_builder.get_steps(scenario))
+      end
+    end
+  end
+end

--- a/lib/cucumber/multiline_argument.rb
+++ b/lib/cucumber/multiline_argument.rb
@@ -1,11 +1,9 @@
 require 'delegate'
 require 'cucumber/multiline_argument/data_table'
 require 'cucumber/multiline_argument/doc_string'
-require 'gherkin/rubify'
 
 module Cucumber
   module MultilineArgument
-    extend Gherkin::Rubify
 
     class << self
       def from_core(node)
@@ -14,7 +12,6 @@ module Cucumber
 
       def from(argument, location=nil)
         location ||= Core::Ast::Location.of_caller
-        argument = rubify(argument)
         case argument
         when String
           doc_string(argument, 'text/plain', location)

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -1,5 +1,5 @@
 require 'forwardable'
-require 'gherkin/formatter/escaping'
+require 'cucumber/gherkin/formatter/escaping'
 require 'cucumber/core/ast/describes_itself'
 
 module Cucumber
@@ -639,7 +639,7 @@ module Cucumber
       # Represents a row of cells or columns of cells
       class Cells #:nodoc:
         include Enumerable
-        include Gherkin::Formatter::Escaping
+        include Cucumber::Gherkin::Formatter::Escaping
 
         attr_reader :exception
 

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'cucumber/gherkin/data_table_parser'
 require 'cucumber/gherkin/formatter/escaping'
 require 'cucumber/core/ast/describes_itself'
 
@@ -37,7 +38,7 @@ module Cucumber
           @rows = []
         end
 
-        def row(row, line_number)
+        def row(row)
           @rows << row
         end
 
@@ -73,8 +74,8 @@ module Cucumber
         private
         def parse(text, location = Core::Ast::Location.of_caller)
           builder = Builder.new
-          lexer = Gherkin::Lexer::I18nLexer.new(builder)
-          lexer.scan(text)
+          parser = Cucumber::Gherkin::DataTableParser.new(builder)
+          parser.parse(text)
           from_array(builder.rows, location)
         end
 

--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -1,5 +1,5 @@
 require 'cucumber/platform'
-require 'gherkin/formatter/ansi_escapes'
+require 'cucumber/gherkin/formatter/ansi_escapes'
 begin
   # Support Rake > 0.8.7
   require 'rake/dsl_definition'
@@ -25,7 +25,7 @@ module Cucumber
     #
     # See the attributes for additional configuration possibilities.
     class Task
-      include Gherkin::Formatter::AnsiEscapes
+      include Cucumber::Gherkin::Formatter::AnsiEscapes
       include ::Rake::DSL if defined?(::Rake::DSL)
 
       class InProcessCucumberRunner #:nodoc:

--- a/lib/cucumber/rb_support/rb_language.rb
+++ b/lib/cucumber/rb_support/rb_language.rb
@@ -38,7 +38,7 @@ module Cucumber
 
       all_keywords = ::Gherkin3::DIALECTS.keys.map do |dialect_name|
         dialect = ::Gherkin3::Dialect.for(dialect_name)
-        dialect.given + dialect.when + dialect.then + dialect.and + dialect.but
+        dialect.given_keywords + dialect.when_keywords + dialect.then_keywords + dialect.and_keywords + dialect.but_keywords
       end
       Cucumber::Gherkin::I18n.code_keywords_for(all_keywords.flatten.uniq.sort).each do |adverb|
         RbDsl.alias_adverb(adverb.strip)

--- a/lib/cucumber/rb_support/rb_language.rb
+++ b/lib/cucumber/rb_support/rb_language.rb
@@ -5,6 +5,7 @@ require 'cucumber/rb_support/rb_step_definition'
 require 'cucumber/rb_support/rb_hook'
 require 'cucumber/rb_support/rb_transform'
 require 'cucumber/rb_support/snippet'
+require 'cucumber/gherkin/i18n'
 require 'multi_test'
 
 module Cucumber
@@ -35,8 +36,12 @@ module Cucumber
       attr_reader :current_world,
                   :step_definitions
 
-      Gherkin::I18n.code_keywords.each do |adverb|
-        RbDsl.alias_adverb(adverb)
+      all_keywords = ::Gherkin3::DIALECTS.keys.map do |dialect_name|
+        dialect = ::Gherkin3::Dialect.for(dialect_name)
+        dialect.given + dialect.when + dialect.then + dialect.and + dialect.but
+      end
+      Cucumber::Gherkin::I18n.code_keywords_for(all_keywords.flatten.uniq.sort).each do |adverb|
+        RbDsl.alias_adverb(adverb.strip)
       end
 
       def initialize(runtime)

--- a/lib/cucumber/rb_support/rb_world.rb
+++ b/lib/cucumber/rb_support/rb_world.rb
@@ -1,4 +1,4 @@
-require 'gherkin/formatter/ansi_escapes'
+require 'cucumber/gherkin/formatter/ansi_escapes'
 
 module Cucumber
   module RbSupport
@@ -9,7 +9,7 @@ module Cucumber
     module RbWorld
 
       # @private
-      AnsiEscapes = Gherkin::Formatter::AnsiEscapes
+      AnsiEscapes = Cucumber::Gherkin::Formatter::AnsiEscapes
 
       # Call a Transform with a string from another Transform definition
       def Transform(arg)

--- a/lib/cucumber/rb_support/regexp_argument_matcher.rb
+++ b/lib/cucumber/rb_support/regexp_argument_matcher.rb
@@ -1,4 +1,4 @@
-require 'gherkin/formatter/argument'
+require 'cucumber/gherkin/formatter/argument'
 
 module Cucumber
   module RbSupport
@@ -10,7 +10,7 @@ module Cucumber
           match.captures.map do |val|
             n += 1
             offset = match.offset(n)[0]
-            Gherkin::Formatter::Argument.new(offset, val)
+            Cucumber::Gherkin::Formatter::Argument.new(offset, val)
           end
         else
           nil

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -2,8 +2,6 @@
 require 'fileutils'
 require 'multi_json'
 require 'multi_test'
-require 'gherkin/rubify'
-require 'gherkin/i18n'
 require 'cucumber/configuration'
 require 'cucumber/load_path'
 require 'cucumber/language_support/language_methods'
@@ -12,6 +10,7 @@ require 'cucumber/file_specs'
 require 'cucumber/filters'
 require 'cucumber/formatter/fanout'
 require 'cucumber/formatter/event_bus_report'
+require 'cucumber/gherkin/i18n'
 
 module Cucumber
   module FixRuby21Bug9285
@@ -92,7 +91,7 @@ module Cucumber
     end
 
     def snippet_text(step_keyword, step_name, multiline_arg) #:nodoc:
-      @support_code.snippet_text(::Gherkin::I18n.code_keyword_for(step_keyword), step_name, multiline_arg)
+      @support_code.snippet_text(Cucumber::Gherkin::I18n.code_keyword_for(step_keyword).strip, step_name, multiline_arg)
     end
 
     def begin_scenario(scenario)

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -13,7 +13,6 @@ module Cucumber
 
       require 'forwardable'
       class StepInvoker
-        include Gherkin::Rubify
 
         def initialize(support_code)
           @support_code = support_code

--- a/lib/cucumber/wire_support/wire_protocol/requests.rb
+++ b/lib/cucumber/wire_support/wire_protocol/requests.rb
@@ -1,5 +1,5 @@
 require 'cucumber/wire_support/request_handler'
-require 'gherkin/formatter/argument'
+require 'cucumber/gherkin/formatter/argument'
 
 module Cucumber
   module WireSupport
@@ -27,7 +27,7 @@ module Cucumber
           def create_step_match(raw_step_match)
             step_definition = WireStepDefinition.new(@connection, raw_step_match)
             step_args = raw_step_match['args'].map do |raw_arg|
-              Gherkin::Formatter::Argument.new(raw_arg['pos'], raw_arg['val'])
+              Cucumber::Gherkin::Formatter::Argument.new(raw_arg['pos'], raw_arg['val'])
             end
             step_match(step_definition, step_args)
           end

--- a/spec/cucumber/cli/main_spec.rb
+++ b/spec/cucumber/cli/main_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'yaml'
-require 'gherkin/formatter/model'
 
 module Cucumber
   module Cli

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -87,7 +87,9 @@ module Cucumber
 
             it "displays the language table" do 
               after_parsing '--i18n foo' do 
-                expect(@output_stream.string).to include(Gherkin::I18n.language_table);
+                ::Gherkin3::DIALECTS.keys.map do |key|
+                  expect(@output_stream.string).to include("#{key}");
+                end
               end
             end
           end

--- a/spec/cucumber/rb_support/rb_step_definition_spec.rb
+++ b/spec/cucumber/rb_support/rb_step_definition_spec.rb
@@ -114,6 +114,35 @@ module Cucumber
         }).to raise_error(Cucumber::UndefinedDynamicStep)
       end
 
+      it "raises UndefinedDynamicStep when an undefined step with doc string is parsed dynamically" do
+        dsl.Given(/Outside/) do
+          steps %{
+            Given Inside
+            """
+            abc
+            """
+          }
+        end
+
+        expect(-> {
+          run_step "Outside"
+        }).to raise_error(Cucumber::UndefinedDynamicStep)
+      end
+
+      it "raises UndefinedDynamicStep when an undefined step with data table is parsed dynamically" do
+        dsl.Given(/Outside/) do
+          steps %{
+            Given Inside
+             | a |
+             | 1 |
+          }
+        end
+
+        expect(-> {
+          run_step "Outside"
+        }).to raise_error(Cucumber::UndefinedDynamicStep)
+      end
+
       it "allows forced pending" do
         dsl.Given(/Outside/) do
           pending("Do me!")


### PR DESCRIPTION
This PR make Cucumber-Ruby use Gherkin3 instead of Gherkin2. Some notes:
* Some minor files that were used from Gherkin2 (formatter/ansi_escapes.rb, formatter/escaping.rb, formatter/argument.rb, formatter/hashable.rb and one method from i18n.rb), are copied into [Cucumber::Gherkin](https://github.com/cucumber/cucumber-ruby/tree/c4c54d47b1dee5a51aed0c53517d46665cce2499/lib/cucumber/gherkin) to remove all dependencies to Gherkin2.
* To parse data tables and dynamic steps internal parts of Gherkin2 were used. Now [Cucumber::Gherkin::DataTableParser](https://github.com/cucumber/cucumber-ruby/blob/c4c54d47b1dee5a51aed0c53517d46665cce2499/lib/cucumber/gherkin/data_table_parser.rb) and [Cucumber::Gherkin::StepsParser](https://github.com/cucumber/cucumber-ruby/blob/c4c54d47b1dee5a51aed0c53517d46665cce2499/lib/cucumber/gherkin/steps_parser.rb) are used instead, but they also depend directly on internal parts of Gherkin3 - not the kind of dependencies you really want.
* ~~Escaping doc string separators (\"\"\") in doc strings does not work in Gherkin3, but Gherkin3 support two different doc string separator (""" and ```), so defining steps with doc strings in doc string does still work.~~
* The language defining "comment" at the start of a feature file is not represented as a comment in the AST in Gherkin3 (which is was in Gherkin2), so when the language is not 'en' LegacyApi::Adapter will add such a comment, so it is printed by the Pretty and HTML formatters. When the language is 'en' the language "comment" is never printed regardless whether the language was explicitly set to 'en' or not.
* Descriptions in Gherkin3 do not include any leading blank lines in descriptions, so regardless of the actual number of blank lines between the element and the comment text in the feature file, there will be no blank lines when printed by the Pretty formatter (changing that to another fixed number of blank lines is easy if preferred).

Depends on cucumber/cucumber-ruby-core#93