### PR TITLE
CLI --language option

### DIFF
--- a/features/docs/cli/language.feature
+++ b/features/docs/cli/language.feature
@@ -1,4 +1,4 @@
-@wip
+# @wip
 Feature: Specifying a different spoken language for runs
 
   An

--- a/features/docs/cli/language.feature
+++ b/features/docs/cli/language.feature
@@ -103,7 +103,7 @@ Feature: Specifying a different spoken language for runs
           Given I have deposited ¥10000 in my account
       """
     When I run `cucumber -L ja`
-    Then it should raise Parser errors
+    Then it should raise parser errors
 
   Scenario: A language header is present
     Given a file named "features/cash_withdrawal.feature" with:

--- a/features/docs/cli/language.feature
+++ b/features/docs/cli/language.feature
@@ -1,0 +1,50 @@
+@wip
+Feature: Specifying a different spoken language for runs
+
+  An
+
+    -L, --language LANGUAGE
+
+  option that allows users to switch to a different language
+  without adding a language header to each feature file
+
+  Scenario: An unknown language specified
+    Given an empty file named "features/whatever.feature"
+    When I run `cucumber --language foo`
+    Then it should fail with:
+      """
+      Sorry, we don't recognize this language.
+      Try 'cucumber --i18n help', and look up the abbreviation
+      of the language you want to use in the list.
+      """
+
+  Scenario: Specified language agrees with the language in use
+    Given a file named "features/cash_withdrawal.feature" with:
+      """
+      フィーチャ: 現金引き出し
+        シナリオ: 信用口座から現金を引き出すことができます
+          前提私は自分の口座に¥10000を貯金しました
+      """
+    When I run `cucumber -L ja`
+    Then it should pass
+
+  Scenario: Specified language does not agree with the language in use
+    Given a file named "features/cash_withdrawal.feature" with:
+      """
+      Feature: Cash withdrawal
+        Scenario: Successful withdrawal from an account in credit
+          Given I have deposited ¥10000 in my account
+      """
+    When I run `cucumber -L ja`
+    Then it should raise Parser errors
+
+  Scenario: A language header is present
+    Given a file named "features/cash_withdrawal.feature" with:
+      """
+      # language: en
+      Feature: Cash withdrawal
+        Scenario: Successful withdrawal from an account in credit
+          Given I have deposited ¥10000 in my account
+      """
+    When I run `cucumber -L ja`
+    Then it should pass

--- a/features/docs/cli/language.feature
+++ b/features/docs/cli/language.feature
@@ -13,9 +13,76 @@ Feature: Specifying a different spoken language for runs
     When I run `cucumber --language foo`
     Then it should fail with:
       """
