### PR TITLE
Remove tolerance for @wip scenarios in build

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -2,10 +2,10 @@
 cucumber_pro_opts = ENV['ENABLE_CUCUMBER_PRO'] ? "--format Cucumber::Pro --out /dev/null" : ""
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format progress features" : "--format pretty #{rerun}"
-std_opts = "--format progress features --tags ~@wip --tags ~@wip-new-core -r features --strict #{cucumber_pro_opts}"
+std_opts = "--format progress features -r features --strict #{cucumber_pro_opts}"
 std_opts << " --tags ~@wip-jruby" if defined?(JRUBY_VERSION)
 
-wip_opts = "--color -r features --tags @wip,@wip-new-core"
+wip_opts = "--color -r features --tags @wip"
 wip_opts << ",@wip-jruby" if defined?(JRUBY_VERSION)
 %>
 default:     <%= std_opts %> --tags ~@jruby


### PR DESCRIPTION
## Summary

Clean up `@wip` scenarios from the default profile config, and avoid them being allowed again.

## Details

When I merged in #920, I missed the fact that the scenarios in that PR still had a `@wip` tag and were in fact still failing. This was actually expected, as we'd already discussed in that PR that the summary output is currently unable to handle retried scenarios.

## Motivation and Context

We want our build to fail if there are any `@wip` tagged scenarios that are failing, so we don't build up technical debt.

## To do

- [x] change the two `@wip` scenarios to match the current output
- [x] remove the `@wip` tags
- [x] create a new issue to specify the right output for retry (and link it to #920 because it will be much easier to implement once that is done)