### PR TITLE
Introduce Event Bus (WIP)

### DIFF
--- a/features/docs/api/listen_for_events.feature
+++ b/features/docs/api/listen_for_events.feature
@@ -1,6 +1,5 @@
 Feature: Listen for events
 
-  @spawn
   Scenario: Step Matched Event
     Given a file named "features/test.feature" with:
       """
@@ -16,11 +15,12 @@ Feature: Listen for events
     And a file named "features/support/my_listener.rb" with:
       """
       AfterConfiguration do |config|
+        io = config.out_stream
         config.on_event Cucumber::Events::StepMatch do |event|
-          puts "Success!"
-          puts "Event type:      #{event.class}"
-          puts "Step name:       #{event.test_step.name}"
-          puts "Source location: #{event.step_match.location}"
+          io.puts "Success!"
+          io.puts "Event type:      #{event.class}"
+          io.puts "Step name:       #{event.test_step.name}"
+          io.puts "Source location: #{event.step_match.location}"
         end
       end
       """

--- a/features/docs/api/listen_for_events.feature
+++ b/features/docs/api/listen_for_events.feature
@@ -16,7 +16,7 @@ Feature: Listen for events
     And a file named "features/support/my_listener.rb" with:
       """
       AfterConfiguration do |config|
-        config.on_event :step_match do |event|
+        config.on_event Cucumber::Events::StepMatch do |event|
           puts "Success!"
           puts "Event type:      #{event.class}"
           puts "Step name:       #{event.test_step.name}"

--- a/features/docs/api/listen_for_events.feature
+++ b/features/docs/api/listen_for_events.feature
@@ -32,3 +32,27 @@ Feature: Listen for events
       Step name:       matching
       Source location: features/step_definitions/steps.rb:1
       """
+
+  Scenario: After Test Step event
+    Given a file named "features/test.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given passing
+      """
+    And the standard step definitions
+    And a file named "features/support/my_listener.rb" with:
+      """
+      AfterConfiguration do |config|
+        io = config.out_stream
+        config.on_event Cucumber::Events::AfterTestStep do |event|
+          io.puts "YO"
+        end
+      end
+      """
+    When I run `cucumber`
+    Then it should pass with:
+      """
+      YO
+      """
+

--- a/features/docs/api/listen_for_events.feature
+++ b/features/docs/api/listen_for_events.feature
@@ -5,7 +5,7 @@ Feature: Listen for events
       """
       Feature:
         Scenario:
-        Given matching
+          Given matching
       """
     And a file named "features/steps_definitions/steps.rb" with:
       """

--- a/features/docs/api/listen_for_events.feature
+++ b/features/docs/api/listen_for_events.feature
@@ -1,0 +1,30 @@
+Feature: Listen for events
+
+  Scenario: Step Matched Event
+    Given a file named "features/test.feature" with:
+      """
+      Feature:
+        Scenario:
+        Given matching
+      """
+    And a file named "features/steps_definitions/steps.rb" with:
+      """
+      Given(/matching/) do
+      end
+      """
+    And a file named "features/support/my_listener.rb" with:
+      """
+      AfterConfiguration do |config|
+        config.on_event :step_match do |event|
+          puts "Success!"
+          expect(event).to be_a(Cucumber::Events::StepMatch)
+          expect(event.test_step.name).to eq "passing"
+          expect(event.step_match.regexp_source.location.to_s).to eq "features/step_definitions/steps.rb:1"
+        end
+      end
+      """
+    When I run `cucumber`
+    Then it should pass with:
+      """
+      Success!
+      """

--- a/features/docs/api/listen_for_events.feature
+++ b/features/docs/api/listen_for_events.feature
@@ -1,5 +1,6 @@
 Feature: Listen for events
 
+  @spawn
   Scenario: Step Matched Event
     Given a file named "features/test.feature" with:
       """
@@ -7,7 +8,7 @@ Feature: Listen for events
         Scenario:
           Given matching
       """
-    And a file named "features/steps_definitions/steps.rb" with:
+    And a file named "features/step_definitions/steps.rb" with:
       """
       Given(/matching/) do
       end
@@ -17,9 +18,9 @@ Feature: Listen for events
       AfterConfiguration do |config|
         config.on_event :step_match do |event|
           puts "Success!"
-          expect(event).to be_a(Cucumber::Events::StepMatch)
-          expect(event.test_step.name).to eq "passing"
-          expect(event.step_match.regexp_source.location.to_s).to eq "features/step_definitions/steps.rb:1"
+          puts "Event type:      #{event.class}"
+          puts "Step name:       #{event.test_step.name}"
+          puts "Source location: #{event.step_match.location}"
         end
       end
       """
@@ -27,4 +28,7 @@ Feature: Listen for events
     Then it should pass with:
       """
       Success!
+      Event type:      Cucumber::Events::StepMatch
+      Step name:       matching
+      Source location: features/step_definitions/steps.rb:1
       """

--- a/features/docs/extending_cucumber/custom_formatter.feature
+++ b/features/docs/extending_cucumber/custom_formatter.feature
@@ -9,13 +9,47 @@ Feature: Custom Formatter
       """
     And the standard step definitions
 
