### PR TITLE
fix HTML formatter backtrace duplicate line bug

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -589,13 +589,13 @@ module Cucumber
         (["#{exception.message}"] + exception.backtrace).join("\n")
       end
 
-      def backtrace_line(line)
-        line.gsub(/^([^:]*\.(?:rb|feature|haml)):(\d*).*$/) do
-          if ENV['TM_PROJECT_DIRECTORY']
+     def backtrace_line(line)
+        if ENV['TM_PROJECT_DIRECTORY']
+          line.gsub(/^([^:]*\.(?:rb|feature|haml)):(\d*).*$/) do
             "<a href=\"txmt://open?url=file://#{File.expand_path($1)}&line=#{$2}\">#{$1}:#{$2}</a> "
-          else
-            line
           end
+        else
+          line
         end
       end
 

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -267,6 +267,11 @@ module Cucumber
 
           it { expect(@doc).to have_css_node('.feature .scenario .step.failed .message', /eek/) }
           it { expect(@doc).to have_css_node('.feature .scenario .step.failed .message', /StandardError/) }
+          it 'has the backtrace embeded in the output once and only once' do
+            html_str = @doc.to_s
+            expect(html_str).not_to match(%r{<pre\b.*html_spec.rb:.*html_spec.rb:.*</pre>}m)
+            expect(html_str).to match(%r{<pre\b.*html_spec.rb:.*</pre>}m)
+          end
         end
 
         describe "with a step that fails in the background" do


### PR DESCRIPTION
An alternative to #910.  #910 attempts to fix the problem by altering the regular expression, which seems strange to me.  It could be that the regular expression needs fixing but I am experiencing this bug and I don't have `ENV['TM_PROJECT_DIRECTORY']` set at all.  If `ENV['TM_PROJECT_DIRECTORY']` isn't set at all why even try to match the regular expression against the input?

It should be noted that `line` is not in fact a single line.  It is the backtrace array which has already been joined with newlines.

I also noticed that the code is running `delete_if` on the array it gets from  `exception`.  Mutating objects that do not belong to us is bad practice.  A better practice would be to use `reject` instead to get a new array.  I'm keeping this PR focused on the actual bug though.