### PR TITLE
Pass DocString as String

### DIFF
--- a/features/docs/defining_steps/nested_steps_with_second_arg.feature
+++ b/features/docs/defining_steps/nested_steps_with_second_arg.feature
@@ -34,7 +34,7 @@ Feature: Nested Steps with either table or doc string
 
       """
 
-  Scenario: Use #step with docstring
+  Scenario: Use #step with Doc String
     Given a step definition that looks like this:
       """ruby
       Given /two turtles/ do
@@ -44,30 +44,11 @@ Feature: Nested Steps with either table or doc string
     And a step definition that looks like this:
       """ruby
       Given /turtles:/ do |text|
-        puts text
+        puts "#{text}:#{text.class}"
       end
       """
     When I run the feature with the progress formatter
     Then the output should contain:
       """
-      Sturm and Lioville
-      """
-
-  Scenario: Use #step with docstring and content-type
-    Given a step definition that looks like this:
-      """ruby
-      Given /two turtles/ do
-        step %{turtles:}, doc_string('Sturm and Lioville','math')
-      end
-      """
-    And a step definition that looks like this:
-      """ruby
-      Given /turtles:/ do |text|
-        puts text.content_type
-      end
-      """
-    When I run the feature with the progress formatter
-    Then the output should contain:
-      """
-      math
+      Sturm and Lioville:String
       """

--- a/features/docs/gherkin/doc_strings.feature
+++ b/features/docs/gherkin/doc_strings.feature
@@ -53,22 +53,22 @@ Feature: Doc strings
       Three
       """
 
-  Scenario: DocString with interesting content type
+  Scenario: DocString passed as String
     Given a scenario with a step that looks like this:
       """gherkin
       Given I have some code for you:
-        \"\"\"ruby
-        # hello
+        \"\"\"
+        hello
         \"\"\"
       """
     And a step definition that looks like this:
       """ruby
       Given /code/ do |text|
-        puts text.content_type
+        puts text.class
       end
       """
     When I run the feature with the progress formatter
     Then the output should contain:
       """
-      ruby
+      String
       """

--- a/lib/cucumber/multiline_argument/doc_string.rb
+++ b/lib/cucumber/multiline_argument/doc_string.rb
@@ -2,9 +2,8 @@ module Cucumber
   module MultilineArgument
     class DocString < SimpleDelegator
       def append_to(array)
-        array << self
+        array << self.to_s
       end
     end
   end
 end
-

--- a/lib/cucumber/rb_support/rb_world.rb
+++ b/lib/cucumber/rb_support/rb_world.rb
@@ -65,19 +65,6 @@ module Cucumber
         @__cucumber_runtime.table(text_or_table, file, line_offset)
       end
 
-      # Create an {Cucumber::Ast::DocString} object
-      #
-      # Useful in conjunction with the #step method, when
-      # want to specify a content type.
-      # @example Create a multiline string
-      #   code = multiline_string(%{
-      #     puts "this is ruby code"
-      #   %}, 'ruby')
-      def doc_string(string_without_triple_quotes, content_type='', line_offset=0)
-        # TODO: rename this method to multiline_string
-        @__cucumber_runtime.doc_string(string_without_triple_quotes, content_type, line_offset)
-      end
-
       # @deprecated Use {#puts} instead.
       def announce(*messages)
         STDERR.puts AnsiEscapes.failed + "WARNING: #announce is deprecated. Use #puts instead:" + caller[0] + AnsiEscapes.reset
@@ -89,7 +76,7 @@ module Cucumber
       # @note Cucumber might surprise you with the behaviour of this method. Instead
       #   of sending the output directly to STDOUT, Cucumber will intercept and cache
       #   the message until the current step has finished, and then display it.
-      #   
+      #
       #   If you'd prefer to see the message immediately, call {Kernel.puts} instead.
       def puts(*messages)
         @__cucumber_runtime.puts(*messages)

--- a/lib/cucumber/rb_support/rb_world.rb
+++ b/lib/cucumber/rb_support/rb_world.rb
@@ -65,6 +65,20 @@ module Cucumber
         @__cucumber_runtime.table(text_or_table, file, line_offset)
       end
 
+      # Create an {Cucumber::Ast::DocString} object
+      #
+      # Useful in conjunction with the #step method, when
+      # want to specify a content type.
+      # @example Create a multiline string
+      #   code = multiline_string(%{
+      #     puts "this is ruby code"
+      #   %}, 'ruby')
+      def doc_string(string_without_triple_quotes, content_type='', line_offset=0)
+        STDERR.puts AnsiEscapes.failed + "WARNING: #doc_string is deprecated. Just pass a regular String instead:" + caller[0] + AnsiEscapes.reset
+        # TODO: rename this method to multiline_string
+        @__cucumber_runtime.doc_string(string_without_triple_quotes, content_type, line_offset)
+      end
+
       # @deprecated Use {#puts} instead.
       def announce(*messages)
         STDERR.puts AnsiEscapes.failed + "WARNING: #announce is deprecated. Use #puts instead:" + caller[0] + AnsiEscapes.reset


### PR DESCRIPTION
With this patch, `DocString` objects are now true `String` objects, and not a `Cucumber::MultilineArgument::DocString` object.

I understand that the intention with `Cucumber::MultilineArgument::DocString` is that it behaves just like a `String`, but it doesn't. For example, `expect(some_string).to eq(some_doc_string)` causes an unreadable error message with a `DocString`, but a nice one (with a diff) for a `String`.

Furthermore, `DocString` is an implementation detail of Cucumber that users shouldn't be concerned with. In DDD speak, these are two (or perhaps three) different bounded contexts: Parsing, (Execution) and user code.

A side-effect of this change is that the `content_type` attribute is no longer available. That's fine - I can't think of a reason why users would need this. The `content_type` is purely intended for tools that _render_ Gherkin, and I'm not aware of any tools using it yet.

When those tools exist, the Gherkin3 library should be used to parse the Gherkin document (without Cucumber), and the `content_type` will be available from the [Gherkin3 AST](https://github.com/cucumber/gherkin3#ast).

Finally, I removed the `doc_string` method from `World` - it's not needed, as passing a plain `String` is sufficient.