### PR TITLE
Avoid negative `Cucumber::Ast::HasSteps#source_indent`

### DIFF
--- a/lib/cucumber/ast/has_steps.rb
+++ b/lib/cucumber/ast/has_steps.rb
@@ -46,7 +46,7 @@ module Cucumber
       end
 
       def source_indent(text_length)
-        max_line_length - text_length
+        [max_line_length - text_length, 0].max
       end
 
       def max_line_length


### PR DESCRIPTION
Some monkey patched implementations of `String#indent`, such as Active
Support's, do not handle negative values (see issue #620). This behavior
isn't strictly a bug in Cucumber but a lower bound of 0 in
`#source_indent` would mitigate the occurrences of related errors.