### PR TITLE
Refactor cli options

### DIFF
--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -95,17 +95,17 @@ module Cucumber
           end
 
           opts.on("#{RETRY_FLAG} ATTEMPTS", *retry_msg) {|v| set_option :retry, v.to_i }
-          opts.on("--i18n LANG", *i18n_msg) {|lang| set_language(lang) }
+          opts.on("--i18n LANG", *i18n_msg) {|lang| set_language lang }
           opts.on(FAIL_FAST_FLAG, "Exit immediately following the first failing scenario") { set_option :fail_fast }
-          opts.on("-f FORMAT", "--format FORMAT", *format_msg, *FORMAT_HELP) {|v| @options[:formats] << [v, @out_stream] }
-          opts.on('--init', *init_msg) {|v| ProjectInitializer.new.run && Kernel.exit(0) }
-          opts.on("-o", "--out [FILE|DIR]", *out_msg) {|v| set_out_stream(v) }
-          opts.on("-t TAG_EXPRESSION", "--tags TAG_EXPRESSION", *tags_msg) {|v| @options[:tag_expressions] << v }
-          opts.on("-n NAME", "--name NAME", *name_msg) {|v| @options[:name_regexps] << /#{v}/ }
-          opts.on("-e", "--exclude PATTERN", *exclude_msg) {|v| @options[:excludes] << Regexp.new(v) }
-          opts.on(PROFILE_SHORT_FLAG, "#{PROFILE_LONG_FLAG} PROFILE", *profile_short_flag_msg) {|v| @profiles << v }
-          opts.on(NO_PROFILE_SHORT_FLAG, NO_PROFILE_LONG_FLAG, *no_profile_short_flag_msg) {|v| @disable_profile_loading = true }
-          opts.on("-c", "--[no-]color", *color_msg) {|v| Cucumber::Term::ANSIColor.coloring = v }
+          opts.on("-f FORMAT", "--format FORMAT", *format_msg, *FORMAT_HELP) {|v| add_option :formats, [v, @out_stream] }
+          opts.on('--init', *init_msg) {|v| initialize_project }
+          opts.on("-o", "--out [FILE|DIR]", *out_msg) {|v| set_out_stream v }
+          opts.on("-t TAG_EXPRESSION", "--tags TAG_EXPRESSION", *tags_msg) {|v| add_option :tag_expressions, v }
+          opts.on("-n NAME", "--name NAME", *name_msg) {|v| add_option :name_regexps, /#{v}/ }
+          opts.on("-e", "--exclude PATTERN", *exclude_msg) {|v| add_option :excludes, Regexp.new(v) }
+          opts.on(PROFILE_SHORT_FLAG, "#{PROFILE_LONG_FLAG} PROFILE", *profile_short_flag_msg) {|v| add_profile v }
+          opts.on(NO_PROFILE_SHORT_FLAG, NO_PROFILE_LONG_FLAG, *no_profile_short_flag_msg) {|v| disable_profile_loading }
+          opts.on("-c", "--[no-]color", *color_msg) {|v| set_color v }
           opts.on("-d", "--dry-run", *dry_run_msg) { set_dry_run_and_duration }
           opts.on("-m", "--no-multiline", "Don't print multiline strings and tables under steps.") { set_option :no_multiline }
           opts.on("-s", "--no-source", "Don't print the file and line of the step definition with the steps.") { set_option :source, false }
@@ -332,8 +332,28 @@ TEXT
         end
       end
 
+      def disable_profile_loading
+        @disable_profile_loading = true
+      end
+
       def non_stdout_formats
         @options[:formats].select {|format, output| output != @out_stream }
+      end
+
+      def add_option(option, value)
+        @options[option] << value
+      end
+
+      def set_color(color)
+        Cucumber::Term::ANSIColor.coloring = color
+      end
+
+      def initialize_project
+        ProjectInitializer.new.run && Kernel.exit(0)
+      end
+
+      def add_profile(p)
+        @profiles << p
       end
 
       def set_option(option, value=nil)

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -94,9 +94,9 @@ module Cucumber
             opts.on("-j DIR", "--jars DIR", "Load all the jars under DIR") {|jars| load_jars(jars) }
           end
 
-          opts.on("#{RETRY_FLAG} ATTEMPTS", *retry_msg) {|v| @options[:retry] = v.to_i }
+          opts.on("#{RETRY_FLAG} ATTEMPTS", *retry_msg) {|v| set_option :retry, v.to_i }
           opts.on("--i18n LANG", *i18n_msg) {|lang| set_language(lang) }
-          opts.on(FAIL_FAST_FLAG, "Exit immediately following the first failing scenario") { options[:fail_fast] = true }
+          opts.on(FAIL_FAST_FLAG, "Exit immediately following the first failing scenario") { set_option :fail_fast }
           opts.on("-f FORMAT", "--format FORMAT", *format_msg, *FORMAT_HELP) {|v| @options[:formats] << [v, @out_stream] }
           opts.on('--init', *init_msg) {|v| ProjectInitializer.new.run && Kernel.exit(0) }
           opts.on("-o", "--out [FILE|DIR]", *out_msg) {|v| set_out_stream(v) }
@@ -107,19 +107,19 @@ module Cucumber
           opts.on(NO_PROFILE_SHORT_FLAG, NO_PROFILE_LONG_FLAG, *no_profile_short_flag_msg) {|v| @disable_profile_loading = true }
           opts.on("-c", "--[no-]color", *color_msg) {|v| Cucumber::Term::ANSIColor.coloring = v }
           opts.on("-d", "--dry-run", *dry_run_msg) { set_dry_run_and_duration }
-          opts.on("-m", "--no-multiline", "Don't print multiline strings and tables under steps.") { @options[:no_multiline] = true }
-          opts.on("-s", "--no-source", "Don't print the file and line of the step definition with the steps.") { @options[:source] = false }
-          opts.on("-i", "--no-snippets", "Don't print snippets for pending steps.") { @options[:snippets] = false }
-          opts.on("-I", "--snippet-type TYPE", *snippet_type_msg) {|v| @options[:snippet_type] = v.to_sym }
+          opts.on("-m", "--no-multiline", "Don't print multiline strings and tables under steps.") { set_option :no_multiline }
+          opts.on("-s", "--no-source", "Don't print the file and line of the step definition with the steps.") { set_option :source, false }
+          opts.on("-i", "--no-snippets", "Don't print snippets for pending steps.") { set_option :snippets, false }
+          opts.on("-I", "--snippet-type TYPE", *snippet_type_msg) {|v| set_option :snippet_type, v.to_sym }
           opts.on("-q", "--quiet", "Alias for --no-snippets --no-source.") { shut_up }
-          opts.on("--no-duration", "Don't print the duration at the end of the summary") { @options[:duration] = false }
+          opts.on("--no-duration", "Don't print the duration at the end of the summary") { set_option :duration, false }
           opts.on("-b", "--backtrace", "Show full backtrace for all errors.") { Cucumber.use_full_backtrace = true }
-          opts.on("-S", "--strict", "Fail if there are any undefined or pending steps.") { @options[:strict] = true }
-          opts.on("-w", "--wip", "Fail if there are any passing scenarios.") { @options[:wip] = true }
-          opts.on("-v", "--verbose", "Show the files and features loaded.") { @options[:verbose] = true }
-          opts.on("-g", "--guess", "Guess best match for Ambiguous steps.") { @options[:guess] = true }
-          opts.on("-l", "--lines LINES", *lines_msg) {|lines| @options[:lines] = lines }
-          opts.on("-x", "--expand", "Expand Scenario Outline Tables in output.") { @options[:expand] = true }
+          opts.on("-S", "--strict", "Fail if there are any undefined or pending steps.") { set_option :strict }
+          opts.on("-w", "--wip", "Fail if there are any passing scenarios.") { set_option :wip }
+          opts.on("-v", "--verbose", "Show the files and features loaded.") { set_option :verbose }
+          opts.on("-g", "--guess", "Guess best match for Ambiguous steps.") { set_option :guess }
+          opts.on("-l", "--lines LINES", *lines_msg) {|lines| set_option :lines, lines }
+          opts.on("-x", "--expand", "Expand Scenario Outline Tables in output.") { set_option :expand }
 
           opts.on("--order TYPE[:SEED]", "Run examples in the specified order. Available types:",
             *<<-TEXT.split("\n")) do |order|
@@ -334,6 +334,10 @@ TEXT
 
       def non_stdout_formats
         @options[:formats].select {|format, output| output != @out_stream }
+      end
+
+      def set_option(option, value=nil)
+        @options[option] = value.nil? ? true : value
       end
 
       def set_dry_run_and_duration

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -94,9 +94,7 @@ module Cucumber
             opts.on("-j DIR", "--jars DIR", "Load all the jars under DIR") {|jars| load_jars(jars) }
           end
 
-          opts.on("#{RETRY_FLAG} ATTEMPTS", "Specify the number of times to retry failing tests (default: 0)") do |v|
-            @options[:retry] = v.to_i
-          end
+          opts.on("#{RETRY_FLAG} ATTEMPTS", *retry_msg) {|v| @options[:retry] = v.to_i }
           opts.on("--i18n LANG", *i18n_msg) {|lang| set_language(lang) }
           opts.on(FAIL_FAST_FLAG, "Exit immediately following the first failing scenario") { options[:fail_fast] = true }
           opts.on("-f FORMAT", "--format FORMAT", *format_msg, *FORMAT_HELP) {|v| @options[:formats] << [v, @out_stream] }
@@ -232,6 +230,10 @@ TEXT
           "When feature files are defined in a profile and on the command line",
           "then only the ones from the command line are used."
         ]
+      end
+
+      def retry_msg
+        [ "Specify the number of times to retry failing tests (default: 0)" ]
       end
 
       def name_msg

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -26,9 +26,7 @@ module Cucumber
         'debug'       => ['Cucumber::Formatter::Debug',       'For developing formatters - prints the calls made to the listeners.']
       }
       max = BUILTIN_FORMATS.keys.map{|s| s.length}.max
