### PR TITLE
Change the Progress, Usage and Stepdef formatter use events

### DIFF
--- a/features/docs/defining_steps/printing_messages.feature
+++ b/features/docs/defining_steps/printing_messages.feature
@@ -135,7 +135,6 @@ Feature: Pretty formatter - Printing messages
         Multiple
         
         Announce
-        
         Me
         ..UUU
         Announce with fail

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -89,6 +89,30 @@ module Cucumber
       @options[:expand]
     end
 
+    def source?
+      @options[:source]
+    end
+
+    def duration?
+      @options[:duration]
+    end
+
+    def snippets?
+      @options[:snippets]
+    end
+
+    def skip_profile_information?
+      @options[:skip_profile_information]
+    end
+
+    def profiles
+      @options[:profiles] || []
+    end
+
+    def custom_profiles
+      profiles - [@options[:default_profile]]
+    end
+
     def paths
       @options[:paths]
     end

--- a/lib/cucumber/events.rb
+++ b/lib/cucumber/events.rb
@@ -19,6 +19,7 @@ module Cucumber
   module Events
     def self.registry
       Core::Events.build_registry(
+        StepDefinitionRegistered,
         StepMatch,
         TestRunFinished,
       )

--- a/lib/cucumber/events/step_definition_registered.rb
+++ b/lib/cucumber/events/step_definition_registered.rb
@@ -1,0 +1,23 @@
+require 'cucumber/core/events'
+
+module Cucumber
+  module Events
+
+    # Event fired after each step definition has been registered
+    class StepDefinitionRegistered < Core::Event.new(:step_definition)
+
+
+      #_The step definition that was just registered.
+      #
+      # @return [Cucumber::Core::Test::Case]
+      attr_reader :step_definition
+
+      #_@private
+      def initialize(step_definition)
+        @step_definition = step_definition
+      end
+
+    end
+
+  end
+end

--- a/lib/cucumber/formatter/progress.rb
+++ b/lib/cucumber/formatter/progress.rb
@@ -1,3 +1,5 @@
+require 'cucumber/core/report/summary'
+require 'cucumber/formatter/backtrace_filter'
 require 'cucumber/formatter/console'
 require 'cucumber/formatter/io'
 require 'cucumber/formatter/duration_extractor'
@@ -10,32 +12,58 @@ module Cucumber
       include Console
       include Io
       attr_reader :runtime
+      attr_reader :config, :summary
 
-      def initialize(runtime, path_or_io, options)
-        @runtime, @io, @options = runtime, ensure_io(path_or_io), options
+      def initialize(config)
+        @config, @io = config, ensure_io(config.out_stream)
         @previous_step_keyword = nil
         @snippets_input = []
         @total_duration = 0
+        @summary = Cucumber::Core::Report::Summary.new(config.event_bus)
+        @matches = {}
+        @pending_step_matches = []
+        @failed_results = []
+        @failed_test_cases = []
+        @passed_test_cases = []
+        config.on_event :step_match, &method(:on_step_match)
+        config.on_event :test_case_starting, &method(:on_test_case_starting)
+        config.on_event :test_step_finished, &method(:on_test_step_finished)
+        config.on_event :test_case_finished, &method(:on_test_case_finished)
+        config.on_event :test_run_finished, &method(:on_test_run_finished)
       end
 
-      def before_test_case(_test_case)
+      def on_step_match(event)
+        @matches[event.test_step.source] = event.step_match
+      end
+
+      def on_test_case_starting(_event)
         unless @profile_information_printed
-          print_profile_information
+          do_print_profile_information(config.profiles) unless config.skip_profile_information? || config.profiles.nil? || config.profiles.empty?
           @profile_information_printed = true
         end
         @previous_step_keyword = nil
       end
 
-      def after_test_step(test_step, result)
+      def on_test_step_finished(event)
+        test_step = event.test_step
+        result = event.result.with_filtered_backtrace(Cucumber::Formatter::BacktraceFilter)
         progress(result.to_sym) if !HookQueryVisitor.new(test_step).hook? || result.failed?
-        collect_snippet_data(test_step, result) unless HookQueryVisitor.new(test_step).hook?
+        unless HookQueryVisitor.new(test_step).hook?
+          collect_snippet_data(test_step, result) 
+          @pending_step_matches << @matches[test_step.source] if result.pending?
+          @failed_results << result if result.failed?
+        end
       end
 
-      def after_test_case(_test_case, result)
+      def on_test_case_finished(event)
+        test_case = event.test_case
+        result = event.result.with_filtered_backtrace(Cucumber::Formatter::BacktraceFilter)
+        @failed_test_cases << test_case if result.failed?
+        @passed_test_cases << test_case if result.passed?
         @total_duration += DurationExtractor.new(result).result_duration
       end
 
-      def done
+      def on_test_run_finished(_event)
         @io.puts
         @io.puts
         print_summary
@@ -44,11 +72,41 @@ module Cucumber
       private
 
       def print_summary
