### PR TITLE
Fix Configuration.with_options merge direction

### DIFF
--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -32,7 +32,7 @@ module Cucumber
     end
 
     def with_options(new_options)
-      self.class.new(new_options.merge(@options))
+      self.class.new(@options.merge(new_options))
     end
 
     # TODO: Actually Deprecate???

--- a/spec/cucumber/configuration_spec.rb
+++ b/spec/cucumber/configuration_spec.rb
@@ -136,8 +136,9 @@ module Cucumber
 
     describe "#with_options" do
       it "returns a copy of the configuration with new options" do
-        new_out_stream = double
-        config = Configuration.new.with_options(out_stream: new_out_stream)
+        old_out_stream = double('Old out_stream')
+        new_out_stream = double('New out_stream')
+        config = Configuration.new(out_stream: old_out_stream).with_options(out_stream: new_out_stream)
         expect(config.out_stream).to eq new_out_stream
       end
     end


### PR DESCRIPTION
 Without this change, `factory.new(@configuration.with_options(out_stream: out_stream))` in Cucumber::Runtime#create_formatter doesn't actually changed the `out_stream` from STDOUT in the default configuration because the merge order was `new_options.merge(@options)`, so any keys in both `new_options` and `@options`, like `:out_stream`, would have the value from `@options` win.

The specs weren't catching this problem because `with_options` was being called on `Configuration.new`, which had no keys set.  I changed in spec in 63d4c37 to reveal the bug and fixed it in 067215c.

This bug may have manifested by users unable to override the --out from STDOUT when using new formatters that have `initialize(configuration)` instead of the legacy `initialize/3`