### PR TITLE
WIP: Custom formatter config

### DIFF
--- a/features/docs/extending_cucumber/custom_formatter.feature
+++ b/features/docs/extending_cucumber/custom_formatter.feature
@@ -60,6 +60,7 @@ Feature: Custom Formatter
       {"foo"=>"bar", "one"=>"two"}
       """
 
+  @spawn
   Scenario: Support legacy --out
     Given a file named "features/support/custom_formatter.rb" with:
       """
@@ -67,7 +68,7 @@ Feature: Custom Formatter
         class Formatter
           def initialize(config, options={})
             config.on_event Cucumber::Events::FinishedTesting do |event|
-              puts options["out"]
+              $stdout.puts options["out"]
             end
           end
         end
@@ -76,13 +77,14 @@ Feature: Custom Formatter
     When I run `cucumber features/f.feature --format MyCustom::Formatter --out foo.file`
     Then it should pass with exactly:
       """
-      foo.file
       Deprecated: Please don't use --out, but pass the formatter options like this instead:
 
         --format junit,out=path/to/output
+      foo.file
 
       """
 
+  @spawn
   Scenario: Setting output using the new style per-formatter options
     Given a file named "features/support/custom_formatter.rb" with:
       """
@@ -90,7 +92,7 @@ Feature: Custom Formatter
         class Formatter
           def initialize(config, options={})
             config.on_event Cucumber::Events::FinishedTesting do |event|
-              puts options["out"]
+              $stdout.puts options["out"]
             end
           end
         end

--- a/features/docs/extending_cucumber/custom_formatter.feature
+++ b/features/docs/extending_cucumber/custom_formatter.feature
@@ -41,6 +41,48 @@ Feature: Custom Formatter
 
       """
 
+  Scenario: Custom config
+    Given a file named "features/support/custom_formatter.rb" with:
+      """
+      module MyCustom
+        class Formatter
+          def initialize(config, options={})
+            config.on_event Cucumber::Events::FinishedRunningTests do |event|
+              puts options.inspect
+            end
+          end
+        end
+      end
+      """
+    When I run `cucumber features/f.feature --format MyCustom::Formatter,foo=bar,one=two`
+    Then it should pass with exactly:
+      """
+      { "foo": "bar", "one": "two" }
+      """
+
+  Scenario: Support legacy --out
+    Given a file named "features/support/custom_formatter.rb" with:
+      """
+      module MyCustom
+        class Formatter
+          def initialize(config, options={})
+            config.on_event Cucumber::Events::FinishedRunningTests do |event|
+              puts options["out"]
+            end
+          end
+        end
+      end
+      """
+    When I run `cucumber features/f.feature --format MyCustom::Formatter --out foo/bar.file`
+    Then it should pass with exactly:
+      """
+      Deprecated: Please don't use --out, but pass the formatter options like this intead:
+
+        --format junit,out=path/to/output
+
+      foo/bar.file
+      """
+
   Scenario: Implement v2.0 formatter methods
     Note that this method is likely to be deprecated in favour of events - see above.
 

--- a/features/docs/extending_cucumber/custom_formatter.feature
+++ b/features/docs/extending_cucumber/custom_formatter.feature
@@ -76,11 +76,11 @@ Feature: Custom Formatter
     When I run `cucumber features/f.feature --format MyCustom::Formatter --out foo.file`
     Then it should pass with exactly:
       """
+      foo.file
       Deprecated: Please don't use --out, but pass the formatter options like this instead:
 
         --format junit,out=path/to/output
 
-      foo.file
       """
 
   Scenario: Setting output using the new style per-formatter options
@@ -100,6 +100,7 @@ Feature: Custom Formatter
     Then it should pass with exactly:
       """
       foo.file
+
       """
 
   Scenario: Implement v2.0 formatter methods