-  Scenario: Use the new API
+  Scenario: Subscribe to result events
+
+    This is the recommended way to format output.
+
     Given a file named "features/support/custom_formatter.rb" with:
       """
       module MyCustom
         class Formatter
-          def initialize(runtime, io, options)
-            @io = io
+          def initialize(config)
+            @io = config.out_stream
+            config.on_event Cucumber::Events::BeforeTestCase do |event|
+              print_test_case_name(event.test_case)
+            end
+          end
+
+          def print_test_case_name(test_case)
+            feature = test_case.source.first
+            scenario = test_case.source.last
+            @io.puts feature.short_name.upcase
+            @io.puts "  #{scenario.name.upcase}"
+          end
+        end
+      end
+      """
+    When I run `cucumber features/f.feature --format MyCustom::Formatter`
+    Then it should pass with exactly:
+      """
+      I'LL USE MY OWN
+        JUST PRINT ME
+
+      """
+
+  Scenario: Implement v2.0 formatter methods
+    Note that this method is likely to be deprecated in favour of events - see above.
+
+    Given a file named "features/support/custom_formatter.rb" with:
+      """
+      module MyCustom
+        class Formatter
+          def initialize(config)
+            @io = config.out_stream
           end
 
           def before_test_case(test_case)
@@ -36,6 +70,8 @@ Feature: Custom Formatter
       """
 
   Scenario: Use the legacy API
+    This is deprecated and should no longer be used.
+
     Given a file named "features/support/custom_legacy_formatter.rb" with:
       """
       module MyCustom
@@ -62,7 +98,7 @@ Feature: Custom Formatter
 
       """
 
-  Scenario: Use both
+  Scenario: Use both old and new
     You can use a specific shim to opt-in to both APIs at once.
 
     Given a file named "features/support/custom_mixed_formatter.rb" with:

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -1,15 +1,20 @@
 require 'cucumber/constantize'
 require 'cucumber/cli/rerun_file'
+require 'cucumber/events/bus'
 require 'gherkin/tag_expression'
+require 'forwardable'
 
 module Cucumber
   # The base class for configuring settings for a Cucumber run.
   class Configuration
     include Constantize
+    extend Forwardable
 
     def self.default
       new
     end
+
+    delegate :on_event => :event_bus
 
     def initialize(user_options = {})
       @options = default_options.merge(Hash.try_convert(user_options))
@@ -165,10 +170,6 @@ module Cucumber
       end
     end
 
-    def on_event(event_name, &handler)
-
-    end
-
     def to_hash
       @options
     end
@@ -190,9 +191,15 @@ module Cucumber
         :diff_enabled        => true,
         :snippets            => true,
         :source              => true,
-        :duration            => true
+        :duration            => true,
+        :event_bus           => Events::Bus.new
       }
     end
+
+    def event_bus
+      @options[:event_bus]
+    end
+
 
     def default_features_paths
       ["features"]

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -1,6 +1,6 @@
 require 'cucumber/constantize'
 require 'cucumber/cli/rerun_file'
-require 'cucumber/events/bus'
+require 'cucumber/events'
 require 'gherkin/tag_expression'
 require 'forwardable'
 
@@ -18,6 +18,10 @@ module Cucumber
 
     def initialize(user_options = {})
       @options = default_options.merge(Hash.try_convert(user_options))
+    end
+
+    def with_options(new_options)
+      self.class.new(new_options.merge(@options))
     end
 
     # TODO: Actually Deprecate???

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -14,7 +14,7 @@ module Cucumber
       new
     end
 
-    delegate :on_event => :event_bus
+    delegate [:on_event, :notify] => :event_bus
 
     def initialize(user_options = {})
       @options = default_options.merge(Hash.try_convert(user_options))

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -14,7 +14,18 @@ module Cucumber
       new
     end
 
-    delegate [:on_event, :notify] => :event_bus
+    # Subscribe to an event.
+    #
+    # See {Cucumber::Events} for the list of possible events.
+    #
+    # @param event_id [Symbol, Class, String] Identifier for the type of event to subscribe to
+    # @param handler_object [Object optional] an object to be called when the event occurs
+    # @yield [Object] Block to be called when th event occurs
+    # @method on_event
+    def_instance_delegator :event_bus, :register, :on_event
+
+    # @private
+    def_instance_delegator :event_bus, :notify
 
     def initialize(user_options = {})
       @options = default_options.merge(Hash.try_convert(user_options))
@@ -196,7 +207,7 @@ module Cucumber
         :snippets            => true,
         :source              => true,
         :duration            => true,
-        :event_bus           => Events::Bus.new
+        :event_bus           => Events::Bus.new(Cucumber::Events)
       }
     end
 

--- a/lib/cucumber/events.rb
+++ b/lib/cucumber/events.rb
@@ -1,0 +1,3 @@
+Dir[File.dirname(__FILE__) + '/events/*.rb'].each do |event_file|
+  require event_file
+end

