### PR TITLE
Demonstrate suggested way to capture output

### DIFF
--- a/features/docs/extending_cucumber/custom_formatter.feature
+++ b/features/docs/extending_cucumber/custom_formatter.feature
@@ -60,6 +60,7 @@ Feature: Custom Formatter
       {"foo"=>"bar", "one"=>"two"}
       """
 
+  @spawn
   Scenario: Support legacy --out
     Given a file named "features/support/custom_formatter.rb" with:
       """
@@ -67,7 +68,7 @@ Feature: Custom Formatter
         class Formatter
           def initialize(config, options={})
             config.on_event Cucumber::Events::FinishedTesting do |event|
-              puts options["out"]
+              $stdout.puts options["out"]
             end
           end
         end
@@ -76,13 +77,14 @@ Feature: Custom Formatter
     When I run `cucumber features/f.feature --format MyCustom::Formatter --out foo.file`
     Then it should pass with exactly:
       """
-      foo.file
       Deprecated: Please don't use --out, but pass the formatter options like this instead:
 
         --format junit,out=path/to/output
+      foo.file
 
       """
 
+  @spawn
   Scenario: Setting output using the new style per-formatter options
     Given a file named "features/support/custom_formatter.rb" with:
       """
@@ -90,7 +92,7 @@ Feature: Custom Formatter
         class Formatter
           def initialize(config, options={})
             config.on_event Cucumber::Events::FinishedTesting do |event|
-              puts options["out"]
+              $stdout.puts options["out"]
             end
           end
         end

--- a/lib/cucumber/cli/main.rb
+++ b/lib/cucumber/cli/main.rb
@@ -15,8 +15,8 @@ module Cucumber
       def initialize(args, _=nil, out=STDOUT, err=STDERR, kernel=Kernel)
         @args   = args
         @kernel = kernel
-        $stdout = @out = out
-        $stderr = @err = err
+        @out = out
+        @err = err
       end
 
       def execute!(existing_runtime = nil)


### PR DESCRIPTION
@maxmeyer this is my suggestion for how to deal with the issue we've
been discussing in #958, at least for now.

I think I understand your issue now (it's s00oo much easier with real code
in my hands sometimes!) and what I may have missed suggesting is to use
the `@spawn` tag which uses the "tranditional" adapter for Aruba instead
of the in-process one.

This commit shows you how you'd do that.