--- a/features/docs/extending_cucumber/custom_formatter.feature
+++ b/features/docs/extending_cucumber/custom_formatter.feature
@@ -73,14 +73,33 @@ Feature: Custom Formatter
         end
       end
       """
-    When I run `cucumber features/f.feature --format MyCustom::Formatter --out foo/bar.file`
+    When I run `cucumber features/f.feature --format MyCustom::Formatter --out foo.file`
     Then it should pass with exactly:
       """
-      Deprecated: Please don't use --out, but pass the formatter options like this intead:
+      Deprecated: Please don't use --out, but pass the formatter options like this instead:
 
         --format junit,out=path/to/output
 
-      foo/bar.file
+      foo.file
+      """
+
+  Scenario: Setting output using the new style per-formatter options
+    Given a file named "features/support/custom_formatter.rb" with:
+      """
+      module MyCustom
+        class Formatter
+          def initialize(config, options={})
+            config.on_event Cucumber::Events::FinishedTesting do |event|
+              puts options["out"]
+            end
+          end
+        end
+      end
+      """
+    When I run `cucumber features/f.feature --format MyCustom::Formatter,out=foo.file`
+    Then it should pass with exactly:
+      """
+      foo.file
       """
 
   Scenario: Implement v2.0 formatter methods

--- a/features/docs/extending_cucumber/custom_formatter.feature
+++ b/features/docs/extending_cucumber/custom_formatter.feature
@@ -17,7 +17,7 @@ Feature: Custom Formatter
       """
       module MyCustom
         class Formatter
-          def initialize(config)
+          def initialize(config, options={})
             @io = config.out_stream
             config.on_event Cucumber::Events::BeforeTestCase do |event|
               print_test_case_name(event.test_case)
@@ -47,8 +47,8 @@ Feature: Custom Formatter
       module MyCustom
         class Formatter
           def initialize(config, options={})
-            config.on_event Cucumber::Events::FinishedRunningTests do |event|
-              puts options.inspect
+            config.on_event Cucumber::Events::FinishedTesting do |event|
+              config.out_stream.print options.inspect
             end
           end
         end
@@ -57,7 +57,7 @@ Feature: Custom Formatter
     When I run `cucumber features/f.feature --format MyCustom::Formatter,foo=bar,one=two`
     Then it should pass with exactly:
       """
-      { "foo": "bar", "one": "two" }
+      {"foo"=>"bar", "one"=>"two"}
       """
 
   Scenario: Support legacy --out
@@ -66,7 +66,7 @@ Feature: Custom Formatter
       module MyCustom
         class Formatter
           def initialize(config, options={})
-            config.on_event Cucumber::Events::FinishedRunningTests do |event|
+            config.on_event Cucumber::Events::FinishedTesting do |event|
               puts options["out"]
             end
           end
