### PR TITLE
Remove wip tag

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,7 @@
 
 ### Bugfixes
 
+* Use HTTPS instead of Git as transport protocol ([#960](https://github.com/cucumber/cucumber-ruby/pull/960))
 * Make random order stable and platform independent ([#974](https://github.com/cucumber/cucumber-ruby/pull/974), closes [#971](https://github.com/cucumber/cucumber-ruby/issues/971))
 * Run scenarios in fully random order ([#970](https://github.com/cucumber/cucumber-ruby/pull/970) @threedaymonk)
 * Adding Test Step in AfterStep hook. ([#931](https://github.com/cucumber/cucumber-ruby/pull/931) @t-morgan)

--- a/features/docs/cli/retry_failing_tests.feature
+++ b/features/docs/cli/retry_failing_tests.feature
@@ -1,22 +1,21 @@
-@wip
 Feature: Retry failing tests
 
   Retry gives you a way to get through flaky tests that usually pass after a few runs.
   This gives a development team a way forward other than disabling a valuable test.
-  
+
   - Specify max retry count in option
   - Output information to the screen
   - Output retry information in test report
-  
+
   Questions:
   use a tag for flaky tests?  Global option to retry any test that fails?
-  
+
   Background:
     Given a scenario "Flakey" that fails once, then passes
     And a scenario "Shakey" that fails twice, then passes
     And a scenario "Solid" that passes
     And a scenario "No Dice" that fails
-  
+
   Scenario:
     When I run `cucumber -q --retry 1`
     Then it should fail with:


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

This PR removes the `@wip` tag from `retry_failing_tests.feature`.

## Details

Since `retry_failing_tests.feature` is now fully implemented and passes, it should not be tagged as `@wip` as this will break the build after #981 is merged.

## Motivation and Context

Since we have decided not to allow `@wip` features on master, we need to remove the `@wip` tag from features already on master (and, of course, fix ones that don't pass). This will prevent the build from breaking due to the presence of features that should not have been merged. (Something tells me this whole paragraph doesn't make much sense.)

## How Has This Been Tested?

The feature was already passing, so removing the tag doesn't require additional tests.
