### PR TITLE
Document events

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -192,12 +192,11 @@ Style/AndOr:
 Style/AsciiComments:
   Exclude:
     - 'lib/cucumber/encoding.rb'
-    - 'lib/cucumber/events/step_definition_registered.rb'
-    - 'lib/cucumber/events/step_match.rb'
-    - 'lib/cucumber/events/test_run_finished.rb'
+    - 'lib/cucumber/events/*'
     - 'lib/cucumber/filters/randomizer.rb'
     - 'lib/cucumber/formatter/html.rb'
     - 'lib/cucumber/formatter/legacy_api/adapter.rb'
+    - 'lib/cucumber/rb_support/rb_step_definition.rb'
     - 'lib/cucumber/running_test_case.rb'
     - 'lib/cucumber/runtime.rb'
     - 'spec/cucumber/formatter/legacy_api/adapter_spec.rb'

--- a/features/docs/api/listen_for_events.feature
+++ b/features/docs/api/listen_for_events.feature
@@ -19,7 +19,7 @@ Feature: Listen for events
       """
       AfterConfiguration do |config|
         io = config.out_stream
-        config.on_event :step_match do |event|
+        config.on_event :step_activated do |event|
           io.puts "Success!"
           io.puts "Step name:       #{event.test_step.name}"
           io.puts "Source location: #{event.step_match.location}"

--- a/features/docs/events/step_activated_event.feature
+++ b/features/docs/events/step_activated_event.feature
@@ -1,29 +1,36 @@
 Feature: Step Activated Event
 
-  This event is fired when Cucumber loads the user's step definitions. Typically, this is
-  when the `Given /^my step$/ do` methods are called.
+  This event is fired when Cucumber finds a matching definition for a Gherkin step.
 
-  See [the API documentation](http://www.rubydoc.info/github/cucumber/cucumber-ruby/Cucumber/Events/StepDefinitionRegistered) for more information about the data available on this event.
+  See [the API documentation](http://www.rubydoc.info/github/cucumber/cucumber-ruby/Cucumber/Events/StepActivated)
+  for more information about the data available on this event.
 
-  Scenario: Register a new step definition
-    Given the standard step definitions
-    And a file named "features/step_definitions/steps.rb" with:
+  Scenario: Activate a step
+    Given a file named "features/step_definitions/steps.rb" with:
       """
       Given /a step/ do
         # automation goes here
       end
       """
+    And a file named "features/test.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given a step
+      """
     And a file named "features/support/events.rb" with:
       """
       AfterConfiguration do |config|
-        config.on_event :step_definition_registered do |event|
-          config.out_stream.puts "The step definition: #{event.step_definition.location}"
+        config.on_event :step_activated do |event|
+          config.out_stream.puts "The step: #{event.test_step.location}"
+          config.out_stream.puts "The step definition: #{event.step_match.location}"
         end
       end
       """
     When I run `cucumber`
     Then it should pass with:
       """
+      The step: features/test.feature:3
       The step definition: features/step_definitions/steps.rb:1
       """
 