@@ -90,7 +90,7 @@ Feature: Custom Formatter
       """
       module MyCustom
         class Formatter
-          def initialize(config)
+        def initialize(config, options = {})
             @io = config.out_stream
           end
 

--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -136,8 +136,8 @@ module Cucumber
       end
 
       def arrange_formats
-        @options[:formats] << ['pretty', @out_stream] if @options[:formats].empty?
-        @options[:formats] = @options[:formats].sort_by{|f| f[1] == @out_stream ? -1 : 1}
+        @options[:formats] << ['pretty', {}, @out_stream] if @options[:formats].empty?
+        @options[:formats] = @options[:formats].sort_by{|f| f[2] == @out_stream ? -1 : 1}
         @options[:formats].uniq!
         @options.check_formatter_stream_conflicts()
       end

--- a/lib/cucumber/cli/main.rb
+++ b/lib/cucumber/cli/main.rb
@@ -15,8 +15,8 @@ module Cucumber
       def initialize(args, _=nil, out=STDOUT, err=STDERR, kernel=Kernel)
         @args   = args
         @kernel = kernel
-        $stdout = @out = out
-        $stderr = @err = err
+        @out = out
+        @err = err
       end
 
       def execute!(existing_runtime = nil)

--- a/lib/cucumber/cli/main.rb
+++ b/lib/cucumber/cli/main.rb
@@ -14,9 +14,9 @@ module Cucumber
 
       def initialize(args, _=nil, out=STDOUT, err=STDERR, kernel=Kernel)
         @args   = args
-        @out    = out
-        @err    = err
         @kernel = kernel
+        $stdout = @out = out
+        $stderr = @err = err
       end
 
       def execute!(existing_runtime = nil)

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -150,10 +150,17 @@ module Cucumber
             Kernel.exit(0)
           end
           opts.on("-o", "--out [FILE|DIR]",
-            "Write output to a file/directory instead of STDOUT. This option",
+            "DEPRECATED: Write output to a file/directory instead of STDOUT. This option",
             "applies to the previously specified --format, or the",
             "default format if no format is specified. Check the specific",
             "formatter's docs to see whether to pass a file or a dir.") do |v|
+
+            $stdout.puts [
+              "Deprecated: Please don't use --out, but pass the formatter options like this instead:",
+              '',
+              '  --format junit,out=path/to/output'
+            ].join("\n")
+
             @options[:formats] << ['pretty', {}, nil] if @options[:formats].empty?
             @options[:formats][-1][2] = v
             @options[:formats][-1][1]['out'] = v

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -134,7 +134,14 @@ module Cucumber
           opts.on("-f FORMAT", "--format FORMAT",
             "How to format features (Default: pretty). Available formats:",
             *FORMAT_HELP) do |v|
-            @options[:formats] << [v, @out_stream]
+              formatter, *custom_options = v.split(/,/)
+
+              parsed_options = custom_options.each_with_object({}) do |e, a| 
+                name, value = e.split(/=/)
+                a[name] = value
+              end
+
+              @options[:formats] << [formatter, parsed_options, @out_stream]
           end
           opts.on('--init',
             'Initializes folder structure and generates conventional files for',
@@ -147,8 +154,8 @@ module Cucumber
             "applies to the previously specified --format, or the",
             "default format if no format is specified. Check the specific",
             "formatter's docs to see whether to pass a file or a dir.") do |v|
-            @options[:formats] << ['pretty', nil] if @options[:formats].empty?
-            @options[:formats][-1][1] = v
+            @options[:formats] << ['pretty', {}, nil] if @options[:formats].empty?
+            @options[:formats][-1][2] = v
           end
           opts.on("-t TAG_EXPRESSION", "--tags TAG_EXPRESSION",
             "Only execute the features or scenarios with tags matching TAG_EXPRESSION.",
@@ -291,7 +298,7 @@ TEXT
       end
 
       def check_formatter_stream_conflicts()
-        streams = @options[:formats].uniq.map { |(_, stream)| stream }
+        streams = @options[:formats].uniq.map { |(_, _, stream)| stream }
         if streams != streams.uniq
           raise "All but one formatter must use --out, only one can print to each stream (or STDOUT)"
         end
@@ -309,11 +316,11 @@ TEXT
     private
 
       def non_stdout_formats
-        @options[:formats].select {|format, output| output != @out_stream }
+        @options[:formats].select {|format, _, output| output != @out_stream }
       end
 
       def stdout_formats
-        @options[:formats].select {|format, output| output == @out_stream }
+        @options[:formats].select {|format, _, output| output == @out_stream }
       end
 
       def extract_environment_variables

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -156,6 +156,7 @@ module Cucumber
             "formatter's docs to see whether to pass a file or a dir.") do |v|
             @options[:formats] << ['pretty', {}, nil] if @options[:formats].empty?
             @options[:formats][-1][2] = v
+            @options[:formats][-1][1]['out'] = v
           end
           opts.on("-t TAG_EXPRESSION", "--tags TAG_EXPRESSION",
             "Only execute the features or scenarios with tags matching TAG_EXPRESSION.",

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -173,11 +173,13 @@ module Cucumber
 
     def formatter_factories
       @options[:formats].map do |format_and_out|
-        format = format_and_out[0]
-        path_or_io = format_and_out[1]
+        format     = format_and_out[0]
+        options    = format_and_out[1].empty? ? Cli::Options.new(STDOUT, STDERR, @options) : format_and_out[1]
+        path_or_io = format_and_out[2]
+
         begin
           factory = formatter_class(format)
-          yield factory, path_or_io, Cli::Options.new(STDOUT, STDERR, @options)
+          yield factory, path_or_io, options
         rescue Exception => e
           e.message << "\nError creating formatter: #{format}"
           raise e

--- a/lib/cucumber/formatter/usage.rb
+++ b/lib/cucumber/formatter/usage.rb
@@ -11,6 +11,8 @@ module Cucumber
       end
 
       def initialize(runtime, path_or_io, options)
+        require 'pry'
+        binding.pry
         @runtime = runtime
         @io = ensure_io(path_or_io)
         @options = options

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -194,8 +194,9 @@ module Cucumber
 
     def create_formatter(factory, path_or_io, options)
       if !legacy_formatter?(factory)
-        return factory.new(@configuration) if path_or_io.nil?
-        return factory.new(@configuration.with_options(out_stream: path_or_io))
+        # return factory.new(@configuration) if path_or_io.nil?
+        out_stream = Cucumber::Formatter::Io.ensure_io(path_or_io)
+        return factory.new(@configuration.with_options(out_stream: out_stream), options)
       end
       results = Formatter::LegacyApi::Results.new
       runtime_facade = Formatter::LegacyApi::RuntimeFacade.new(results, @support_code, @configuration)

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -53,7 +53,7 @@ module Cli
 
         config.parse!(%w{--format progress --profile bongo})
 
-        expect(config.options[:formats]).to eq [['progress', out]]
+        expect(config.options[:formats]).to eq [['progress', {}, out]]
         expect(config.options[:require]).to eq ['from/yml']
       end
 
@@ -111,14 +111,14 @@ END_OF_MESSAGE
 
         config.parse!(%w{--profile foo})
 
-        expect(config.options[:formats]).to eq [['progress', out]]
+        expect(config.options[:formats]).to eq [['progress', {}, out]]
       end
 
       it "disregards default STDOUT formatter defined in profile when another is passed in (via cmd line)" do
         given_cucumber_yml_defined_as({'foo' => %w[--format pretty]})
         config.parse!(%w{--format progress --profile foo})
 
-        expect(config.options[:formats]).to eq [['progress', out]]
+        expect(config.options[:formats]).to eq [['progress', {}, out]]
       end
 
       ["--no-profile", "-P"].each do |flag|
@@ -233,21 +233,21 @@ END_OF_MESSAGE
     end
 
     it "accepts --out option" do
-      config.parse!(%w{--out jalla.txt})
+      config.parse!(%w{--out text.txt})
 
-      expect(config.formats).to eq [['pretty', 'jalla.txt']]
+      expect(config.formats).to eq [['pretty', {}, 'text.txt']]
     end
 
     it "accepts multiple --out options" do
       config.parse!(%w{--format progress --out file1 --out file2})
 
-      expect(config.formats).to eq [['progress', 'file2']]
+      expect(config.formats).to eq [['progress', {}, 'file2']]
     end
 
     it "accepts multiple --format options and put the STDOUT one first so progress is seen" do
       config.parse!(%w{--format pretty --out pretty.txt --format progress})
 
-      expect(config.formats).to eq [['progress', out], ['pretty', 'pretty.txt']]
+      expect(config.formats).to eq [['progress', {}, out], ['pretty', {}, 'pretty.txt']]
     end
 
     it "does not accept multiple --format options when both use implicit STDOUT" do
@@ -262,7 +262,7 @@ END_OF_MESSAGE
     it "accepts same --format options with implicit STDOUT, and keep only one" do
       config.parse!(%w{--format pretty --format pretty})
 
-      expect(config.formats).to eq [["pretty", out]]
+      expect(config.formats).to eq [["pretty", {}, out]]
     end
 
     it "does not accept multiple --out streams pointing to the same place" do
@@ -277,19 +277,19 @@ END_OF_MESSAGE
     it "associates --out to previous --format" do
       config.parse!(%w{--format progress --out file1 --format profile --out file2})
 
-      expect(config.formats).to eq [["progress", "file1"], ["profile" ,"file2"]]
+      expect(config.formats).to eq [["progress", {}, "file1"], ["profile", {}, "file2"]]
     end
 
     it "accepts same --format options with same --out streams and keep only one" do
       config.parse!(%w{--format html --out file --format pretty --format html --out file})
 
-      expect(config.formats).to eq [["pretty", out], ["html", "file"]]
+      expect(config.formats).to eq [["pretty", {}, out], ["html", {}, "file"]]
     end
 
     it "accepts same --format options with different --out streams" do
       config.parse!(%w{--format html --out file1 --format html --out file2})
 
-      expect(config.formats).to eq [["html", "file1"], ["html", "file2"]]
+      expect(config.formats).to eq [["html", {}, "file1"], ["html", {}, "file2"]]
     end
 
     it "accepts --color option" do

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -235,19 +235,19 @@ END_OF_MESSAGE
     it "accepts --out option" do
       config.parse!(%w{--out text.txt})
 
-      expect(config.formats).to eq [['pretty', {}, 'text.txt']]
+      expect(config.formats).to eq [['pretty', {'out' => 'text.txt'}, 'text.txt']]
     end
 
     it "accepts multiple --out options" do
       config.parse!(%w{--format progress --out file1 --out file2})
 
-      expect(config.formats).to eq [['progress', {}, 'file2']]
+      expect(config.formats).to eq [['progress', {'out' => 'file2'}, 'file2']]
     end
 
     it "accepts multiple --format options and put the STDOUT one first so progress is seen" do
       config.parse!(%w{--format pretty --out pretty.txt --format progress})
 
-      expect(config.formats).to eq [['progress', {}, out], ['pretty', {}, 'pretty.txt']]
+      expect(config.formats).to eq [['progress', {'out' => out}, out], ['pretty', {'out' => 'pretty.txt'}, 'pretty.txt']]
     end
 
     it "does not accept multiple --format options when both use implicit STDOUT" do
@@ -277,19 +277,19 @@ END_OF_MESSAGE
     it "associates --out to previous --format" do
       config.parse!(%w{--format progress --out file1 --format profile --out file2})
 
-      expect(config.formats).to eq [["progress", {}, "file1"], ["profile", {}, "file2"]]
+      expect(config.formats).to eq [["progress", {'out' => 'file1'}, "file1"], ["profile", {'out' => 'file2'}, "file2"]]
     end
 
     it "accepts same --format options with same --out streams and keep only one" do
       config.parse!(%w{--format html --out file --format pretty --format html --out file})
 
-      expect(config.formats).to eq [["pretty", {}, out], ["html", {}, "file"]]
+      expect(config.formats).to eq [["pretty", {'out' => out}, out], ["html", {'out' => 'file'}, "file"]]
     end
 
     it "accepts same --format options with different --out streams" do
       config.parse!(%w{--format html --out file1 --format html --out file2})
 
-      expect(config.formats).to eq [["html", {}, "file1"], ["html", {}, "file2"]]
+      expect(config.formats).to eq [["html", {'out' => 'file1'}, "file1"], ["html", {'out' => 'file2'}, "file2"]]
     end
 
     it "accepts --color option" do

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -107,11 +107,12 @@ module Cucumber
 
         context '-o [FILE|DIR] or --out [FILE|DIR]' do
           it "defaults the formatter to 'pretty' when not specified earlier" do
-            after_parsing('-o file.txt') { expect(options[:formats]).to eq [['pretty', {}, 'file.txt']] }
+            after_parsing('-o file.txt') { expect(options[:formats]).to eq [['pretty', { 'out' => 'file.txt' }, 'file.txt']] }
           end
+
           it "sets the output for the formatter defined immediatly before it" do
             after_parsing('-f profile --out file.txt -f pretty -o file2.txt') do
-              expect(options[:formats]).to eq [['profile', {}, 'file.txt'], ['pretty', {}, 'file2.txt']]
+              expect(options[:formats]).to eq [['profile', { 'out' => 'file.txt' }, 'file.txt'], ['pretty', { 'out' => 'file2.txt' }, 'file2.txt']]
             end
           end
         end

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -103,6 +103,10 @@ module Cucumber
           it "extracts per formatter options" do
             after_parsing('-f pretty,foo=bar,foo2=bar2') { expect(options[:formats]).to eq [['pretty', { 'foo' => 'bar', 'foo2' => 'bar2' }, output_stream]] }
           end
+
+          it "formatter option take precendence over --out option" do
+            after_parsing('-f pretty,out=file1.txt --out file2.txt') { expect(options[:formats]).to eq [['pretty', { 'out' => 'file1.txt'}, 'file1.txt']] }
+          end
         end
 
         context '-o [FILE|DIR] or --out [FILE|DIR]' do
@@ -142,7 +146,7 @@ module Cucumber
 
             options.parse!(%w{-f pretty})
             
-            expect(options[:formats]).to eq [['pretty', {}, output_stream], ["junit", {}, "result.xml"]]
+            expect(options[:formats]).to eq [['pretty', {'out' => output_stream}, output_stream], ["junit", {'out' => 'result.xml'}, "result.xml"]]
           end
         end
 
@@ -254,21 +258,21 @@ module Cucumber
             given_cucumber_yml_defined_as({'html' => %w[--format html -o features.html --format pretty]})
             options.parse!(%w{--format progress --profile html})
 
-            expect(options[:formats]).to eq [['progress', {}, output_stream], ['html', {}, 'features.html']]
+            expect(options[:formats]).to eq [['progress', {'out' => output_stream}, output_stream], ['html', {'out' => 'features.html'}, 'features.html']]
           end
 
           it "includes any STDOUT formatters from the profile if no STDOUT formatter was specified in command line" do
             given_cucumber_yml_defined_as({'html' => %w[--format html]})
             options.parse!(%w{--format rerun -o rerun.txt --profile html})
 
-            expect(options[:formats]).to eq [['html', {}, output_stream], ['rerun', {}, 'rerun.txt']]
+            expect(options[:formats]).to eq [['html', {'out' => output_stream}, output_stream], ['rerun', {'out' => 'rerun.txt'}, 'rerun.txt']]
           end
 
           it "assumes all of the formatters defined in the profile when none are specified on cmd line" do
             given_cucumber_yml_defined_as({'html' => %w[--format progress --format html -o features.html]})
             options.parse!(%w{--profile html})
 
-            expect(options[:formats]).to eq [['progress', {}, output_stream], ['html', {}, 'features.html']]
+            expect(options[:formats]).to eq [['progress', {'out' => output_stream}, output_stream], ['html', {'out' => 'features.html'}, 'features.html']]
           end
 
           it "only reads cucumber.yml once" do

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -97,17 +97,21 @@ module Cucumber
 
         context '-f FORMAT or --format FORMAT' do
           it "defaults the output for the formatter to the output stream (STDOUT)" do
-            after_parsing('-f pretty') { expect(options[:formats]).to eq [['pretty', output_stream]] }
+            after_parsing('-f pretty') { expect(options[:formats]).to eq [['pretty', {}, output_stream]] }
+          end
+
+          it "extracts per formatter options" do
+            after_parsing('-f pretty,foo=bar,foo2=bar2') { expect(options[:formats]).to eq [['pretty', { 'foo' => 'bar', 'foo2' => 'bar2' }, output_stream]] }
           end
         end
 
         context '-o [FILE|DIR] or --out [FILE|DIR]' do
           it "defaults the formatter to 'pretty' when not specified earlier" do
-            after_parsing('-o file.txt') { expect(options[:formats]).to eq [['pretty', 'file.txt']] }
+            after_parsing('-o file.txt') { expect(options[:formats]).to eq [['pretty', {}, 'file.txt']] }
           end
           it "sets the output for the formatter defined immediatly before it" do
             after_parsing('-f profile --out file.txt -f pretty -o file2.txt') do
-              expect(options[:formats]).to eq [['profile', 'file.txt'], ['pretty', 'file2.txt']]
+              expect(options[:formats]).to eq [['profile', {}, 'file.txt'], ['pretty', {}, 'file2.txt']]
             end
           end
         end
@@ -137,7 +141,7 @@ module Cucumber
 
             options.parse!(%w{-f pretty})
             
-            expect(options[:formats]).to eq [['pretty', output_stream], ["junit", "result.xml"]]
+            expect(options[:formats]).to eq [['pretty', {}, output_stream], ["junit", {}, "result.xml"]]
           end
         end
 
@@ -235,35 +239,35 @@ module Cucumber
             given_cucumber_yml_defined_as({'foo' => %w[--format pretty]})
             options.parse!(%w{--format progress --profile foo})
 
-            expect(options[:formats]).to eq [['progress', output_stream]]
+            expect(options[:formats]).to eq [['progress', {}, output_stream]]
           end
 
           it "includes any non-STDOUT formatters from the profile" do
             given_cucumber_yml_defined_as({'html' => %w[--format html -o features.html]})
             options.parse!(%w{--format progress --profile html})
 
-            expect(options[:formats]).to eq [['progress', output_stream], ['html', 'features.html']]
+            expect(options[:formats]).to eq [['progress', {}, output_stream], ['html', {}, 'features.html']]
           end
 
           it "does not include STDOUT formatters from the profile if there is a STDOUT formatter in command line" do
             given_cucumber_yml_defined_as({'html' => %w[--format html -o features.html --format pretty]})
             options.parse!(%w{--format progress --profile html})
 
-            expect(options[:formats]).to eq [['progress', output_stream], ['html', 'features.html']]
+            expect(options[:formats]).to eq [['progress', {}, output_stream], ['html', {}, 'features.html']]
           end
 
           it "includes any STDOUT formatters from the profile if no STDOUT formatter was specified in command line" do
             given_cucumber_yml_defined_as({'html' => %w[--format html]})
             options.parse!(%w{--format rerun -o rerun.txt --profile html})
 
-            expect(options[:formats]).to eq [['html', output_stream], ['rerun', 'rerun.txt']]
+            expect(options[:formats]).to eq [['html', {}, output_stream], ['rerun', {}, 'rerun.txt']]
           end
 
           it "assumes all of the formatters defined in the profile when none are specified on cmd line" do
             given_cucumber_yml_defined_as({'html' => %w[--format progress --format html -o features.html]})
             options.parse!(%w{--profile html})
 
-            expect(options[:formats]).to eq [['progress', output_stream], ['html', 'features.html']]
+            expect(options[:formats]).to eq [['progress', {}, output_stream], ['html', {}, 'features.html']]
           end
 
           it "only reads cucumber.yml once" do

--- a/spec/cucumber/configuration_spec.rb
+++ b/spec/cucumber/configuration_spec.rb
@@ -143,5 +143,10 @@ module Cucumber
       end
     end
 
+    describe "#io_for" do
+      it "returns the writable IO stream for the given formatter" do
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Currently, formatter instances fall into three categories:

1) the one that's writing to STDOUT
2) opening a file and writing to that
3) other arbitrary config (e.g. JUnit formatter)

We have an `io` argument that's passed in the constructor to v1.0-style formatters that could be one of the following:
- the STDOUT stream to write to
- the path to a file to open
- the path to the directory that the JUnit formatter is going to write files into

This is messy and confusing. This PR aims to introduce a new, per-formatter configuration structure and un-pick the old `--out` option.
