### PR TITLE
Resolve issue 961

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,16 @@ gemspec
 unless ENV['CUCUMBER_USE_RELEASED_CORE']
   core_path = File.expand_path("../../cucumber-ruby-core", __FILE__)
   wire_path = File.expand_path("../../cucumber-ruby-wire", __FILE__)
-  if File.exist?(core_path) && !ENV['CUCUMBER_USE_GIT_CORE']
-    gem 'cucumber-core', :path => core_path
-    gem 'cucumber-wire', :path => wire_path
+  if File.exist?(core_path) && !ENV["cucumber_use_git_core"]
+    gem "cucumber-core", :path => core_path
   else
-    gem 'cucumber-core', :git => "https://github.com/cucumber/cucumber-ruby-core.git"
+    gem "cucumber-core", :git => "git://github.com/cucumber/cucumber-ruby-core.git"
+  end
+
+  if File.exist?(wire_path) && !ENV["CUCUMBER_USE_GIT_CORE"]
+    gem "cucumber-wire", :path => wire_path
+  else
+    gem "cucumber-wire", :git => "git://github.com/cucumber/cucumber-ruby-wire.git"
   end
 end
 

--- a/History.md
+++ b/History.md
@@ -6,6 +6,7 @@
 
 ### Bugfixes
 
+* Use HTTPS instead of Git as transport protocol ([#960](https://github.com/cucumber/cucumber-ruby/pull/960))
 * Make random order stable and platform independent ([#974](https://github.com/cucumber/cucumber-ruby/pull/974), closes [#971](https://github.com/cucumber/cucumber-ruby/issues/971))
 * Run scenarios in fully random order ([#970](https://github.com/cucumber/cucumber-ruby/pull/970) @threedaymonk)
 * Adding Test Step in AfterStep hook. ([#931](https://github.com/cucumber/cucumber-ruby/pull/931) @t-morgan)


### PR DESCRIPTION
## Summary

This PR resolves issue #961, where `bundle install` fails because of `cucumber-ruby-wire`. It makes changes to the Gemfile so that if the user does not have `cucumber-ruby-wire` locally, or doesn't have it in the expected location, it will be fetched from git instead of erroring out.

## Details

Added a conditional to the Gemfile to check whether the `cucumber-ruby-wire` code exists locally in the expected location and, if not, gets it from git instead.

## Motivation and Context

This issue was causing errors in `bundle install`, making it harder for developers to work on Cucumber.

## How Has This Been Tested?

Gemfile change probably doesn't need tests.

## Screenshots (if appropriate):

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