--- a/lib/cucumber/events.rb
+++ b/lib/cucumber/events.rb
@@ -1,3 +1,20 @@
-Dir[File.dirname(__FILE__) + '/events/*.rb'].each do |event_file|
-  require event_file
+module Cucumber
+
+  # Events tell you what's happening while Cucumber runs your features.
+  #
+  # They're designed to be read-only, appropriate for writing formatters and other
+  # output tools. If you need to be able to influence the result of a scenario, use a hook instead.
+  #
+  # To subscribe to an event, use {Cucumber::Configuration#on_event}
+  #
+  # @example
+  #   AfterConfiguration do |config|
+  #     config.on_event :after_test_step do |event|
+  #       puts event.result
+  #     end
+  #   end
+  module Events
+  end
 end
+
+Dir[File.dirname(__FILE__) + '/events/*.rb'].map(&method(:require))

--- a/lib/cucumber/events/after_test_case.rb
+++ b/lib/cucumber/events/after_test_case.rb
@@ -1,0 +1,11 @@
+module Cucumber
+  module Events
+    class AfterTestCase
+      attr_reader :test_case, :result
+
+      def initialize(test_case, result)
+        @test_case, @result = test_case, result
+      end
+    end
+  end
+end

--- a/lib/cucumber/events/after_test_case.rb
+++ b/lib/cucumber/events/after_test_case.rb
@@ -1,11 +1,25 @@
 module Cucumber
   module Events
-    class AfterTestCase
-      attr_reader :test_case, :result
 
+    # Event fired after a test case has finished executing
+    class AfterTestCase
+
+      # The test case that was just executed.
+      #
+      # @return [Cucumber::Core::Test::Case]
+      attr_reader :test_case
+
+      # The result of executing the test case.
+      #
+      # @return [Cucumber::Core::Test::Result]
+      attr_reader :result
+
+      # @private
       def initialize(test_case, result)
         @test_case, @result = test_case, result
       end
+
     end
+
   end
 end

--- a/lib/cucumber/events/after_test_step.rb
+++ b/lib/cucumber/events/after_test_step.rb
@@ -1,0 +1,11 @@
+module Cucumber
+  module Events
+    class AfterTestStep
+      attr_reader :test_case, :test_step, :result
+
+      def initialize(test_case, test_step, result)
+        @test_case, @test_step, @result = test_case, test_step, result
+      end
+    end
+  end
+end

--- a/lib/cucumber/events/after_test_step.rb
+++ b/lib/cucumber/events/after_test_step.rb
@@ -1,11 +1,30 @@
 module Cucumber
   module Events
-    class AfterTestStep
-      attr_reader :test_case, :test_step, :result
 
+    # Event fired after each test step has been executed
+    class AfterTestStep
+
+      # The test case currently being executed.
+      #
+      # @return [Cucumber::Core::Test::Case]
+      attr_reader :test_case
+
+      # The test step that was just executed.
+      #
+      # @return [Cucumber::Core::Test::Step]
+      attr_reader :test_step
+
+      # The result of executing the test step.
+      #
+      # @return [Cucumber::Core::Test::Result]
+      attr_reader :result
+
+      # @private
       def initialize(test_case, test_step, result)
         @test_case, @test_step, @result = test_case, test_step, result
       end
+
     end
+
   end
 end

--- a/lib/cucumber/events/before_test_case.rb
+++ b/lib/cucumber/events/before_test_case.rb
@@ -1,0 +1,11 @@
+module Cucumber
+  module Events
+    class BeforeTestCase
+      attr_reader :test_case
+
+      def initialize(test_case)
+        @test_case = test_case
+      end
+    end
+  end
+end

--- a/lib/cucumber/events/before_test_case.rb
+++ b/lib/cucumber/events/before_test_case.rb
@@ -1,8 +1,15 @@
 module Cucumber
   module Events
+
+    # Event fired before a test case is executed
     class BeforeTestCase
+
+      # The test case about to be executed.
+      #
+      # @return [Cucumber::Core::Test::Case]
       attr_reader :test_case
 
+      # @private
       def initialize(test_case)
         @test_case = test_case
       end

--- a/lib/cucumber/events/before_test_step.rb
+++ b/lib/cucumber/events/before_test_step.rb
@@ -1,0 +1,11 @@
+module Cucumber
+  module Events
+    class BeforeTestStep
+      attr_reader :test_case, :test_step
+
+      def initialize(test_case, test_step)
+        @test_case, @test_step = test_case, test_step
+      end
+    end
+  end
+end

--- a/lib/cucumber/events/before_test_step.rb
+++ b/lib/cucumber/events/before_test_step.rb
@@ -1,8 +1,20 @@
 module Cucumber
   module Events
-    class BeforeTestStep
-      attr_reader :test_case, :test_step
 
+    # Event fired before a test step is executed
+    class BeforeTestStep
+
+      # The test case currently being executed.
+      #
+      # @return [Cucumber::Core::Test::Case]
+      attr_reader :test_case
+
+      # The test step about to be executed.
+      #
+      # @return [Cucumber::Core::Test::Step]
+      attr_reader :test_step
+
+      # @private
       def initialize(test_case, test_step)
         @test_case, @test_step = test_case, test_step
       end

--- a/lib/cucumber/events/bus.rb
+++ b/lib/cucumber/events/bus.rb
@@ -1,8 +1,19 @@
 module Cucumber
   module Events
     class Bus
-      def on_event(event_name, &handler)
+      def initialize
+        @handlers = Hash.new(UnknownEventHandler)
       end
