### PR TITLE
Run scenarios in fully random order

### DIFF
--- a/features/docs/cli/randomize.feature
+++ b/features/docs/cli/randomize.feature
@@ -10,14 +10,21 @@ Feature: Randomize
   the test run.
 
   Background:
-    Given a file named "features/bad_practice.feature" with:
+    Given a file named "features/bad_practice_part_1.feature" with:
       """
-      Feature: Bad practice
+      Feature: Bad practice, part 1
         
         Scenario: Set state
           Given I set some state
       
-        Scenario: Depend on state
+        Scenario: Depend on state from a preceding scenario
+          When I depend on the state
+      """
+    And a file named "features/bad_practice_part_2.feature" with:
+      """
+      Feature: Bad practice, part 2
+
+        Scenario: Depend on state from a preceding feature
           When I depend on the state
       """
     And a file named "features/step_definitions/steps.rb" with:
@@ -37,28 +44,39 @@ Feature: Randomize
 
   @spawn
   Scenario: Run scenarios randomized
-    When I run `cucumber --order random:41515 -q`
+    When I run `cucumber --order random:41516 -q`
     Then it should fail
     And the stdout should contain exactly:
       """
-      Feature: Bad practice
-      
-        Scenario: Depend on state
+      Feature: Bad practice, part 1
+
+        Scenario: Depend on state from a preceding scenario
           When I depend on the state
             I expect the state to be set! (RuntimeError)
             ./features/step_definitions/steps.rb:6:in `/^I depend on the state$/'
-            features/bad_practice.feature:7:in `When I depend on the state'
+            features/bad_practice_part_1.feature:7:in `When I depend on the state'
+
+      Feature: Bad practice, part 2
+
+        Scenario: Depend on state from a preceding feature
+          When I depend on the state
+            I expect the state to be set! (RuntimeError)
+            ./features/step_definitions/steps.rb:6:in `/^I depend on the state$/'
+            features/bad_practice_part_2.feature:4:in `When I depend on the state'
+
+      Feature: Bad practice, part 1
 
         Scenario: Set state
           Given I set some state
       
       Failing Scenarios:
-      cucumber features/bad_practice.feature:6
+      cucumber features/bad_practice_part_1.feature:6
+      cucumber features/bad_practice_part_2.feature:3
     
-      2 scenarios (1 failed, 1 passed)
-      2 steps (1 failed, 1 passed)
+      3 scenarios (2 failed, 1 passed)
+      3 steps (2 failed, 1 passed)
       
-      Randomized with seed 41515
+      Randomized with seed 41516
       
       """
 

--- a/features/docs/cli/randomize.feature
+++ b/features/docs/cli/randomize.feature
@@ -44,7 +44,7 @@ Feature: Randomize
 
   @spawn
   Scenario: Run scenarios randomized
-    When I run `cucumber --order random:41516 -q`
+    When I run `cucumber --order random:41529 -q`
     Then it should fail
     And the stdout should contain exactly:
       """
@@ -76,7 +76,7 @@ Feature: Randomize
       3 scenarios (2 failed, 1 passed)
       3 steps (2 failed, 1 passed)
       
-      Randomized with seed 41516
+      Randomized with seed 41529
       
       """
 

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -226,11 +226,11 @@ module Cucumber
       name_regexps = @configuration.name_regexps
       tag_limits = @configuration.tag_limits
       [].tap do |filters|
-        filters << Filters::Randomizer.new(@configuration.seed) if @configuration.randomize?
         filters << Filters::TagLimits.new(tag_limits) if tag_limits.any?
         filters << Cucumber::Core::Test::TagFilter.new(tag_expressions)
         filters << Cucumber::Core::Test::NameFilter.new(name_regexps)
         filters << Cucumber::Core::Test::LocationsFilter.new(filespecs.locations)
+        filters << Filters::Randomizer.new(@configuration.seed) if @configuration.randomize?
         filters << Filters::Quit.new
         # TODO: can we just use RbLanguages's step definitions directly?
         step_match_search = StepMatchSearch.new(@support_code.ruby.method(:step_matches), @configuration)


### PR DESCRIPTION
This documents the desired behaviour of the random order option across multiple features and corrects the ordering of filters within `runtime.rb` in order to run scenarios in a genuinely random order.

Previously, using `--order=random` resulted in the order of scenarios being randomised within a feature, but features themselves always proceeded in alphabetical (or ASCIIbetical) order based on their file path, i.e.:

    Feature: 1
      Scenario: 1B
      Scenario: 1A

    Feature: 2
      Scenario: 2B
      Scenario: 2A

Although `Randomizer` does indeed shuffle the scenarios, it was followed in the filter chain by `LocationsFilter` which groups scenarios by file path. Moving `Randomizer` later in the chain avoids this.

Now, each scenario is run in random order regardless of the name or path of the feature:

    Feature: 1
      Scenario: 1A

    Feature: 2
      Scenario: 2B
      Scenario: 2A

    Feature: 1
      Scenario: 1B

Fixes #969.