### PR TITLE
Fix typo in loading file specs

### DIFF
--- a/spec/cucumber/rb_support/rb_language_spec.rb
+++ b/spec/cucumber/rb_support/rb_language_spec.rb
@@ -17,10 +17,11 @@ module Cucumber
       describe "#load_code_file" do
         after do
           FileUtils.rm_rf('tmp.rb')
+          FileUtils.rm_rf('docs.md')
         end
 
         def a_file_called(name)
-          File.open('tmp.rb', 'w') do |f|
+          File.open(name, 'w') do |f|
             f.puts yield
           end
         end
@@ -43,10 +44,10 @@ module Cucumber
         end
 
         it "only loads ruby files" do
-          a_file_called("readme.md") do
+          a_file_called("docs.md") do
             "yo"
           end
-          rb.load_code_file('readme.md')
+          rb.load_code_file('docs.md')
         end
       end
 


### PR DESCRIPTION
## Details

Previously spec didn't create file before trying to load it. While it's a minor problem, it does not reproduce real test case. Also, I've changed the test file name, as it was changing the actual README.md of the project in the test.

## Motivation and Context

It improves quality of tests.

## How Has This Been Tested?

Running locally, Travis build of fork is [green](https://travis-ci.org/brain-geek/cucumber-ruby/builds/137108960).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)