+
+      def on_event(event_name, &handler)
+        @handlers[event_name] = handler
+      end
+
+      def notify(event_name, payload)
+        @handlers[event_name].call(payload)
+      end
+
+      UnknownEventHandler = ->(event) {}
     end
   end
 end

--- a/lib/cucumber/events/bus.rb
+++ b/lib/cucumber/events/bus.rb
@@ -5,9 +5,10 @@ module Cucumber
         @handlers = {}
       end
 
-      def on_event(event_class, handler_object = nil, &handler_proc)
+      def on_event(event_id, handler_object = nil, &handler_proc)
         handler = handler_proc || handler_object
         raise ArgumentError.new("Please pass either an object or a handler block") unless handler
+        event_class = parse_event_id(event_id)
         handlers_for(event_class) << handler
       end
 
@@ -19,6 +20,21 @@ module Cucumber
 
       def handlers_for(event_class)
         @handlers[event_class.to_s] ||= []
+      end
+
+      def parse_event_id(event_id)
+        case event_id
+        when Class
+          return event_id
+        when String
+          return Object.const_get(event_id)
+        else
+          Object.const_get("Cucumber::Events::#{camel_case(event_id)}")
+        end
+      end
+
+      def camel_case(underscored_name)
+        underscored_name.to_s.split("_").map { |word| word.upcase[0] + word[1..-1] }.join
       end
 
     end

--- a/lib/cucumber/events/bus.rb
+++ b/lib/cucumber/events/bus.rb
@@ -5,7 +5,9 @@ module Cucumber
         @handlers = {}
       end
 
-      def on_event(event_class, &handler)
+      def on_event(event_class, handler_object = nil, &handler_proc)
+        handler = handler_proc || handler_object
+        raise ArgumentError.new("Please pass either an object or a handler block") unless handler
         handlers_for(event_class) << handler
       end
 
@@ -16,7 +18,7 @@ module Cucumber
       private
 
       def handlers_for(event_class)
-        @handlers[event_class] ||= []
+        @handlers[event_class.to_s] ||= []
       end
 
     end

--- a/lib/cucumber/events/bus.rb
+++ b/lib/cucumber/events/bus.rb
@@ -1,0 +1,8 @@
+module Cucumber
+  module Events
+    class Bus
+      def on_event(event_name, &handler)
+      end
+    end
+  end
+end

--- a/lib/cucumber/events/bus.rb
+++ b/lib/cucumber/events/bus.rb
@@ -5,12 +5,12 @@ module Cucumber
         @handlers = Hash.new(UnknownEventHandler)
       end
 
-      def on_event(event_name, &handler)
-        @handlers[event_name] = handler
+      def on_event(event_type, &handler)
+        @handlers[event_type] = handler
       end
 
-      def notify(event_name, payload)
-        @handlers[event_name].call(payload)
+      def notify(event)
+        @handlers[event.class].call(event)
       end
 
       UnknownEventHandler = ->(event) {}

--- a/lib/cucumber/events/bus.rb
+++ b/lib/cucumber/events/bus.rb
@@ -2,18 +2,23 @@ module Cucumber
   module Events
     class Bus
       def initialize
-        @handlers = Hash.new(UnknownEventHandler)
+        @handlers = {}
       end
 
-      def on_event(event_type, &handler)
-        @handlers[event_type] = handler
+      def on_event(event_class, &handler)
+        handlers_for(event_class) << handler
       end
 
       def notify(event)
-        @handlers[event.class].call(event)
+        handlers_for(event.class).each { |handler| handler.call(event) }
       end
 
-      UnknownEventHandler = ->(event) {}
+      private
+
+      def handlers_for(event_class)
+        @handlers[event_class] ||= []
+      end
+
     end
   end
 end

--- a/lib/cucumber/events/bus.rb
+++ b/lib/cucumber/events/bus.rb
@@ -38,14 +38,47 @@ module Cucumber
         when Class
           return event_id
         when String
-          return Object.const_get(event_id)
+          constantize(event_id)
         else
-          Object.const_get("#{@default_namespace}::#{camel_case(event_id)}")
+          constantize("#{@default_namespace}::#{camel_case(event_id)}")
         end
       end
 
       def camel_case(underscored_name)
         underscored_name.to_s.split("_").map { |word| word.upcase[0] + word[1..-1] }.join
+      end
+
+      # Thanks ActiveSupport
+      # (Only needed to support Ruby 1.9.3 and JRuby)
+      def constantize(camel_cased_word)
+        names = camel_cased_word.split('::')
+
+        # Trigger a built-in NameError exception including the ill-formed constant in the message.
+        Object.const_get(camel_cased_word) if names.empty?
+
+        # Remove the first blank element in case of '::ClassName' notation.
+        names.shift if names.size > 1 && names.first.empty?
+
+        names.inject(Object) do |constant, name|
+          if constant == Object
+            constant.const_get(name)
+          else
+            candidate = constant.const_get(name)
+            next candidate if constant.const_defined?(name, false)
+            next candidate unless Object.const_defined?(name)
+
+            # Go down the ancestors to check if it is owned directly. The check
+            # stops when we reach Object or the end of ancestors tree.
+            constant = constant.ancestors.inject do |const, ancestor|
+              break const    if ancestor == Object
+              break ancestor if ancestor.const_defined?(name, false)
+              const
+            end
+
+            # owner is in Object, so raise
+            constant.const_get(name, false)
+          end
+        end
       end
 
     end