-        print_steps(:pending)
-        print_steps(:failed)
-        print_statistics(@total_duration, @options)
-        print_snippets(@options)
-        print_passing_wip(@options)
+        print_elements(@pending_step_matches, :pending, 'steps')
+        print_elements(@failed_results, :failed, 'steps')
+        print_statistics_local(@total_duration)
+        snippet_text_proc = lambda { |step_keyword, step_name, multiline_arg|
+          snippet_text(step_keyword, step_name, multiline_arg)
+        }
+        do_print_snippets(snippet_text_proc) if config.snippets? && summary.test_steps.total(:undefined) > 0
+        if config.wip?
+          messages = @passed_test_cases.map do |test_case|
+            message = linebreaks("#{test_case.location.on_line(test_case.location.line)}:in `#{test_case.name}'", ENV['CUCUMBER_TRUNCATE_OUTPUT'].to_i)
+          end
+          do_print_passing_wip(messages)
+        end
+      end
+
+      def print_statistics_local(duration)
+        if @failed_test_cases.any?
+          failed_test_cases_data = @failed_test_cases.map do |test_case|
+            TestCaseData.new(name="#{test_case.keyword}: #{test_case.name}", location=test_case.location)
+          end
+          print_failing_scenarios(failed_test_cases_data, config.custom_profiles, config.source?)
+        end
+
+        scenarios_proc = lambda{|status| summary.test_cases.total(status)}
+        @io.puts dump_summary_counts(summary.test_cases.total, scenarios_proc, "scenario") {|status_count, status| format_string(status_count, status)}
+        steps_proc = lambda{|status| summary.test_steps.total(status)}
+        @io.puts dump_summary_counts(summary.test_steps.total, steps_proc, "step") {|status_count, status| format_string(status_count, status)}
+        @io.puts(format_duration(duration)) if duration && config.duration?
+
+        if config.randomize?
+          @io.puts
+          @io.puts "Randomized with seed #{config.seed}"
+        end
+
+        @io.flush
       end
 
       CHARS = {
@@ -68,6 +126,8 @@ module Cucumber
       def table_header_cell?(status)
         status == :skipped_param
       end
+
+      TestCaseData = Struct.new(:name, :location)
     end
   end
 end

--- a/lib/cucumber/rb_support/rb_language.rb
+++ b/lib/cucumber/rb_support/rb_language.rb
@@ -9,6 +9,7 @@ require 'cucumber/gherkin/i18n'
 require 'multi_test'
 require 'cucumber/step_match'
 require 'cucumber/step_definition_light'
+require 'cucumber/events/step_definition_registered'
 
 module Cucumber
   module RbSupport
@@ -46,11 +47,11 @@ module Cucumber
       end
 
       def initialize(runtime, configuration)
-        @runtime = runtime
+        @runtime, @configuration = runtime, configuration
         @step_definitions = []
         RbDsl.rb_language = self
         @world_proc = @world_modules = nil
-        configuration.register_snippet_generator(Snippet::Generator.new)
+        @configuration.register_snippet_generator(Snippet::Generator.new)
       end
 
       def step_matches(name_to_match)
@@ -79,6 +80,7 @@ module Cucumber
       def register_rb_step_definition(regexp, proc_or_sym, options)
         step_definition = RbStepDefinition.new(self, regexp, proc_or_sym, options)
         @step_definitions << step_definition
+        @configuration.notify :step_definition_registered, step_definition
         step_definition
       end
 

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -57,9 +57,11 @@ module Cucumber
 
     require 'cucumber/wire/plugin'
     def run!
-      load_step_definitions
       install_wire_plugin
+      load_support_files
       fire_after_configuration_hook
+      formatters
+      load_step_definitions
       self.visitor = report
 
       receiver = Test::Runner.new(@configuration.event_bus)
@@ -244,8 +246,13 @@ module Cucumber
       end
     end
 
+    def load_support_files
+      files = @configuration.support_to_load
+      @support_code.load_files!(files)
+    end
+
     def load_step_definitions
-      files = @configuration.support_to_load + @configuration.step_defs_to_load
+      files = @configuration.step_defs_to_load
       @support_code.load_files!(files)
     end
 

--- a/spec/cucumber/formatter/progress_spec.rb
+++ b/spec/cucumber/formatter/progress_spec.rb
@@ -12,7 +12,7 @@ module Cucumber
       before(:each) do
         Cucumber::Term::ANSIColor.coloring = false
         @out = StringIO.new
-        @formatter = Progress.new(runtime, @out, Cucumber::Cli::Options.new)
+        @formatter = Progress.new(actual_runtime.configuration.with_options(out_stream: @out))
       end
 
       describe "given a single feature" do


### PR DESCRIPTION
Change the Progress, Usage and Stepdef formatter use events and also the new initialize method signature.

For the Usage formatter to be able to find out which step definitions that were not matched to any step, the StepDefinitionLoaded event is added. This also means that the step definitions are loaded after the AfterConfigurationHooks have been executed and the formatter have been created, whereas the support files are loaded before the AfterConfigurationHooks are executed.

The API:s of Cucumber::Formatter::Console and Cucumber::Formatter::Summary are extended, but are backward compatible as they are use both by the Pretty formatter and existing custom formatters.

To simplify the usage of Cucumber::Core::Test::Result::Summary its API has been extended in https://github.com/cucumber/cucumber-ruby-core/commit/e7fb8b77e99bc881e254a9c18a1b3c92e435af3c (already on master of Cucumber-Ruby-Core).