### PR TITLE
Allow Rake task to accept multiple profiles. fixes #905

### DIFF
--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -153,7 +153,7 @@ module Cucumber
       end
 
       def cucumber_opts_with_profile #:nodoc:
-        @profile ? [cucumber_opts, '--profile', @profile] : cucumber_opts
+        @profile ? [cucumber_opts, Array(@profile).flat_map {|p| ["--profile", p] }] : cucumber_opts
       end
 
       def feature_files #:nodoc:

--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -153,7 +153,7 @@ module Cucumber
       end
 
       def cucumber_opts_with_profile #:nodoc:
-        @profile ? [cucumber_opts, Array(@profile).flat_map {|p| ["--profile", p] }] : cucumber_opts
+        Array(cucumber_opts).concat Array(@profile).flat_map {|p| ["--profile", p] }
       end
 
       def feature_files #:nodoc:

--- a/spec/cucumber/rake/task_spec.rb
+++ b/spec/cucumber/rake/task_spec.rb
@@ -20,6 +20,52 @@ module Cucumber
         end
       end
 
+      describe "#cucumber_opts_with_profile" do
+        before do
+          subject.cucumber_opts = opts
+          subject.profile = profile
+        end
+
+        context "with cucumber_opts" do
+          let(:opts) { [ :foo, :bar ] }
+
+          context "without profile" do
+            let(:profile) { nil }
+
+            it "should return just cucumber_opts" do
+              expect(subject.cucumber_opts_with_profile).to be opts
+            end
+          end
+
+          context "with profile" do
+            let(:profile) { "fancy" }
+
+            it "should combine opts and profile into an array, prepending --profile option" do
+              expect(subject.cucumber_opts_with_profile).to eq [ [:foo, :bar], "--profile", "fancy" ]
+            end
+          end
+        end
+
+        context "without cucumber_opts" do
+          let(:opts) { nil }
+
+          context "without profile" do
+            let(:profile) { nil }
+
+            it "should return just cucumber_opts" do
+              expect(subject.cucumber_opts_with_profile).to be opts
+            end
+          end
+
+          context "with profile" do
+            let(:profile) { "fancy" }
+
+            it "should combine opts and profile into an array, prepending --profile option" do
+              expect(subject.cucumber_opts_with_profile).to eq [ nil, "--profile", "fancy" ]
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/cucumber/rake/task_spec.rb
+++ b/spec/cucumber/rake/task_spec.rb
@@ -41,15 +41,15 @@ module Cucumber
             let(:profile) { "fancy" }
 
             it "should combine opts and profile into an array, prepending --profile option" do
-              expect(subject.cucumber_opts_with_profile).to eq [ %w[ foo bar ], "--profile", "fancy" ]
+              expect(subject.cucumber_opts_with_profile).to eq %w[ foo bar --profile fancy ]
             end
           end
 
           context "with multiple profiles" do
             let(:profile) { %w[ fancy pants ] }
 
-            it "should combine opts and profile into an array, prepending --profile option" do
-              expect(subject.cucumber_opts_with_profile).to eq [ %w[ foo bar ], "--profile", "fancy", "--profile", "pants" ]
+            it "should combine opts and each profile into an array, prepending --profile option" do
+              expect(subject.cucumber_opts_with_profile).to eq %w[ foo bar --profile fancy --profile pants ]
             end
           end
         end
@@ -60,24 +60,22 @@ module Cucumber
           context "without profile" do
             let(:profile) { nil }
 
-            it "should return just cucumber_opts" do
-              expect(subject.cucumber_opts_with_profile).to be opts
-            end
+            it { expect(subject.cucumber_opts_with_profile).to eq [] }
           end
 
           context "with profile" do
             let(:profile) { "fancy" }
 
             it "should combine opts and profile into an array, prepending --profile option" do
-              expect(subject.cucumber_opts_with_profile).to eq [ nil, "--profile", "fancy" ]
+              expect(subject.cucumber_opts_with_profile).to eq %w[ --profile fancy ]
             end
           end
 
           context "with multiple profiles" do
             let(:profile) { %w[ fancy pants ] }
 
