### PR TITLE
Lock mime-types-data to older version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,5 @@ unless ENV['CUCUMBER_USE_RELEASED_CORE']
     gem 'cucumber-core', :git => "git://github.com/cucumber/cucumber-ruby-core.git"
   end
 end
+
+gem 'mime-types', '~>2.99'


### PR DESCRIPTION
## Reason:

Build fails on ruby 1.9.3 due to ruby version conflict for a gem.

## Description

This `cucumber-ruby`-[build](https://travis-ci.org/cucumber/cucumber-ruby/jobs/118065154) fails on ruby 1.9.3. A newer version of `mime-types` requires ruby 2.0, so installing it on ruby 1.9.3 fails. This gem is required by 'capybara'. `capybara` is required by the devs deps in the gemspec.

~~~
Gem::InstallError: mime-types-data requires Ruby version >= 2.0.
~~~

## Motivation and Context

Make the build pass again.

## How Has This Been Tested?

This is tested via Travis.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
