### PR TITLE
Refactor event name resolving

### DIFF
--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -212,7 +212,7 @@ module Cucumber
         :snippets            => true,
         :source              => true,
         :duration            => true,
-        :event_bus           => Events::Bus.new(Cucumber::Events)
+        :event_bus           => Events::Bus.new(Events::NameResolver.new(Cucumber::Events))
       }
     end
 

--- a/lib/cucumber/errors.rb
+++ b/lib/cucumber/errors.rb
@@ -48,4 +48,8 @@ module Cucumber
       super(messages.join("\n"))
     end
   end
+
+  # Raised if an event name cannot be resolved
+  class EventNameResolveError < StandardError; end
+  class NoEventError < StandardError; end
 end

--- a/lib/cucumber/events/bus.rb
+++ b/lib/cucumber/events/bus.rb
@@ -1,6 +1,8 @@
+require 'cucumber/events/name_resolver'
+require 'cucumber/errors'
+
 module Cucumber
   module Events
-
     # Event bus
     #
     # Implements and in-process pub-sub events broadcaster allowing multiple observers
@@ -8,79 +10,31 @@ module Cucumber
     #
     # @private
     class Bus
-
-      def initialize(default_namespace)
-        @default_namespace = default_namespace.to_s
-        @handlers = {}
+      def initialize(resolver)
+        @resolver = resolver
+        @handlers = Hash.new { |h, k| h[k] = [] }
       end
 
       # Register for an event
       def register(event_id, handler_object = nil, &handler_proc)
         handler = handler_proc || handler_object
-        raise ArgumentError.new("Please pass either an object or a handler block") unless handler
-        event_class = parse_event_id(event_id)
-        handlers_for(event_class) << handler
+
+        raise ArgumentError, "Please pass either an object#call or a handler block" if handler.nil? || !handler.respond_to?(:call)
+
+        event_class = @resolver.transform(event_id)
+
+        fail EventNameResolveError, %(Transforming "#{event_id}" into an event name failed for unknown reason.) if event_class.nil?
+        @handlers[event_class.to_s] << handler
+
+        nil
       end
 
       # Broadcast an event
       def notify(event)
-        handlers_for(event.class).each { |handler| handler.call(event) }
+        fail NoEventError, 'Please pass an event object, not a class' if event.is_a?(Class)
+
+        @handlers[event.class.to_s].each { |handler| handler.call(event) }
       end
-
-      private
-
-      def handlers_for(event_class)
-        @handlers[event_class.to_s] ||= []
-      end
-
-      def parse_event_id(event_id)
-        case event_id
-        when Class
-          return event_id
-        when String
-          constantize(event_id)
-        else
-          constantize("#{@default_namespace}::#{camel_case(event_id)}")
-        end
-      end
-
-      def camel_case(underscored_name)
-        underscored_name.to_s.split("_").map { |word| word.upcase[0] + word[1..-1] }.join
-      end
-
-      # Thanks ActiveSupport
-      # (Only needed to support Ruby 1.9.3 and JRuby)
-      def constantize(camel_cased_word)
-        names = camel_cased_word.split('::')
-
-        # Trigger a built-in NameError exception including the ill-formed constant in the message.
-        Object.const_get(camel_cased_word) if names.empty?
-
-        # Remove the first blank element in case of '::ClassName' notation.
-        names.shift if names.size > 1 && names.first.empty?
-
-        names.inject(Object) do |constant, name|
-          if constant == Object
-            constant.const_get(name)
-          else
-            candidate = constant.const_get(name)
-            next candidate if constant.const_defined?(name, false)
-            next candidate unless Object.const_defined?(name)
-
-            # Go down the ancestors to check if it is owned directly. The check
-            # stops when we reach Object or the end of ancestors tree.
-            constant = constant.ancestors.inject do |const, ancestor|
-              break const    if ancestor == Object
-              break ancestor if ancestor.const_defined?(name, false)
-              const
-            end
-
-            # owner is in Object, so raise
-            constant.const_get(name, false)
-          end
-        end
-      end
-
     end
   end
 end