-      Sorry, we don't recognize this language.
-      Try 'cucumber --i18n help', and look up the abbreviation
-      of the language you want to use in the list.
+      Invalid language 'foo'. Available languages are:
+
+        | af        | Afrikaans           | Afrikaans         |
+        | am        | Armenian            | հայերեն           |
+        | ar        | Arabic              | العربية           |
+        | bg        | Bulgarian           | български         |
+        | bm        | Malay               | Bahasa Melayu     |
+        | bs        | Bosnian             | Bosanski          |
+        | ca        | Catalan             | català            |
+        | cs        | Czech               | Česky             |
+        | cy-GB     | Welsh               | Cymraeg           |
+        | da        | Danish              | dansk             |
+        | de        | German              | Deutsch           |
+        | el        | Greek               | Ελληνικά          |
+        | em        | Emoji               | 😀                 |
+        | en        | English             | English           |
+        | en-Scouse | Scouse              | Scouse            |
+        | en-au     | Australian          | Australian        |
+        | en-lol    | LOLCAT              | LOLCAT            |
+        | en-old    | Old English         | Englisc           |
+        | en-pirate | Pirate              | Pirate            |
+        | eo        | Esperanto           | Esperanto         |
+        | es        | Spanish             | español           |
+        | et        | Estonian            | eesti keel        |
+        | fa        | Persian             | فارسی             |
+        | fi        | Finnish             | suomi             |
+        | fr        | French              | français          |
+        | ga        | Irish               | Gaeilge           |
+        | gj        | Gujarati            | ગુજરાતી           |
+        | gl        | Galician            | galego            |
+        | he        | Hebrew              | עברית             |
+        | hi        | Hindi               | हिंदी             |
+        | hr        | Croatian            | hrvatski          |
+        | ht        | Creole              | kreyòl            |
+        | hu        | Hungarian           | magyar            |
+        | id        | Indonesian          | Bahasa Indonesia  |
+        | is        | Icelandic           | Íslenska          |
+        | it        | Italian             | italiano          |
+        | ja        | Japanese            | 日本語               |
+        | jv        | Javanese            | Basa Jawa         |
+        | kn        | Kannada             | ಕನ್ನಡ             |
+        | ko        | Korean              | 한국어               |
+        | lt        | Lithuanian          | lietuvių kalba    |
+        | lu        | Luxemburgish        | Lëtzebuergesch    |
+        | lv        | Latvian             | latviešu          |
+        | mn        | Mongolian           | монгол            |
+        | nl        | Dutch               | Nederlands        |
+        | no        | Norwegian           | norsk             |
+        | pa        | Panjabi             | ਪੰਜਾਬੀ            |
+        | pl        | Polish              | polski            |
+        | pt        | Portuguese          | português         |
+        | ro        | Romanian            | română            |
+        | ru        | Russian             | русский           |
+        | sk        | Slovak              | Slovensky         |
+        | sl        | Slovenian           | Slovenski         |
+        | sr-Cyrl   | Serbian             | Српски            |
+        | sr-Latn   | Serbian (Latin)     | Srpski (Latinica) |
+        | sv        | Swedish             | Svenska           |
+        | ta        | Tamil               | தமிழ்             |
+        | th        | Thai                | ไทย               |
+        | tl        | Telugu              | తెలుగు            |
+        | tlh       | Klingon             | tlhIngan          |
+        | tr        | Turkish             | Türkçe            |
+        | tt        | Tatar               | Татарча           |
+        | uk        | Ukrainian           | Українська        |
+        | ur        | Urdu                | اردو              |
+        | uz        | Uzbek               | Узбекча           |
+        | vi        | Vietnamese          | Tiếng Việt        |
+        | zh-CN     | Chinese simplified  | 简体中文              |
+        | zh-TW     | Chinese traditional | 繁體中文              |
       """
 
   Scenario: Specified language agrees with the language in use

--- a/features/lib/step_definitions/language_steps.rb
+++ b/features/lib/step_definitions/language_steps.rb
@@ -7,3 +7,7 @@ Then(/^cucumber lists all the supported languages$/) do
     expect(all_output.force_encoding('utf-8')).to include(language)
   end
 end
+
+Then(/^it should raise parser errors$/) do
+  step "it should fail with:", "Parser error"
+end

--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -74,6 +74,10 @@ module Cucumber
         @options[:snippet_type] || :regexp
       end
 
+      def language
+        @options[:language] || 'en'
+      end
+
       def log
         logger = Logger.new(@out_stream)
         logger.formatter = LogFormatter.new

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -96,7 +96,7 @@ module Cucumber
             opts.on('-j DIR', '--jars DIR', 'Load all the jars under DIR') {|jars| load_jars(jars) }
           end
 
-          opts.on("-L LANGUAGE", "--language LANGUAGE") {|v| set_option :language, v }
+          opts.on("-L LANGUAGE", "--language LANGUAGE", "Set language") {|v| set_option :language, v }
           opts.on("#{RETRY_FLAG} ATTEMPTS", *retry_msg) {|v| set_option :retry, v.to_i }
           opts.on('--i18n LANG', *i18n_msg) {|lang| set_language lang }
           opts.on(FAIL_FAST_FLAG, 'Exit immediately following the first failing scenario') { set_option :fail_fast }

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -96,6 +96,7 @@ module Cucumber
             opts.on('-j DIR', '--jars DIR', 'Load all the jars under DIR') {|jars| load_jars(jars) }
           end
 
+          opts.on("-L LANGUAGE", "--language LANGUAGE") {|v| set_option :language, v }
           opts.on("#{RETRY_FLAG} ATTEMPTS", *retry_msg) {|v| set_option :retry, v.to_i }
           opts.on('--i18n LANG', *i18n_msg) {|lang| set_language lang }
           opts.on(FAIL_FAST_FLAG, 'Exit immediately following the first failing scenario') { set_option :fail_fast }
@@ -138,8 +139,8 @@ TEXT
             end
           end
 
-          opts.on_tail('--version', 'Show version.') { exit_ok(Cucumber::VERSION) }
-          opts.on_tail('-h', '--help', "You're looking at it.") { exit_ok(opts.help) }
+          opts.on_tail('--version', 'Show version.') { show_version }
+          opts.on_tail('-h', '--help', 'You\'re looking at it.') { show_help(opts) }
         end.parse!
 
         @args.map! { |a| "#{a}:#{@options[:lines]}" } if @options[:lines]
@@ -396,8 +397,13 @@ TEXT
         @options[:duration] = false
       end
 
-      def exit_ok(text)
-        @out_stream.puts text
+      def show_help(opts)
+        @out_stream.puts opts.help
+        Kernel.exit(0)
+      end
+
+      def show_version
+        @out_stream.puts Cucumber::VERSION
         Kernel.exit(0)
       end
 

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -63,6 +63,10 @@ module Cucumber
       @options[:fail_fast]
     end
 
+    def language
+      @options[:language]
+    end
+
     def retry_attempts
       @options[:retry]
     end

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -120,7 +120,7 @@ module Cucumber
       @features ||= feature_files.map do |path|
         source = NormalisedEncodingFile.read(path)
         @configuration.notify :gherkin_source_read, path, source
-        Cucumber::Core::Gherkin::Document.new(path, source)
+        Cucumber::Core::Gherkin::Document.new(path, source, @configuration.language)
       end
     end
 

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -50,7 +50,7 @@ module Cli
       it 'sets the language' do
         config.parse!(%w{--language it})
 
-        expect(config.options[:language]).to eql 'it'
+        expect(config.language).to eql 'it'
       end
     end
 

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -46,6 +46,14 @@ module Cli
       expect(config.options[:require]).to include('some_file')
     end
 
+    context '--language' do
+      it 'sets the language' do
+        config.parse!(%w{--language it})
+
+        expect(config.options[:language]).to eql 'it'
+      end
+    end
+
     context '--profile' do
       include RSpec::WorkInProgress
 

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -144,7 +144,11 @@ module Cucumber
 
             options.parse!(%w{-f pretty})
 
+<<<<<<< HEAD
             expect(options[:formats]).to eq [['pretty', {}, output_stream], ['junit', {}, 'result.xml']]
+=======
+            expect(options[:formats]).to eq [['pretty', output_stream], ["junit", "result.xml"]]
+>>>>>>> Correct some typos
           end
         end
 
@@ -209,7 +213,7 @@ module Cucumber
             expect(options[:verbose]).to be true
           end
 
-          it "gives precendene to the origianl options' paths" do
+          it "gives precedence to the original options' paths" do
             given_cucumber_yml_defined_as('foo' => %w[features])
             options.parse!(%w[my.feature -p foo])
 
@@ -327,7 +331,11 @@ module Cucumber
             expect(options[:duration]).to be false
           end
 
+<<<<<<< HEAD
           it 'uses --no-duration when defined in the profile' do
+=======
+          it "uses --no-duration when defined in the profile" do
+>>>>>>> Correct some typos
             given_cucumber_yml_defined_as('foo' => '--no-duration')
             options.parse!(%w[-p foo])
 
@@ -383,13 +391,21 @@ module Cucumber
 
         context '--retry ATTEMPTS' do
           it 'is 0 by default' do
+<<<<<<< HEAD
             after_parsing('') do
+=======
+            after_parsing("") do
+>>>>>>> Correct some typos
               expect(options[:retry]).to eql 0
             end
           end
 
           it 'sets the options[:retry] value' do
+<<<<<<< HEAD
             after_parsing('--retry 4') do
+=======
+            after_parsing("--retry 4") do
+>>>>>>> Correct some typos
               expect(options[:retry]).to eql 4
             end
           end

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -195,6 +195,12 @@ module Cucumber
           end
         end
 
+        context '-L LANGUAGE or --language LANGUAGE' do
+          it "sets the language" do
+            after_parsing('--language it') { expect(options[:language]).to eq 'it' }
+          end
+        end
+
         context '-p PROFILE or --profile PROFILE' do
           it 'uses the default profile passed in during initialization if none are specified by the user' do
             given_cucumber_yml_defined_as({'default' => '--require some_file'})


### PR DESCRIPTION
This PR reintroduces the changes made in @esdoppio's closed PR #975. 
## Summary

This is a feature file for a new CLI flag, `--language`, enriching the API for users to select i18n options using the command line tool.
## Details

The feature describes a proposed command line flag `-L, --language`, that would enable a user to select a language using the command line tool without having to add a language header to each feature file. Using this option, features would be run in the specified language, raising an error if the language specified on the command line is not the one in use in the feature file. The command line option would be overridden by a language header if one is present.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
