### PR TITLE
Fix regression displaying CLI help

### DIFF
--- a/features/docs/cli/help.feature
+++ b/features/docs/cli/help.feature
@@ -1,0 +1,8 @@
+Feature: Help
+
+  Running `cucumber --help` shows you command-line options.
+
+  Scenario: Show help
+    When I run `cucumber --help`
+    Then it should pass
+    And I should see the CLI help

--- a/features/lib/step_definitions/cli_steps.rb
+++ b/features/lib/step_definitions/cli_steps.rb
@@ -1,0 +1,3 @@
+Then(/^I should see the CLI help$/) do
+  expect(all_output).to include("Usage:")
+end

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -135,7 +135,7 @@ TEXT
           end
 
           opts.on_tail("--version", "Show version.") { show_version }
-          opts.on_tail("-h", "--help", "You're looking at it.") { show_help }
+          opts.on_tail("-h", "--help", "You're looking at it.") { show_help(opts.help) }
         end.parse!
 
         @args.map! { |a| "#{a}:#{@options[:lines]}" } if @options[:lines]
@@ -365,8 +365,8 @@ TEXT
         @options[:duration] = false
       end
 
-      def show_help
-        @out_stream.puts opts.help
+      def show_help(text)
+        @out_stream.puts text
         Kernel.exit(0)
       end
 

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -134,8 +134,8 @@ TEXT
             end
           end
 
-          opts.on_tail("--version", "Show version.") { show_version }
-          opts.on_tail("-h", "--help", "You're looking at it.") { show_help(opts.help) }
+          opts.on_tail("--version", "Show version.") { exit_ok(Cucumber::VERSION) }
+          opts.on_tail("-h", "--help", "You're looking at it.") { exit_ok(opts.help) }
         end.parse!
 
         @args.map! { |a| "#{a}:#{@options[:lines]}" } if @options[:lines]
@@ -365,13 +365,8 @@ TEXT
         @options[:duration] = false
       end
 
-      def show_help(text)
+      def exit_ok(text)
         @out_stream.puts text
-        Kernel.exit(0)
-      end
-
-      def show_version
-        @out_stream.puts Cucumber::VERSION
         Kernel.exit(0)
       end
 


### PR DESCRIPTION
## Summary

Fix regression displaying CLI help

## Details

Added a test, added a quick fix.

## Motivation and Context

`cucumber --help` was broken.

## How Has This Been Tested?

Added a new feature - surprised we didn't already have one!

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
