### PR TITLE
stringifying location for more consistent json parsing - address #945

### DIFF
--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -179,7 +179,7 @@ module Cucumber
       end
 
       def create_match_hash(test_step, result)
-        { location: test_step.action_location }
+        { location: test_step.action_location.to_s }
       end
 
       def create_result_hash(result)


### PR DESCRIPTION
I started running into issues when formatting cucumber reports as JSON. With the default JSON gem (also I believe 'oj' and 'yajl'), it seems that the JSON formatter has started stringifying the `location` object on steps as hashes instead of using the `to_s` method found in [cucumber-ruby-core](https://github.com/cucumber/cucumber-ruby-core/blob/master/lib/cucumber/core/ast/location.rb#L75).

Desired Output:
```
"location": "features/step_definitions/selenium/selenium.rb:8"
```

Undesired Output:
```
              "location": {
                "filepath": {
                  "filename": "json_spec-1.1.4/lib/json_spec/cucumber.rb"
                },
                "lines": {
                  "data": [
                    "5"
                    ]
                  }
                }
```

This issue does not occur when running the spec tests using the `json_spec` gem, but happens every time with the classic ruby JSON gem (1.8.3). I added a `to_s` call when creating the match hash, which doesn't seem to have any other repercussions besides fixing this bug.

Fixes #945.