### PR TITLE
Convert badges to SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://secure.travis-ci.org/cucumber/cucumber-ruby.svg)](http://travis-ci.org/cucumber/cucumber-ruby)
 [![Code Climate](https://codeclimate.com/github/cucumber/cucumber-ruby.svg)](https://codeclimate.com/github/cucumber/cucumber-ruby)
 [![Coverage Status](https://coveralls.io/repos/cucumber/cucumber-ruby/badge.svg?branch=master)](https://coveralls.io/r/cucumber/cucumber-ruby?branch=master)
-[![Dependency Status](https://gemnasium.com/cucumber/cucumber-ruby.png)](https://gemnasium.com/cucumber/cucumber-ruby)
+[![Dependency Status](https://gemnasium.com/cucumber/cucumber-ruby.svg)](https://gemnasium.com/cucumber/cucumber-ruby)
 
 # Cucumber
 


### PR DESCRIPTION
SVG badges are much better readable on hi-res displays. See https://github.com/Originate/cucumber-ruby vs https://github.com/cucumber/cucumber-ruby.