### PR TITLE
Load gems from local Gemfile which is not part of the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ Gemfile.lock
 tags
 .ruby-version
 .project
+Gemfile.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,19 @@ The rest of this document is a guide for those maintaining Cucumber, and others 
 
 You can chat with the core team on https://gitter.im/cucumber/cucumber. We try to have office hours on Fridays.
 
+## Installing your own gems
+
+A `Gemfile.local`-file can be used to have your own gems installed to support
+your normal development workflow.
+
+Example:
+
+~~~ruby
+gem 'pry'
+gem 'pry-byebug'
+gem 'byebug'
+~~~
+
 ## Note on Patches/Pull Requests
 
 * Fork the project. Make a branch for your change.

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 gem "cucumber-pro", "0.0.13", :group => :test
 source "https://rubygems.org"
 gemspec
+load File.expand_path('../Gemfile.local', __FILE__) if File.file? File.expand_path('../Gemfile.local', __FILE__)
+
 unless ENV['CUCUMBER_USE_RELEASED_CORE']
   core_path = File.expand_path("../../cucumber-ruby-core", __FILE__)
   wire_path = File.expand_path("../../cucumber-ruby-wire", __FILE__)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I normally use some gems for debugging etc. which are quite "individual". This PR adds the possibility to have an local `Gemfile.local` which is not part of the cucumber repository. In this Gemfile a developer can have "his/her" private gems which are not shared with the community because each developer has his/her own workflow/tool chain.

Using a git ignored `Gemfile.local` gives developers a "convenient" way to have their own gems installed - e.g `pry` + `byebug` - while not littering the projects `Gemfile` with developer's specific gems. If you're interested I can also submit a PR for cucumber-ruby-core.

## Motivation and Context

Developer can have "his/her" private gems which are not shared with the community because each developer has his/her own workflow/tool chain.

## How Has This Been Tested?

Tested locally with own `Gemfile.local`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.


Any thoughts about this?