--- a/lib/cucumber/events/step_match.rb
+++ b/lib/cucumber/events/step_match.rb
@@ -1,0 +1,11 @@
+module Cucumber
+  module Events
+    class StepMatch
+      attr_reader :test_step, :step_match
+
+      def initialize(test_step, step_match)
+        @test_step, @step_match = test_step, step_match
+      end
+    end
+  end
+end

--- a/lib/cucumber/events/step_match.rb
+++ b/lib/cucumber/events/step_match.rb
@@ -1,8 +1,20 @@
 module Cucumber
   module Events
-    class StepMatch
-      attr_reader :test_step, :step_match
 
+    # Event fired when a step is matched to a definition
+    class StepMatch
+
+      # The test step that was matched.
+      #
+      # @return [Cucumber::Core::Test::Step]
+      attr_reader :test_step
+
+      # Information about the matching definition.
+      #
+      # @return [Cucumber::StepMatch]
+      attr_reader :step_match
+
+      # @private
       def initialize(test_step, step_match)
         @test_step, @step_match = test_step, step_match
       end

--- a/lib/cucumber/formatter/event_bus_report.rb
+++ b/lib/cucumber/formatter/event_bus_report.rb
@@ -1,0 +1,34 @@
+module Cucumber
+  module Formatter
+
+    # Adapter between Cucumber::Core::Test::Runner's Report API and 
+    # Cucumber's event bus
+    class EventBusReport
+      attr_reader :config
+      private :config
+
+      def initialize(config)
+        @config = config
+      end
+
+      def before_test_case(test_case)
+        @config.notify Events::BeforeTestCase.new(test_case)
+        @test_case = test_case
+      end
+
+      def before_test_step(test_step)
+        @config.notify Events::BeforeTestStep.new(@test_case, test_step)
+      end
+
+      def after_test_step(test_step, result)
+        @config.notify Events::AfterTestStep.new(@test_case, test_step, result)
+      end
+
+      def after_test_case(test_case, result)
+        @config.notify Events::AfterTestCase.new(test_case, result)
+      end
+    end
+
+  end
+end
+

--- a/lib/cucumber/formatter/io.rb
+++ b/lib/cucumber/formatter/io.rb
@@ -1,6 +1,8 @@
 module Cucumber
   module Formatter
     module Io
+      module_function
+
       def ensure_io(path_or_io)
         return nil if path_or_io.nil?
         return path_or_io if path_or_io.respond_to?(:write)

--- a/lib/cucumber/formatter/usage.rb
+++ b/lib/cucumber/formatter/usage.rb
@@ -16,12 +16,16 @@ module Cucumber
         @options = options
         @stepdef_to_match = Hash.new { |h, stepdef_key| h[stepdef_key] = [] }
         @total_duration = 0
+        @matches = {}
+        runtime.configuration.on_event :step_match do |event|
+          @matches[event.test_step.source] = event.step_match
+        end
       end
 
       def after_test_step(test_step, result)
         return if HookQueryVisitor.new(test_step).hook?
 
-        step_match = @runtime.step_match(test_step.source.last.name)
+        step_match = @matches[test_step.source]
         step_definition = step_match.step_definition
         stepdef_key = StepDefKey.new(step_definition.regexp_source, step_definition.location)
         unless @stepdef_to_match[stepdef_key].map { |key| key[:location] }.include? test_step.location

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -87,10 +87,6 @@ module Cucumber
       @results.steps(status)
     end
 
-    def step_match(step_name, name_to_report=nil) #:nodoc:
-      @support_code.step_match(step_name, name_to_report)
-    end
-
     def unmatched_step_definitions
       @support_code.unmatched_step_definitions
     end

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -139,7 +139,7 @@ module Cucumber
         rescue Cucumber::Undefined
           return NoStepMatch.new(test_step.source.last, test_step.name)
         end
-        @configuration.notify :step_match, Events::StepMatch.new(test_step, match)
+        @configuration.notify Events::StepMatch.new(test_step, match)
         if @configuration.dry_run?
           return SkippingStepMatch.new
         end

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -3,6 +3,7 @@ require 'cucumber/runtime/for_programming_languages'
 require 'cucumber/runtime/step_hooks'
 require 'cucumber/runtime/before_hooks'
 require 'cucumber/runtime/after_hooks'
+require 'cucumber/events/step_match'
 
 module Cucumber
 
@@ -138,6 +139,7 @@ module Cucumber
         rescue Cucumber::Undefined
           return NoStepMatch.new(test_step.source.last, test_step.name)
         end
+        @configuration.notify :step_match, Events::StepMatch.new(test_step, match)
         if @configuration.dry_run?
           return SkippingStepMatch.new
         end

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -139,6 +139,7 @@ module Cucumber
         rescue Cucumber::Undefined
           return NoStepMatch.new(test_step.source.last, test_step.name)
         end
+        # TODO: move this onto Filters::ActivateSteps
         @configuration.notify Events::StepMatch.new(test_step, match)
         if @configuration.dry_run?
           return SkippingStepMatch.new