-      FORMAT_HELP = (BUILTIN_FORMATS.keys.sort.map do |key|
-        "  #{key}#{' ' * (max - key.length)} : #{BUILTIN_FORMATS[key][1]}"
-      end) + ["Use --format rerun --out rerun.txt to write out failing",
+      FORMAT_HELP_MSG = ["Use --format rerun --out rerun.txt to write out failing",
         "features. You can rerun them with cucumber @rerun.txt.",
         "FORMAT can also be the fully qualified class name of",
         "your own custom formatter. If the class isn't loaded,",
@@ -39,6 +37,10 @@ module Cucumber
         "path underneath your features/support directory or anywhere",
         "on Ruby's LOAD_PATH, for example in a Ruby gem."
       ]
+
+      FORMAT_HELP = (BUILTIN_FORMATS.keys.sort.map do |key|
+        "  #{key}#{' ' * (max - key.length)} : #{BUILTIN_FORMATS[key][1]}"
+      end) + FORMAT_HELP_MSG
       PROFILE_SHORT_FLAG = '-p'
       NO_PROFILE_SHORT_FLAG = '-P'
       PROFILE_LONG_FLAG = '--profile'
@@ -265,8 +267,7 @@ TEXT
       protected :options, :profiles, :expanded_args
 
     private
-
-      def no_profile_short_tag_msg
+      def no_profile_short_flag_msg
         [
           "Disables all profile loading to avoid using the 'default' profile."
         ]


### PR DESCRIPTION
## Summary

This PR refactors the `#parse!` method for the `Cucumber::Cli::Options` class.

## Details

I extracted descriptions and option handlers to new private methods and turned the `opts.on` blocks into single lines.

## Motivation and Context

I noticed that Code Climate had rated this class F, and when I looked at the code, I could see why. I think the new way is more readable.

## How Has This Been Tested?

I tested the changes using the existing test suite to check for regressions. Since I didn't add or remove functionality, new tests were not required.