### PR TITLE
Replace git through https as transport protocol

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ unless ENV['CUCUMBER_USE_RELEASED_CORE']
     gem 'cucumber-core', :path => core_path
     gem 'cucumber-wire', :path => wire_path
   else
-    gem 'cucumber-core', :git => "git://github.com/cucumber/cucumber-ruby-core.git"
+    gem 'cucumber-core', :git => "https://github.com/cucumber/cucumber-ruby-core.git"
   end
 end
 


### PR DESCRIPTION
## Summary

<!--- Provide a general summary of your changes in the Title above -->

Replace git through https as transport protocol  since the latter is p…roxyable

## Details

If a developer is required to access the WWW via a HTTP proxy, git cannot be used as transport protocol since it is not proxyable. `git` is set in https://github.com/cucumber/cucumber-ruby/blob/master/Gemfile#L11.

Old:
~~~
gem 'cucumber-core', :git => "git://github.com/cucumber/cucumber-ruby-core.git"
~~~

New:
~~~
gem 'cucumber-core', :git => "https://github.com/cucumber/cucumber-ruby-core.git"
~~~
<!--- Describe your changes in detail -->

There might be other cucumber projects where such a change makes sense.

## Motivation and Context

In bigger companies the use of HTTP proxies is quite common. There's not direct access from a laptop/computer to the WWW. Using `git` as transport protocol is a burden for new developers from such an environment as a local change is required each time they want to send a pull request. Since I've never had any performance impact in using HTTPS instead of GIT, put together this PR.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Yes, many times locally.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.