--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -60,10 +60,6 @@ module Cucumber
       location.to_s
     end
 
-    def location
-      Core::Ast::Location.new(file_colon_line)
-    end
-
     def backtrace_line
       "#{file_colon_line}:in `#{@step_definition.regexp_source}'"
     end

--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -60,6 +60,10 @@ module Cucumber
       location.to_s
     end
 
+    def location
+      Core::Ast::Location.new(file_colon_line)
+    end
+
     def backtrace_line
       "#{file_colon_line}:in `#{@step_definition.regexp_source}'"
     end

--- a/spec/cucumber/cli/main_spec.rb
+++ b/spec/cucumber/cli/main_spec.rb
@@ -66,27 +66,6 @@ module Cucumber
         end
       end
 
-      describe "--format with class" do
-        describe "in module" do
-          let(:double_module) { double('module') }
-          let(:formatter) { double('formatter') }
-
-          it "resolves each module until it gets Formatter class" do
-            cli = Main.new(%w{--format ZooModule::MonkeyFormatterClass}, stdin, stdout, stderr, kernel)
-
-            allow(Object).to receive(:const_defined?) { true }
-            allow(double_module).to receive(:const_defined?) { true }
-
-            expect(Object).to receive(:const_get).with('ZooModule', false) { double_module }
-            expect(double_module).to receive(:const_get).with('MonkeyFormatterClass', false) { double('formatter class', :new => formatter) }
-
-            expect(kernel).to receive(:exit).with(0)
-
-            cli.execute!
-          end
-        end
-      end
-
       [ProfilesNotDefinedError, YmlLoadError, ProfileNotFound].each do |exception_klass|
         it "rescues #{exception_klass}, prints the message to the error stream" do
           configuration = double('configuration')

--- a/spec/cucumber/configuration_spec.rb
+++ b/spec/cucumber/configuration_spec.rb
@@ -134,5 +134,13 @@ module Cucumber
       end
     end
 
+    describe "#with_options" do
+      it "returns a copy of the configuration with new options" do
+        new_out_stream = double
+        config = Configuration.new.with_options(out_stream: new_out_stream)
+        expect(config.out_stream).to eq new_out_stream
+      end
+    end
+
   end
 end

--- a/spec/cucumber/configuration_spec.rb
+++ b/spec/cucumber/configuration_spec.rb
@@ -113,26 +113,25 @@ module Cucumber
         expect(configuration.feature_files).to eq ["cucumber.feature"]
       end
 
-    end
+      it "gets the feature files from the rerun file" do
+        allow(File).to receive(:directory?).and_return(false)
+        allow(File).to receive(:file?).and_return(true)
+        allow(IO).to receive(:read).and_return(
+          "cucumber.feature:1:3\ncucumber.feature:5 cucumber.feature:10\n"\
+          "domain folder/different cuke.feature:134 domain folder/cuke.feature:1\n"\
+          "domain folder/different cuke.feature:4:5 bar.feature")
 
-    it "gets the feature files from the rerun file" do
-      allow(File).to receive(:directory?).and_return(false)
-      allow(File).to receive(:file?).and_return(true)
-      allow(IO).to receive(:read).and_return(
-        "cucumber.feature:1:3\ncucumber.feature:5 cucumber.feature:10\n"\
-        "domain folder/different cuke.feature:134 domain folder/cuke.feature:1\n"\
-        "domain folder/different cuke.feature:4:5 bar.feature")
+        configuration = Configuration.new(paths: %w{@rerun.txt})
 
-      configuration = Configuration.new(paths: %w{@rerun.txt})
-
-      expect(configuration.feature_files).to eq [
-        "cucumber.feature:1:3",
-        "cucumber.feature:5",
-        "cucumber.feature:10",
-        "domain folder/different cuke.feature:134",
-        "domain folder/cuke.feature:1",
-        "domain folder/different cuke.feature:4:5",
-        "bar.feature"]
+        expect(configuration.feature_files).to eq [
+          "cucumber.feature:1:3",
+          "cucumber.feature:5",
+          "cucumber.feature:10",
+          "domain folder/different cuke.feature:134",
+          "domain folder/cuke.feature:1",
+          "domain folder/different cuke.feature:4:5",
+          "bar.feature"]
+      end
     end
 
   end

--- a/spec/cucumber/events/bus_spec.rb
+++ b/spec/cucumber/events/bus_spec.rb
@@ -61,6 +61,17 @@ module Cucumber
         expect(received_payload).to eq(test_event)
       end
 
+      it "allows subscription by symbol (for events in the Cucumber::Events namespace)" do
+        received_payload = nil
+        bus.on_event(:test_event) do |event|
+          received_payload = event
+        end
+
+        bus.notify test_event
+
+        expect(received_payload).to eq(test_event)
+      end
+
       it "allows handlers that are objects with a `call` method" do
         class MyHandler
           attr_reader :received_payload
@@ -77,6 +88,7 @@ module Cucumber
 
         expect(handler.received_payload).to eq test_event
       end
+
     end
   end
 end

--- a/spec/cucumber/events/bus_spec.rb
+++ b/spec/cucumber/events/bus_spec.rb
@@ -10,36 +10,33 @@ module Cucumber
       end
 
       let(:bus) { Bus.new }