--- a/features/docs/events/step_activated_event.feature
+++ b/features/docs/events/step_activated_event.feature
@@ -1,0 +1,29 @@
+Feature: Step Activated Event
+
+  This event is fired when Cucumber loads the user's step definitions. Typically, this is
+  when the `Given /^my step$/ do` methods are called.
+
+  See [the API documentation](http://www.rubydoc.info/github/cucumber/cucumber-ruby/Cucumber/Events/StepDefinitionRegistered) for more information about the data available on this event.
+
+  Scenario: Register a new step definition
+    Given the standard step definitions
+    And a file named "features/step_definitions/steps.rb" with:
+      """
+      Given /a step/ do
+        # automation goes here
+      end
+      """
+    And a file named "features/support/events.rb" with:
+      """
+      AfterConfiguration do |config|
+        config.on_event :step_definition_registered do |event|
+          config.out_stream.puts "The step definition: #{event.step_definition.location}"
+        end
+      end
+      """
+    When I run `cucumber`
+    Then it should pass with:
+      """
+      The step definition: features/step_definitions/steps.rb:1
+      """
+

--- a/features/docs/events/step_definition_registered_event.feature
+++ b/features/docs/events/step_definition_registered_event.feature
@@ -1,0 +1,29 @@
+Feature: Step definition registered
+
+  This event is fired when Cucumber loads the user's step definitions. Typically, this is
+  when the `Given /^my step$/ do` methods are called.
+
+  See [the API documentation](http://www.rubydoc.info/github/cucumber/cucumber-ruby/Cucumber/Events/StepDefinitionRegistered) for more information about the data available on this event.
+
+  Scenario: Register a new step definition
+    Given the standard step definitions
+    And a file named "features/step_definitions/steps.rb" with:
+      """
+      Given /a step/ do
+        # automation goes here
+      end
+      """
+    And a file named "features/support/events.rb" with:
+      """
+      AfterConfiguration do |config|
+        config.on_event :step_definition_registered do |event|
+          config.out_stream.puts "The step definition: #{event.step_definition.location}"
+        end
+      end
+      """
+    When I run `cucumber`
+    Then it should pass with:
+      """
+      The step definition: features/step_definitions/steps.rb:1
+      """
+

--- a/features/docs/events/test_case_finished_event.feature
+++ b/features/docs/events/test_case_finished_event.feature
@@ -4,6 +4,8 @@ Feature: Test Case Finished Event
   Test Case) has finished executing. You can use the event to learn about the 
   result of the test case.
 
+  See [the API documentation](http://www.rubydoc.info/github/cucumber/cucumber-ruby/Cucumber/Events/TestCaseFinished) for more information about the data available on this event.
+
   Scenario: Test case passes
     Given the standard step definitions
     And a file named "features/passing.feature" with:

--- a/features/docs/events/test_case_finished_event.feature
+++ b/features/docs/events/test_case_finished_event.feature
@@ -8,20 +8,26 @@ Feature: Test Case Finished Event
     Given the standard step definitions
     And a file named "features/passing.feature" with:
       """
-      Feature:
-        Scenario:
+      Feature: A feature
+        Scenario: A scenario
           Given this step passes
       """
     And a file named "features/support/events.rb" with:
       """
       AfterConfiguration do |config|
         config.on_event :test_case_finished do |event|
-          config.out_stream.puts "The result is #{event.result}"
+          config.out_stream.puts "Results"
+          config.out_stream.puts "-------"
+          config.out_stream.puts "Test case: #{event.test_case.name}"
+          config.out_stream.puts "The result is: #{event.result}"
         end
       end
       """
     When I run `cucumber`
     Then it should pass with:
       """
-      The result is ✓
+      Results
+      -------
+      Test case: A scenario
+      The result is: ✓
       """

--- a/features/docs/events/test_case_finished_event.feature
+++ b/features/docs/events/test_case_finished_event.feature
@@ -1,0 +1,27 @@
+Feature: Test Case Finished Event
+
+  This event is fired after each scenario or examples table row (generally named a 
+  Test Case) has finished executing. You can use the event to learn about the 
+  result of the test case.
+
+  Scenario: Test case passes
+    Given the standard step definitions
+    And a file named "features/passing.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given this step passes
+      """
+    And a file named "features/support/events.rb" with:
+      """
+      AfterConfiguration do |config|
+        config.on_event :test_case_finished do |event|
+          config.out_stream.puts "The result is #{event.result}"
+        end
+      end
+      """
+    When I run `cucumber`
+    Then it should pass with:
+      """
+      The result is ✓
+      """

--- a/features/docs/events/test_case_starting_event.feature
+++ b/features/docs/events/test_case_starting_event.feature
@@ -1,0 +1,46 @@
+Feature: Test Case Starting Event
+
+  This event is fired just before each scenario or scenario outline example row
+  (generally named a Test Case) starts to be executed. This event is read-only.
+
+  See [the API documentation](http://www.rubydoc.info/github/cucumber/cucumber-ruby/Cucumber/Events/TestCaseStarting) for more information about the data available on this event and the result object.
+
+  Background:
+    Given the standard step definitions
+    And a file named "features/test.feature" with:
+      """
+      Feature: A feature
+
+        Scenario: A passing scenario
+          Given this is a step
+      """
+    And a file named "features/support/events.rb" with:
+      """
+      stdout = nil
+      AfterConfiguration do |config|
+        stdout = config.out_stream # make sure all the `puts` calls can write to the same output
+        config.on_event :test_case_starting do |event|
+          stdout.puts "before"
+        end
+        config.on_event :test_case_finished do |event|
+          stdout.puts "after"
+        end
+      end
+
+      Given(/this is a step/) do 
+      end
+
+      """
+
+  Scenario: Run the test case
+    When I run `cucumber -q`
+    Then it should pass with:
+      """
+      before
+      Feature: A feature
+      
+        Scenario: A passing scenario
+          Given this is a step
+      after
+      """
+

--- a/features/docs/events/test_run_finished_event.feature
+++ b/features/docs/events/test_run_finished_event.feature
@@ -4,8 +4,9 @@ Feature: Test Run Finished
 
   Typically, a formatter would use this to print out summary information.
 
-  At the moment this event contains no data, but it could be extended in the future to carry the summary information
-  for the convenience of formatter authors.
+  At the moment this event contains no data, but it could be extended 
+  in the future to carry the summary information for the convenience 
+  of formatter authors.
 
   Background:
     Given the standard step definitions

--- a/features/docs/events/test_run_finished_event.feature
+++ b/features/docs/events/test_run_finished_event.feature
@@ -1,0 +1,39 @@
+Feature: Test Run Finished
+
+  This event is fired after all the test cases have been executed.
+
+  Typically, a formatter would use this to print out summary information.
+
+  At the moment this event contains no data, but it could be extended in the future to carry the summary information
+  for the convenience of formatter authors.
+
+  Background:
+    Given the standard step definitions
+    And a file named "features/test.feature" with:
+      """
+      Feature: A feature
+
+        Scenario: A passing scenario
+          Given this is a step
+      """
+    And a file named "features/support/events.rb" with:
+      """
+      class MyFormatter
+        def initialize(config)
+          config.on_event :test_case_finished do
+            config.out_stream.puts "test case finished"
+          end
+          config.on_event :test_run_finished do
+            config.out_stream.puts "the end"
+          end
+        end
+      end
+      """
+
+  Scenario: Run the test case
+    When I run `cucumber -q -f MyFormatter`
+    Then it should pass with:
+      """
+      test case finished
+      the end
+      """

--- a/features/docs/events/test_step_finished_event.feature
+++ b/features/docs/events/test_step_finished_event.feature
@@ -1,0 +1,47 @@
+Feature: Test Step Finished Event
+
+  This event is fired after each step in a scenario or scenario outline example 
+  (generally named a Test Step) has finished executing. You can use the event to learn about the 
+  result of the test step.
+
+  See [the API documentation](http://www.rubydoc.info/github/cucumber/cucumber-ruby/Cucumber/Events/TestStepFinished) for more information about the data available on this event and the result object.
+
+  Background:
+    Given the standard step definitions
+    And a file named "features/test.feature" with:
+      """
+      Feature: A feature
+
+        @pass
+        Scenario: A passing scenario
+          Given this step passes
+
+        @fail
+        Scenario: A failing scenario
+          Given this step fails
+      """
+    And a file named "features/support/events.rb" with:
+      """
+      AfterConfiguration do |config|
+        config.on_event :test_step_finished do |event|
+          config.out_stream.puts "Test step: #{event.test_step.name}"
+          config.out_stream.puts "The result is: #{event.result}"
+        end
+      end
+      """
+
+  Scenario: Test step passes
+    When I run `cucumber --tags @pass`
+    Then it should pass with:
+      """
+      Test step: this step passes
+      The result is: ✓
+      """
+
+  Scenario: Test step fails
+    When I run `cucumber --tags @fail`
+    Then it should fail with:
+      """
+      Test step: this step fails
+      The result is: ✗
+      """

--- a/features/docs/events/test_step_started_event.feature
+++ b/features/docs/events/test_step_started_event.feature
@@ -1,0 +1,43 @@
+Feature: Test Step Started Event
+
+  This event is fired just before each step in a scenario or scenario outline example 
+  (generally named a Test Step) starts to be executed. This event is read-only, so there
+  is no way to prevent the test step from running, but you can use it for logging or user
+  notification.
+
+  See [the API documentation](http://www.rubydoc.info/github/cucumber/cucumber-ruby/Cucumber/Events/TestStepStarting) for more information about the data available on this event and the result object.
+
+  Background:
+    Given the standard step definitions
+    And a file named "features/test.feature" with:
+      """
+      Feature: A feature
+
+        Scenario: A passing scenario
+          Given this is a step
+      """
+    And a file named "features/support/events.rb" with:
+      """
+      stdout = nil
+      AfterConfiguration do |config|
+        stdout = config.out_stream # make sure all the `puts` calls can write to the same output
+        config.on_event :test_step_starting do |event|
+          stdout.puts "before"
+        end
+        config.on_event :test_step_finished do |event|
+          stdout.puts "after"
+        end
+      end
+      Given(/this is a step/) do
+        stdout.puts "during"
+      end
+      """
+
+  Scenario: Test step passes
+    When I run `cucumber`
+    Then it should pass with:
+      """
+      before
+      during
+      after
+      """

--- a/features/docs/events/test_step_starting_event.feature
+++ b/features/docs/events/test_step_starting_event.feature
@@ -1,4 +1,4 @@
-Feature: Test Step Started Event
+Feature: Test Step Starting Event
 
   This event is fired just before each step in a scenario or scenario outline example 
   (generally named a Test Step) starts to be executed. This event is read-only, so there

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -262,7 +262,7 @@ module Cucumber
         :snippets            => true,
         :source              => true,
         :duration            => true,
-        :event_bus           => Core::EventBus.new(Core::Events.registry.merge(Cucumber::Events.registry))
+        :event_bus           => Cucumber::Events.make_event_bus
       }
     end
 

--- a/lib/cucumber/events.rb
+++ b/lib/cucumber/events.rb
@@ -18,8 +18,16 @@ module Cucumber
   #   end
   #
   module Events
+    def self.make_event_bus
+      Core::EventBus.new(registry)
+    end
+
     def self.registry
       Core::Events.build_registry(
+        Core::Events::TestCaseStarting,
+        Core::Events::TestCaseFinished,
+        Core::Events::TestStepFinished,
+        Core::Events::TestStepStarting,
         StepDefinitionRegistered,
         StepMatch,
         TestRunFinished,

--- a/lib/cucumber/events.rb
+++ b/lib/cucumber/events.rb
@@ -24,10 +24,10 @@ module Cucumber
 
     def self.registry
       Core::Events.build_registry(
-        Core::Events::TestCaseStarting,
-        Core::Events::TestCaseFinished,
-        Core::Events::TestStepFinished,
-        Core::Events::TestStepStarting,
+        TestCaseStarting,
+        TestCaseFinished,
+        TestStepFinished,
+        TestStepStarting,
         StepDefinitionRegistered,
         StepMatch,
         TestRunFinished,

--- a/lib/cucumber/events.rb
+++ b/lib/cucumber/events.rb
@@ -29,7 +29,7 @@ module Cucumber
         TestStepFinished,
         TestStepStarting,
         StepDefinitionRegistered,
-        StepMatch,
+        StepActivated,
         TestRunFinished,
       )
     end

--- a/lib/cucumber/events/step_activated.rb
+++ b/lib/cucumber/events/step_activated.rb
@@ -4,8 +4,8 @@ require 'cucumber/core/events'
 module Cucumber
   module Events
 
-    # Event fired when a step is matched to a definition
-    class StepMatch < Core::Event.new(:test_step, :step_match)
+    # Event fired when a step is activated
+    class StepActivated < Core::Event.new(:test_step, :step_match)
 
       # The test step that was matched.
       #

--- a/lib/cucumber/events/step_definition_registered.rb
+++ b/lib/cucumber/events/step_definition_registered.rb
@@ -10,7 +10,7 @@ module Cucumber
 
       #_The step definition that was just registered.
       #
-      # @return [Cucumber::Core::Test::Case]
+      # @return [RbSupport::RbStepDefinition]
       attr_reader :step_definition
 
       #_@private

--- a/lib/cucumber/events/test_case_finished.rb
+++ b/lib/cucumber/events/test_case_finished.rb
@@ -1,0 +1,18 @@
+require 'cucumber/core/events'
+
+module Cucumber
+  module Events
+
+    # Signals that a {Cucumber::Core::Test::Case} has finished executing
+    class TestCaseFinished < Core::Events::TestCaseFinished
+
+      # @return [Cucumber::Core::Test::Case] that was executed
+      attr_reader :test_case
+
+      # @return [Cucumber::Core::Test::Result] the result of running the {Cucumber::Core::Test::Step}
+      attr_reader :result
+
+    end
+
+  end
+end

--- a/lib/cucumber/events/test_case_starting.rb
+++ b/lib/cucumber/events/test_case_starting.rb
@@ -1,0 +1,15 @@
+require 'cucumber/core/events'
+
+module Cucumber
+  module Events
+
+    # Signals that a {Cucumber::Core::Test::Case} is about to be executed
+    class TestCaseStarting < Core::Events::TestCaseStarting
+
+      # @return [Cucumber::Core::Test::Case] the test case to be executed
+      attr_reader :test_case
+
+    end
+
+  end
+end

--- a/lib/cucumber/events/test_step_finished.rb
+++ b/lib/cucumber/events/test_step_finished.rb
@@ -1,0 +1,20 @@
+require 'cucumber/core/events'
+
+module Cucumber
+  module Events
+
+    # Signals that a {Cucumber::Core::Test::Step} has finished executing
+    class TestStepFinished < Core::Events::TestStepFinished
+
+      # @return [Cucumber::Core::Test::Step] the test step that was executed
+      attr_reader :test_step
+
+      # @return [Cucumber::Core::Test::Result] the result of running the {Cucumber::Core::Test::Step}
+      attr_reader :result
+
+    end
+
+  end
+end
+
+

--- a/lib/cucumber/events/test_step_starting.rb
+++ b/lib/cucumber/events/test_step_starting.rb
@@ -1,0 +1,17 @@
+require 'cucumber/core/events'
+
+module Cucumber
+  module Events
+
+    # Signals that a {Cucumber::Core::Test::Step} is about to be executed
+    class TestStepStarting < Core::Events::TestStepStarting
+
+      # @return [Cucumber::Core::Test::Step] the test step to be executed
+      attr_reader :test_step
+
+    end
+
+  end
+end
+
+

--- a/lib/cucumber/filters/activate_steps.rb
+++ b/lib/cucumber/filters/activate_steps.rb
@@ -44,7 +44,7 @@ module Cucumber
 
           def result
             return NoStepMatch.new(test_step.source.last, test_step.name) unless matches.any?
-            configuration.notify :step_match, test_step, match
+            configuration.notify :step_activated, test_step, match
             return SkippingStepMatch.new if configuration.dry_run?
             match
           end

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -61,7 +61,7 @@ module Cucumber
 
         def collect_matches
           result = {}
-          config.on_event(:step_match) do |event|
+          config.on_event(:step_activated) do |event|
             test_step, step_match = *event.attributes
             result[test_step.source.last] = step_match
           end

--- a/lib/cucumber/formatter/progress.rb
+++ b/lib/cucumber/formatter/progress.rb
@@ -30,14 +30,14 @@ module Cucumber
         @passed_test_cases = []
         @counts = ConsoleCounts.new(config)
         @issues = ConsoleIssues.new(config)
-        config.on_event :step_match, &method(:on_step_match)
+        config.on_event :step_activated, &method(:on_step_activated)
         config.on_event :test_case_starting, &method(:on_test_case_starting)
         config.on_event :test_step_finished, &method(:on_test_step_finished)
         config.on_event :test_case_finished, &method(:on_test_case_finished)
         config.on_event :test_run_finished, &method(:on_test_run_finished)
       end
 
-      def on_step_match(event)
+      def on_step_activated(event)
         @matches[event.test_step.source] = event.step_match
       end
 

--- a/lib/cucumber/formatter/usage.rb
+++ b/lib/cucumber/formatter/usage.rb
@@ -15,7 +15,7 @@ module Cucumber
         @stepdef_to_match = Hash.new { |h, stepdef_key| h[stepdef_key] = [] }
         @total_duration = 0
         @matches = {}
-        config.on_event :step_match do |event|
+        config.on_event :step_activated do |event|
           test_step, step_match = *event.attributes
           @matches[test_step.source] = step_match
         end

--- a/lib/cucumber/rb_support/rb_step_definition.rb
+++ b/lib/cucumber/rb_support/rb_step_definition.rb
@@ -5,9 +5,9 @@ require 'cucumber/core_ext/string'
 
 module Cucumber
   module RbSupport
-    # A Ruby Step Definition holds a Regexp and a Proc, and is created
-    # by calling <tt>Given</tt>, <tt>When</tt> or <tt>Then</tt>
-    # in the <tt>step_definitions</tt> ruby files. See also RbDsl.
+    # A Ruby Step Definition holds a Regexp pattern and a Proc, and is 
+    # typically created by calling {RbDsl#register_rb_step_definition Given, When or Then}
+    # in the step_definitions Ruby files.
     #
     # Example:
     #
@@ -75,10 +75,12 @@ module Cucumber
         @rb_language.available_step_definition(regexp_source, location)
       end
 
+      # @api private
       def regexp_source
         @regexp.inspect
       end
 
+      # @api private
       def to_hash
         flags = ''
         flags += 'm' if (@regexp.options & Regexp::MULTILINE) != 0
@@ -87,16 +89,19 @@ module Cucumber
         {'source' => @regexp.source, 'flags' => flags}
       end
 
+      # @api private
       def ==(step_definition)
         regexp_source == step_definition.regexp_source
       end
 
+      # @api private
       def arguments_from(step_name)
         args = StepArgument.arguments_from(@regexp, step_name)
         @rb_language.invoked_step_definition(regexp_source, location) if args
         args
       end
 
+      # @api private
       def invoke(args)
         begin
           args = @rb_language.execute_transforms(args)
@@ -107,10 +112,12 @@ module Cucumber
         end
       end
 
+      # @api private
       def backtrace_line
         "#{location}:in `#{regexp_source}'"
       end
 
+      # @api private
       def file_colon_line
         case @proc
         when Proc
@@ -120,10 +127,12 @@ module Cucumber
         end
       end
 
+      # The source location where the step defintion can be found
       def location
         @location ||= Cucumber::Core::Ast::Location.from_source_location(*@proc.source_location)
       end
 
+      # @api private
       def file
         @file ||= location.file
       end

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -4,7 +4,6 @@ require 'cucumber/runtime/for_programming_languages'
 require 'cucumber/runtime/step_hooks'
 require 'cucumber/runtime/before_hooks'
 require 'cucumber/runtime/after_hooks'
-require 'cucumber/events/step_match'
 require 'cucumber/gherkin/steps_parser'
 require 'cucumber/step_match_search'
 

--- a/spec/cucumber/filters/activate_steps_spec.rb
+++ b/spec/cucumber/filters/activate_steps_spec.rb
@@ -32,9 +32,9 @@ describe Cucumber::Filters::ActivateSteps do
       compile [doc], receiver, [filter]
     end
 
-    it 'notifies with a StepMatch event' do
+    it 'notifies with a StepActivated event' do
       expect(configuration).to receive(:notify) do |message, test_step, step_match|
-        expect(message).to eq :step_match
+        expect(message).to eq :step_activated
         expect(test_step.name).to eq 'a passing step'
         expect(step_match).to eq step_match
       end
@@ -112,9 +112,9 @@ describe Cucumber::Filters::ActivateSteps do
       compile [doc], receiver, [filter]
     end
 
-    it 'notifies with a StepMatch event' do
+    it 'notifies with a StepActivated event' do
       expect(configuration).to receive(:notify) do |message, test_step, step_match|
-        expect(message).to eq :step_match
+        expect(message).to eq :step_activated
         expect(test_step.name).to eq 'a passing step'
         expect(step_match).to eq step_match
       end


### PR DESCRIPTION
## Summary

Improve documentation for the Events API
## Details

This change wraps each of the test case/step starting/finished events that are emitted from `cucumber-core` with event types defined in the `Cucumber::Events` namespace.

It also adds a feature file / acceptance test describing each event.
## Motivation and Context

The events API is the most important part of Cucumber's API, and needs to be well documented. This will help people writing future plug-ins and extensions, as well as those migrating their formatters off of the old API once we deprecate it.

Since we moved main before/after test case/step events into the core, the YARD API docs have got worse, because those events have disappeared from the `Cucumber::Events` namespace. This change wraps the events in core with subclasses in `Cucumber::Events` so that all of the events a user can consume from the API will be listed under http://www.rubydoc.info/github/cucumber/cucumber-ruby/Cucumber/Events

It also means we have a layer of indirection that will allow us to change the underlying events from the core if we choose to, without breaking the user's API.
## How Has This Been Tested?

This change is a refactoring so existing tests should cover it, but I've also added acceptance tests as part of the change.
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist:
- [x] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
## To do:
- [x] Add wrapper events for all events fired from `Cucumber::Core`

Write acceptance tests for the following events:
- [x] Step Definition registered
- [x] Step Match
- [x] Test Case Starting
- [x] Test Step Starting
- [x] Test Step Finished
- [x] Test Case Finished
- [x] Test Run Finished