-            it "should combine opts and profile into an array, prepending --profile option" do
-              expect(subject.cucumber_opts_with_profile).to eq [ nil, "--profile", "fancy", "--profile", "pants" ]
+            it "should combine opts and each profile into an array, prepending --profile option" do
+              expect(subject.cucumber_opts_with_profile).to eq %w[ --profile fancy --profile pants ]
             end
           end
         end

--- a/spec/cucumber/rake/task_spec.rb
+++ b/spec/cucumber/rake/task_spec.rb
@@ -10,13 +10,13 @@ module Cucumber
         before { subject.cucumber_opts = opts }
 
         context "when set via array" do
-          let(:opts) { [ :foo, :bar ] }
+          let(:opts) { %w[ foo bar ] }
           it { expect(subject.cucumber_opts).to be opts }
         end
 
         context "when set via space-delimited string" do
           let(:opts) { "foo bar" }
-          it { expect(subject.cucumber_opts).to eq [ "foo", "bar" ] }
+          it { expect(subject.cucumber_opts).to eq %w[ foo bar ] }
         end
       end
 
@@ -27,7 +27,7 @@ module Cucumber
         end
 
         context "with cucumber_opts" do
-          let(:opts) { [ :foo, :bar ] }
+          let(:opts) { %w[ foo bar ] }
 
           context "without profile" do
             let(:profile) { nil }
@@ -41,7 +41,7 @@ module Cucumber
             let(:profile) { "fancy" }
 
             it "should combine opts and profile into an array, prepending --profile option" do
-              expect(subject.cucumber_opts_with_profile).to eq [ [:foo, :bar], "--profile", "fancy" ]
+              expect(subject.cucumber_opts_with_profile).to eq [ %w[ foo bar ], "--profile", "fancy" ]
             end
           end
         end

--- a/spec/cucumber/rake/task_spec.rb
+++ b/spec/cucumber/rake/task_spec.rb
@@ -44,6 +44,14 @@ module Cucumber
               expect(subject.cucumber_opts_with_profile).to eq [ %w[ foo bar ], "--profile", "fancy" ]
             end
           end
+
+          context "with multiple profiles" do
+            let(:profile) { %w[ fancy pants ] }
+
+            it "should combine opts and profile into an array, prepending --profile option" do
+              expect(subject.cucumber_opts_with_profile).to eq [ %w[ foo bar ], "--profile", "fancy", "--profile", "pants" ]
+            end
+          end
         end
 
         context "without cucumber_opts" do
@@ -62,6 +70,14 @@ module Cucumber
 
             it "should combine opts and profile into an array, prepending --profile option" do
               expect(subject.cucumber_opts_with_profile).to eq [ nil, "--profile", "fancy" ]
+            end
+          end
+
+          context "with multiple profiles" do
+            let(:profile) { %w[ fancy pants ] }
+
+            it "should combine opts and profile into an array, prepending --profile option" do
+              expect(subject.cucumber_opts_with_profile).to eq [ nil, "--profile", "fancy", "--profile", "pants" ]
             end
           end
         end

--- a/spec/cucumber/rake/task_spec.rb
+++ b/spec/cucumber/rake/task_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'cucumber/rake/task'
+require 'rake'
+
+module Cucumber
+  module Rake
+    describe Task do
+
+      describe "#cucumber_opts" do
+        before { subject.cucumber_opts = opts }
+
+        context "when set via array" do
+          let(:opts) { [ :foo, :bar ] }
+          it { expect(subject.cucumber_opts).to be opts }
+        end
+
+        context "when set via space-delimited string" do
+          let(:opts) { "foo bar" }
+          it { expect(subject.cucumber_opts).to eq [ "foo", "bar" ] }
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Tests around the Rake task were already pretty sparse. So tests against existing behavior were added first, then failing tests for the new array support, and finally implementation (and refactoring of tests/implementation).

Can be squashed if desired.