+      let(:test_event) { TestEvent.new }
+      let(:another_test_event) { AnotherTestEvent.new }
 
-      it "calls named handler with event payload" do
-        event = TestEvent.new
-
+      it "calls subscriber with event payload" do
         received_payload = nil
         bus.on_event(TestEvent) do |event|
           received_payload = event
         end
 
-        bus.notify event
+        bus.notify test_event
 
-        expect(received_payload).to eq(event)
+        expect(received_payload).to eq(test_event)
       end
 
-      it "does not call for different event" do
-        event = AnotherTestEvent.new
-
+      it "does not call subscribers for other events" do
         handler_called = false
         bus.on_event(TestEvent) do |event|
           handler_called = true
         end
 
-        bus.notify event
+        bus.notify another_test_event
 
         expect(handler_called).to eq(false)
       end
 
       it "broadcasts to multiple subscribers" do
         received_events = []
-
         bus.on_event(TestEvent) do |event|
           received_events << event
         end
@@ -47,9 +44,38 @@ module Cucumber
           received_events << event
         end
 
-        bus.notify TestEvent.new
+        bus.notify test_event
 
         expect(received_events.length).to eq 2
+        expect(received_events).to all eq test_event
+      end
+
+      it "allows subscription by string" do
+        received_payload = nil
+        bus.on_event('Cucumber::Events::TestEvent') do |event|
+          received_payload = event
+        end
+
+        bus.notify test_event
+
+        expect(received_payload).to eq(test_event)
+      end
+
+      it "allows handlers that are objects with a `call` method" do
+        class MyHandler
+          attr_reader :received_payload
+
+          def call(event)
+            @received_payload = event
+          end
+        end
+
+        handler = MyHandler.new
+        bus.on_event(TestEvent, handler)
+
+        bus.notify test_event
+
+        expect(handler.received_payload).to eq test_event
       end
     end
   end

--- a/spec/cucumber/events/bus_spec.rb
+++ b/spec/cucumber/events/bus_spec.rb
@@ -1,0 +1,34 @@
+require "cucumber/events/bus"
+
+module Cucumber
+  module Events
+    describe Bus do
+      it "calls named handler with event payload" do
+        bus = Bus.new
+        payload = double(:an_event)
+
+        received_payload = nil
+        bus.on_event(:abcd1234) do |event|
+          received_payload = event
+        end
+
+        bus.notify(:abcd1234, payload)
+
+        expect(received_payload).to eq(payload)
+      end
+
+      it "does not call for different event" do
+        bus = Bus.new
+
+        handler_called = false
+        bus.on_event(:abcd1234) do |event|
+          handler_called = true
+        end
+
+        bus.notify(:xyz987, double(:payload))
+
+        expect(handler_called).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/cucumber/events/bus_spec.rb
+++ b/spec/cucumber/events/bus_spec.rb
@@ -3,29 +3,36 @@ require "cucumber/events/bus"
 module Cucumber
   module Events
     describe Bus do
+      class TestEvent
+      end
+
+      class AnotherTestEvent
+      end
+
       it "calls named handler with event payload" do
         bus = Bus.new
-        payload = double(:an_event)
+        event = TestEvent.new
 
         received_payload = nil
-        bus.on_event(:abcd1234) do |event|
+        bus.on_event(TestEvent) do |event|
           received_payload = event
         end
 
-        bus.notify(:abcd1234, payload)
+        bus.notify event
 
-        expect(received_payload).to eq(payload)
+        expect(received_payload).to eq(event)
       end
 
       it "does not call for different event" do
         bus = Bus.new
+        event = AnotherTestEvent.new
 
         handler_called = false
-        bus.on_event(:abcd1234) do |event|
+        bus.on_event(TestEvent) do |event|
           handler_called = true
         end
 
-        bus.notify(:xyz987, double(:payload))
+        bus.notify event
 
         expect(handler_called).to eq(false)
       end

--- a/spec/cucumber/events/bus_spec.rb
+++ b/spec/cucumber/events/bus_spec.rb
@@ -9,8 +9,9 @@ module Cucumber
       class AnotherTestEvent
       end
 
+      let(:bus) { Bus.new }
+
       it "calls named handler with event payload" do
-        bus = Bus.new
         event = TestEvent.new
 
         received_payload = nil
@@ -24,7 +25,6 @@ module Cucumber
       end
 
       it "does not call for different event" do
-        bus = Bus.new
         event = AnotherTestEvent.new
 
         handler_called = false
@@ -35,6 +35,21 @@ module Cucumber
         bus.notify event
 
         expect(handler_called).to eq(false)
+      end
+
+      it "broadcasts to multiple subscribers" do
+        received_events = []
+
+        bus.on_event(TestEvent) do |event|
+          received_events << event
+        end
+        bus.on_event(TestEvent) do |event|
+          received_events << event
+        end
+
+        bus.notify TestEvent.new
+
+        expect(received_events.length).to eq 2
       end
     end
   end

--- a/spec/cucumber/events/bus_spec.rb
+++ b/spec/cucumber/events/bus_spec.rb
@@ -2,13 +2,13 @@ require "cucumber/events/bus"
 
 module Cucumber
   module Events
