### PR TITLE
Set $stderr/$stdout to mocked io in runner

### DIFF
--- a/lib/cucumber/cli/main.rb
+++ b/lib/cucumber/cli/main.rb
@@ -14,9 +14,9 @@ module Cucumber
 
       def initialize(args, _=nil, out=STDOUT, err=STDERR, kernel=Kernel)
         @args   = args
-        @out    = out
-        @err    = err
         @kernel = kernel
+        $stdout = @out = out
+        $stderr = @err = err
       end
 
       def execute!(existing_runtime = nil)


### PR DESCRIPTION

Set $stderr/$stdout to mocked io in runner

## Description

Set $stderr/$stdout to mocked io in runner so that the output is captured correctly if someone uses $stdout.puts or $stderr.puts inside cucumber. This trival changes makes testing output on $stderr/$stdout a lot of easier. Otherwise some quirks are needed to capture and check them using steps from `aruba`.

I found that one while implementing the new `options`-API for formatters. Without that change testing is cumbersome.

## Motivation and Context

I would like to be able to capture `puts` output to make feature https://github.com/cucumber/cucumber-ruby/pull/954/files#diff-61df043d3516e6b2647a8c992f671037R70 pass.

## How Has This Been Tested?

* Tested via cucumber run
* I verified the output of cucumber

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
