### PR TITLE
Backport a version of Ruby > 2 Hash method

### DIFF
--- a/lib/cucumber.rb
+++ b/lib/cucumber.rb
@@ -26,5 +26,18 @@ module Cucumber
       called_by = caller[1]
       warn("Deprecated: #{class_name}##{method} #{message}. Caller: #{called_by}")
     end
+
+    if Cucumber::RUBY_1_9
+      # Backported from Ruby 2.0 to 1.9
+      def Hash(other)
+        return {} if other.nil? || other == []
+        raise TypeError, "can't convert #{other.class} into Hash" unless other.respond_to?(:to_hash)
+        other.to_hash
+      end
+    else
+      def Hash(other)
+        Kernel::Hash(other)
+      end
+    end
   end
 end

--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -114,7 +114,7 @@ module Cucumber
       end
 
       def to_hash
-        Hash.try_convert(@options).merge(out_stream: @out_stream, error_stream: @error_stream)
+        Cucumber::Hash(@options).merge(out_stream: @out_stream, error_stream: @error_stream)
       end
 
       private

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -294,7 +294,7 @@ TEXT
       end
 
       def to_hash
-        Hash.try_convert(@options)
+        Cucumber::Hash(@options)
       end
 
     protected

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -28,7 +28,7 @@ module Cucumber
     def_instance_delegator :event_bus, :notify
 
     def initialize(user_options = {})
-      @options = default_options.merge(Hash.try_convert(user_options))
+      @options = default_options.merge(Cucumber::Hash(user_options))
     end
 
     def with_options(new_options)

--- a/spec/cucumber_spec.rb
+++ b/spec/cucumber_spec.rb
@@ -1,0 +1,39 @@
+require 'cucumber'
+
+describe Cucumber do
+
+  # Implementation is backported from ruby 2.0 when cucumber is used on ruby 1.9.
+  # The tests will run on all implementations to ensure we have the same
+  # feature set.
+  describe 'Hash' do
+    it "converts nil to empty {}" do
+      expect(Cucumber::Hash(nil)).to eq({})
+    end
+
+    it "converts [] to {}" do
+      expect(Cucumber::Hash([])).to eq({})
+    end
+
+    it "converts a hash to an equivalent hash" do
+      original = {:a => 1, :b => 2}
+      expect(Cucumber::Hash(original)).to eq({a: 1, b: 2})
+    end
+
+    it "converts an object with a to_hash method" do
+      original = Object.new
+      def original.to_hash
+        {key: "value"}
+      end
+
+      expect(Cucumber::Hash(original)).to eq({key: "value"})
+    end
+
+    it "raises a TypeError for an object that does not have .to_hash" do
+      original = %w(cannot convert to hash)
+
+      expect { Cucumber::Hash(original) }.to raise_error TypeError
+    end
+  end
+end
+
+


### PR DESCRIPTION
This gives us way to use `Hash(object)` in cucumber including ruby 1.9.

I'm not sure if its a good idea to add this directly to Kernel though? There's a risk someone could use it in their app unknowingly and have passing tests but fail in production when cucumber is not required?

We could instead add an explicit `Cucumber::Hash` method to isolate this change against that?