--- a/lib/cucumber/events/name_resolver.rb
+++ b/lib/cucumber/events/name_resolver.rb
@@ -1,0 +1,63 @@
+require 'cucumber/errors'
+
+module Cucumber
+  module Events
+    class NameResolver
+      def initialize(default_namespace)
+        @default_namespace = default_namespace
+      end
+
+      def transform(event_id)
+        case event_id
+        when Class
+          event_id
+        when String
+          constantize(event_id)
+        else
+          constantize("#{@default_namespace}::#{camel_case(event_id)}")
+        end
+      rescue => e
+        raise EventNameResolveError, %(Transforming "#{event_id}" into an event class failed: #{e.message}.)
+      end
+
+      private
+
+      def camel_case(underscored_name)
+        underscored_name.to_s.split("_").map { |word| word.upcase[0] + word[1..-1] }.join
+      end
+
+      # Thanks ActiveSupport
+      # (Only needed to support Ruby 1.9.3 and JRuby)
+      def constantize(camel_cased_word)
+        names = camel_cased_word.split('::')
+
+        # Trigger a built-in NameError exception including the ill-formed constant in the message.
+        Object.const_get(camel_cased_word) if names.empty?
+
+        # Remove the first blank element in case of '::ClassName' notation.
+        names.shift if names.size > 1 && names.first.empty?
+
+        names.inject(Object) do |constant, name|
+          if constant == Object
+            constant.const_get(name)
+          else
+            candidate = constant.const_get(name)
+            next candidate if constant.const_defined?(name, false)
+            next candidate unless Object.const_defined?(name)
+
+            # Go down the ancestors to check if it is owned directly. The check
+            # stops when we reach Object or the end of ancestors tree.
+            constant = constant.ancestors.inject do |const, ancestor|
+              break const    if ancestor == Object
+              break ancestor if ancestor.const_defined?(name, false)
+              const
+            end
+
+            # owner is in Object, so raise
+            constant.const_get(name, false)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cucumber/events/bus_spec.rb
+++ b/spec/cucumber/events/bus_spec.rb
@@ -1,94 +1,185 @@
-require "cucumber/events/bus"
+require 'cucumber/events/bus'
 
-module Cucumber
-  module Events
-    class TestEvent
+describe Cucumber::Events::Bus do
+  subject(:bus) { described_class.new(name_resolver) }
+
+  let(:name_resolver) { instance_double('Cucumber::Events::NameResolver') }
+
+  let!(:test_event_klass) do
+    class_double('Events::TestEvent').tap do |double|
+      stub_const('Events::TestEvent', double)
+      allow(double).to receive(:new).and_return(test_event_instance)
+      allow(double).to receive(:to_s).and_return('Events::TestEvent')
+      allow(double).to receive(:is_a?).with(Class).and_return(true)
+    end
+  end
+
+  let!(:test_event_instance) do
+    instance_double('Events::TestEvent').tap do |double|
+      allow(double).to receive(:is_a?).with(Class).and_return(false)
+      allow(double).to receive(:class).and_return('Events::TestEvent')
+    end
+  end
+
+  let!(:another_test_event_klass) do
+    class_double('Events::AnotherTestEvent').tap do |double|
+      stub_const('Events::AnotherTestEvent', double)
+      allow(double).to receive(:new).and_return(another_test_event_instance)
+      allow(double).to receive(:to_s).and_return('Events::AnotherTestEvent')
+      allow(double).to receive(:is_a?).with(Class).and_return(true)
+    end
+  end
+
+  let!(:another_test_event_instance) do
+    class_double('Events::AnotherTestEvent').tap do |double|
+      stub_const('Events::AnotherTestEvent', double)
+      allow(double).to receive(:is_a?).with(Class).and_return(false)
+      allow(double).to receive(:class).and_return('Events::AnotherTestEvent')
+    end
+  end
+
+  let!(:event_name) { test_event_klass }
+  let!(:event_klass) { test_event_klass }
+  let!(:event_instance) { test_event_instance }
+
+  describe '#notify' do
+    before(:each) do
+      allow(name_resolver).to receive(:transform).with(event_name).and_return(event_klass)
     end
 
-    class AnotherTestEvent
+    context 'when subscriber to event, the block is called and get\'s an instance of the event passed as payload' do
+      before :each do
+        bus.register(event_klass) do |event|
+          @received_payload = event
+        end
+
+        bus.notify event_instance
+      end
+
+      it { expect(@received_payload).to eq(event_instance) }
     end
 
-    describe Bus do
-      let(:bus) { Bus.new(Cucumber::Events) }
-      let(:test_event) { TestEvent.new }
-      let(:another_test_event) { AnotherTestEvent.new }
+    context 'when not subscriber to event' do
+      let!(:other_event_instance) { another_test_event_instance }
 
-      it "calls subscriber with event payload" do
-        received_payload = nil
-        bus.register(TestEvent) do |event|
-          received_payload = event
-        end
-
-        bus.notify test_event
-
-        expect(received_payload).to eq(test_event)
+      before :each do
+        @received_payload = false
+        bus.register(event_klass) { @received_payload = true }
+        bus.notify other_event_instance
       end
 
-      it "does not call subscribers for other events" do
-        handler_called = false
-        bus.register(TestEvent) do |event|
-          handler_called = true
-        end
+      it { expect(@received_payload).to eq(false) }
+    end
 
-        bus.notify another_test_event
+    context 'when multiple subscribers are given' do
+      let(:received_events) { [] }
 
-        expect(handler_called).to eq(false)
-      end
-
-      it "broadcasts to multiple subscribers" do
-        received_events = []
-        bus.register(TestEvent) do |event|
+      before :each do
+        bus.register(Events::TestEvent) do |event|
           received_events << event
         end
-        bus.register(TestEvent) do |event|
+        bus.register(Events::TestEvent) do |event|
           received_events << event
         end
 
-        bus.notify test_event
-
-        expect(received_events.length).to eq 2
-        expect(received_events).to all eq test_event
+        bus.notify event_instance
       end
 
-      it "allows subscription by string" do
-        received_payload = nil
-        bus.register('Cucumber::Events::TestEvent') do |event|
-          received_payload = event
+      it { expect(received_events.length).to eq 2 }
+      it { expect(received_events).to all eq event_instance }
+    end
+
+    context 'when subscriber is given by string' do
+      let!(:event_name) { test_event_klass.to_s }
+      let(:received_payload) { [] }
+
+      before :each do
+        bus.register(event_klass.to_s) do |event|
+          received_payload << event
         end
 
-        bus.notify test_event
-
-        expect(received_payload).to eq(test_event)
+        bus.notify event_instance
       end
 
-      it "allows subscription by symbol (for events in the Cucumber::Events namespace)" do
-        received_payload = nil
-        bus.register(:test_event) do |event|
-          received_payload = event
+      it { expect(received_payload).to include event_instance }
+    end
+
+    context "when subscriber is given by symbol (for events in the Cucumber::Events namespace)" do
+      let!(:event_name) { :test_event }
+      let(:received_payload) { [] }
+
+      before :each do
+        bus.register(event_name) do |event|
+          received_payload << event
         end
 
-        bus.notify test_event
-
-        expect(received_payload).to eq(test_event)
+        bus.notify event_instance
       end
 
-      it "allows handlers that are objects with a `call` method" do
-        class MyHandler
-          attr_reader :received_payload
+      it { expect(received_payload).to include event_instance }
+    end
 
-          def call(event)
-            @received_payload = event
-          end
+    context 'when event is not an instance of event class' do
+      let!(:event_name) { :test_event }
+      let(:received_payload) { [] }
+
+      before :each do
+        bus.register(event_name, proc {})
+      end
+
+      it { expect { bus.notify event_klass }.to raise_error Cucumber::NoEventError }
+    end
+  end
+
+  describe '#register' do
+    context 'when valid custom handler' do
+      before(:each) do
+        allow(name_resolver).to receive(:transform).with(event_name).and_return(event_klass)
+      end
+
+      let!(:handler_klass) do
+        class_double('MyHandler').tap do |double|
+          stub_const('MyHandler', double)
+          allow(double).to receive(:new).and_return(handler_instance)
         end
-
-        handler = MyHandler.new
-        bus.register(TestEvent, handler)
-
-        bus.notify test_event
-
-        expect(handler.received_payload).to eq test_event
       end
 
+      let!(:handler_instance) do
+        instance_double('MyHandler').tap do |double|
+          expect(double).to receive(:call).with(event_instance)
+        end
+      end
+
+      before :each do
+        bus.register(event_klass, MyHandler.new)
+      end
+
+      it { expect { bus.notify event_instance }.not_to raise_error }
+    end
+
+    context 'when malformed custom handler' do
+      let!(:handler_klass) do
+        class_double('MyHandler').tap do |double|
+          stub_const('MyHandler', double)
+          allow(double).to receive(:new).and_return(handler_instance)
+        end
+      end
+
+      let!(:handler_instance) { instance_double('MyHandler') }
+
+      it { expect { bus.register(event_klass, MyHandler.new) }.to raise_error ArgumentError }
+    end
+
+    context 'when no handler is given' do
+      it { expect { bus.register(event_klass) }.to raise_error ArgumentError }
+    end
+
+    context 'when malformed name resolver' do
+      before(:each) do
+        allow(name_resolver).to receive(:transform).with(event_name).and_return(nil)
+      end
+
+      it { expect { bus.register(event_klass, proc { }) }.to raise_error Cucumber::EventNameResolveError, %(Transforming "#{event_klass}" into an event name failed for unknown reason.) }
     end
   end
 end

--- a/spec/cucumber/events/name_resolver_spec.rb
+++ b/spec/cucumber/events/name_resolver_spec.rb
@@ -1,0 +1,63 @@
+require 'cucumber/events/name_resolver'
+
+describe Cucumber::Events::NameResolver do
+  subject(:resolver) { described_class.new(default_name_space) }
+  let(:default_name_space) { 'Cucumber::Events' }
+  let(:resolved_name) { resolver.transform(original_name) }
+
+  before :each do
+    stub_const('Events::MyEvent', Class.new)
+    stub_const('Cucumber::Events::MyEvent', Class.new)
+  end
+
+  describe '#transform' do
+    context 'when name is string' do
+      context 'when simple' do
+        let(:original_name) { 'Events::MyEvent' }
+        it { expect(resolved_name).to eq Events::MyEvent }
+      end
+
+      context 'when prefixed' do
+        let(:original_name) { '::Events::MyEvent' }
+        it { expect(resolved_name).to eq Events::MyEvent }
+      end
+    end
+
+    context 'when name is class' do
+      context 'when simple' do
+        let(:original_name) { Events::MyEvent }
+        it { expect(resolved_name).to eq Events::MyEvent }
+      end
+
+      context 'when prefixed' do
+        let(:original_name) { ::Events::MyEvent }
+        it { expect(resolved_name).to eq Events::MyEvent }
+      end
+    end
+
+    context 'when name is symbol' do
+      let(:original_name) { :my_event }
+      it { expect(resolved_name).to eq Cucumber::Events::MyEvent }
+    end
+
+    context 'when namespace ...' do
+      before :each do
+        stub_const('MyLib::Events::MyEvent', Class.new)
+      end
+
+      context 'when is string' do
+        let!(:default_name_space) { 'MyLib::Events' }
+        let!(:original_name) { :my_event }
+
+        it { expect(resolved_name).to eq MyLib::Events::MyEvent }
+      end
+
+      context 'when is module' do
+        let!(:default_name_space) { MyLib::Events }
+        let!(:original_name) { :my_event }
+
+        it { expect(resolved_name).to eq MyLib::Events::MyEvent }
+      end
+    end
+  end
+end


### PR DESCRIPTION
@mattwynne As discussed some weeks ago I finished the refactoring of the `Event::Bus`:

* Added more tests for Bus + NameResolver
* Refactored the the test suite to make use of `context` to show the code behaves in different contexts/situations

Maybe we should really move that event bus thing to a separate library. This would make sharing the code much easier and we could use rubygems + version requirement(s) to make aruba and cucumber depend on the correct interface. WDT? What about `cucumber-ruby-common` or just `event-bus`.
