### PR TITLE
fix typo in lib/cucumber/step_match.rb

### DIFF
--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -2,7 +2,7 @@ require 'cucumber/multiline_argument'
 
 module Cucumber
 
-  # Represents the match found between a Test Step and it's activation
+  # Represents the match found between a Test Step and its activation
   class StepMatch #:nodoc:
     attr_reader :step_definition, :step_arguments
 


### PR DESCRIPTION
it's -> its