+    class TestEvent
+    end
+
+    class AnotherTestEvent
+    end
+
     describe Bus do
-      class TestEvent
-      end
-
-      class AnotherTestEvent
-      end
-
       let(:bus) { Bus.new(Cucumber::Events) }
       let(:test_event) { TestEvent.new }
       let(:another_test_event) { AnotherTestEvent.new }

--- a/spec/cucumber/events/bus_spec.rb
+++ b/spec/cucumber/events/bus_spec.rb
@@ -9,13 +9,13 @@ module Cucumber
       class AnotherTestEvent
       end
 
-      let(:bus) { Bus.new }
+      let(:bus) { Bus.new(Cucumber::Events) }
       let(:test_event) { TestEvent.new }
       let(:another_test_event) { AnotherTestEvent.new }
 
       it "calls subscriber with event payload" do
         received_payload = nil
-        bus.on_event(TestEvent) do |event|
+        bus.register(TestEvent) do |event|
           received_payload = event
         end
 
@@ -26,7 +26,7 @@ module Cucumber
 
       it "does not call subscribers for other events" do
         handler_called = false
-        bus.on_event(TestEvent) do |event|
+        bus.register(TestEvent) do |event|
           handler_called = true
         end
 
@@ -37,10 +37,10 @@ module Cucumber
 
       it "broadcasts to multiple subscribers" do
         received_events = []
-        bus.on_event(TestEvent) do |event|
+        bus.register(TestEvent) do |event|
           received_events << event
         end
-        bus.on_event(TestEvent) do |event|
+        bus.register(TestEvent) do |event|
           received_events << event
         end
 
@@ -52,7 +52,7 @@ module Cucumber
 
       it "allows subscription by string" do
         received_payload = nil
-        bus.on_event('Cucumber::Events::TestEvent') do |event|
+        bus.register('Cucumber::Events::TestEvent') do |event|
           received_payload = event
         end
 
@@ -63,7 +63,7 @@ module Cucumber
 
       it "allows subscription by symbol (for events in the Cucumber::Events namespace)" do
         received_payload = nil
-        bus.on_event(:test_event) do |event|
+        bus.register(:test_event) do |event|
           received_payload = event
         end
 
@@ -82,7 +82,7 @@ module Cucumber
         end
 
         handler = MyHandler.new
-        bus.on_event(TestEvent, handler)
+        bus.register(TestEvent, handler)
 
         bus.notify test_event
 

--- a/spec/cucumber/formatter/event_bus_report_spec.rb
+++ b/spec/cucumber/formatter/event_bus_report_spec.rb
@@ -1,0 +1,79 @@
+require 'cucumber/configuration'
+require 'cucumber/runtime'
+require 'cucumber/formatter/spec_helper'
+require 'cucumber/formatter/event_bus_report'
+
+module Cucumber
+  module Formatter
+    describe EventBusReport do
+      extend SpecHelperDsl
+      include SpecHelper
+
+      context "With no options" do
+        let(:config) { Cucumber::Configuration.new }
+
+        before(:each) do
+          @formatter = EventBusReport.new(config)
+        end
+
+        describe "given a single feature" do
+
+          describe "a scenario with a single passing step" do
+            define_feature <<-FEATURE
+          Feature:
+            Scenario: Test Scenario
+              Given passing
+            FEATURE
+
+            define_steps do
+              Given(/pass/) {}
+            end
+
+            it "emits a BeforeTestCase event" do
+              received_event = nil
+              config.on_event Cucumber::Events::BeforeTestCase do |event|
+                received_event = event
+              end
+              run_defined_feature
+              expect(received_event.test_case.name).to eq "Test Scenario"
+            end
+
+            it "emits a BeforeTestStep event" do
+              received_event = nil
+              config.on_event Cucumber::Events::BeforeTestStep do |event|
+                received_event = event
+              end
+              run_defined_feature
+              expect(received_event.test_case.name).to eq "Test Scenario"
+              expect(received_event.test_step.name).to eq "passing"
+            end
+
+            it "emits an AfterTestStep event with a passed result" do
+              received_event = nil
+              config.on_event Cucumber::Events::AfterTestStep do |event|
+                received_event = event
+              end
+              run_defined_feature
+              expect(received_event.test_case.name).to eq "Test Scenario"
+              expect(received_event.test_step.name).to eq "passing"
+              expect(received_event.result).to be_passed
+            end
+
+            it "emits an AfterTestCase event with a passed result" do
+              received_event = nil
+              config.on_event Cucumber::Events::AfterTestCase do |event|
+                received_event = event
+              end
+              run_defined_feature
+              expect(received_event.test_case.name).to eq "Test Scenario"
+              expect(received_event.result).to be_passed
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+
+


### PR DESCRIPTION
With this change, clients both within the Cucumber codebase and built by our users, can consume events about various things that happen as your tests run.

For example:

  * when a test case finishes
  * when a step definition is matched

This should help us remove some of the ugly coupling between different parts of the code, and allow for more flexiblity in the API for users who want to build formatters and other tools.

Feedback please!

The intention is that this change is backwards compatible, with the idea that it will become the mandatory API for writing formatters from version 3.0