### PR TITLE
AfterAll hook

### DIFF
--- a/features/docs/writing_support_code/after_all_hooks.feature
+++ b/features/docs/writing_support_code/after_all_hooks.feature
@@ -136,3 +136,22 @@ Feature: After All Hook
       """
       After All
       """
+
+  Scenario: Exit code is not zero if a test fails
+    Given a file named "features/support/hooks.rb" with:
+      """
+      AfterAll do
+        puts "After All"
+      end
+      """
+    And a file named "features/test.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given this step fails
+      """
+    When I run `cucumber -f progress features`
+    Then it should fail with:
+    """
+    features/test.feature:3
+    """

--- a/features/docs/writing_support_code/after_all_hooks.feature
+++ b/features/docs/writing_support_code/after_all_hooks.feature
@@ -1,0 +1,138 @@
+Feature: After All Hook
+
+  In order to extend Cucumber
+  As a developer
+  I want to run code after all Cucumber tests are finished
+
+  Background:
+    Given the standard step definitions
+
+  Scenario: AfterAll hook gets executed after all steps are executed
+    Given a file named "features/support/env.rb" with:
+      """
+      AfterAll do
+        puts "After All"
+      end
+      """
+    And a file named "features/step_definitions/puts_steps.rb" with:
+      """
+      Given /^I use puts with text "(.*)"$/ do |text|
+        puts(text)
+      end
+      """
+    And a file named "features/test1.feature" with:
+      """
+      Feature:
+
+        Scenario:
+          Given I use puts with text "Step 1"
+          And I use puts with text "Step 2"
+      """
+    And a file named "features/test2.feature" with:
+      """
+      Feature:
+
+        Scenario:
+          Given I use puts with text "Step 3"
+          And I use puts with text "Step 4"
+      """
+    When I run `cucumber -f progress features`
+    Then the output should contain:
+      """
+      Step 1
+
+      Step 2
+
+      Step 3
+
+      Step 4
+
+      After All
+      """
+
+  Scenario: AfterAll hook gets executed after all hooks are executed
+    Given a file named "features/support/env.rb" with:
+      """
+      Before do
+        puts "Before"
+      end
+
+      After do
+        puts "After"
+      end
+
+      AfterAll do
+        puts "After All"
+      end
+      """
+    And a file named "features/step_definitions/puts_steps.rb" with:
+      """
+      Given /^I use puts with text "(.*)"$/ do |text|
+        puts(text)
+      end
+      """
+    And a file named "features/test.feature" with:
+      """
+      Feature:
+
+        Scenario:
+          Given I use puts with text "Step 1"
+          And I use puts with text "Step 2"
+      """
+    When I run `cucumber -f progress features`
+    Then the output should contain:
+      """
+      Before
+
+      Step 1
+
+      Step 2
+
+      After
+
+      After All
+      """
+
+  Scenario: AfterAll hooks are executed in reverse order of definition
+    Given a file named "features/support/hooks.rb" with:
+      """
+      AfterAll do
+        puts "First"
+      end
+
+      AfterAll do
+        puts "Second"
+      end
+      """
+    And a file named "features/test.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given this step passes
+      """
+    When I run `cucumber features`
+    Then the output should contain:
+      """
+      Second
+
+      First
+      """
+
+  Scenario: AfterAll hook is executed if test failed
+    Given a file named "features/support/hooks.rb" with:
+      """
+      AfterAll do
+        puts "After All"
+      end
+      """
+    And a file named "features/test.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given this step fails
+      """
+    When I run `cucumber -f progress features`
+    Then the output should contain:
+      """
+      After All
+      """

--- a/lib/cucumber/rb_support/rb_dsl.rb
+++ b/lib/cucumber/rb_support/rb_dsl.rb
@@ -93,6 +93,10 @@ module Cucumber
         RbDsl.register_rb_hook('after_configuration', [], proc)
       end
 
+      def AfterAll(&proc)
+        RbDsl.register_rb_hook('after_all', [], proc)
+      end
+
       # Registers a new Ruby StepDefinition. This method is aliased
       # to <tt>Given</tt>, <tt>When</tt> and <tt>Then</tt>, and
       # also to the i18n translations whenever a feature of a

--- a/lib/cucumber/rb_support/rb_language.rb
+++ b/lib/cucumber/rb_support/rb_language.rb
@@ -112,6 +112,12 @@ module Cucumber
         end
       end
 
+      def after_all
+        hooks[:after_all].each do |hook|
+          hook.invoke('AfterAll', nil)
+        end
+      end
+
       def execute_transforms(args)
         args.map do |arg|
           matching_transform = transforms.detect {|transform| transform.match(arg) }

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -67,6 +67,7 @@ module Cucumber
       receiver = Test::Runner.new(@configuration.event_bus)
       compile features, receiver, filters
       @configuration.notify :test_run_finished
+      fire_after_all_hook
     end
 
     def features_paths
@@ -108,6 +109,10 @@ module Cucumber
 
     def fire_after_configuration_hook #:nodoc
       @support_code.fire_hook(:after_configuration, @configuration)
+    end
+
+    def fire_after_all_hook #:nodoc
+      @support_code.fire_hook(:after_all)
     end
 
     require 'cucumber/core/gherkin/document'


### PR DESCRIPTION
## Summary

Carrying on the work done in #858. This pull request aims to add a hook to replace using `Kernel#at_exit` for the end of a cucumber suite's cleanup tasks. 
## Motivation and Context

The problem with using `Kernel#at_exit` for test suite cleanup tasks is that it is very easy to accidentally clobber the exit status of the test suite. If you call any code that throws (and catches) exceptions, that will effectively overwrite the `$ERROR_INFO` value and turn an error status into a success status, which you likely don't want. 

Due to the tricky way in which developers have to treat `Kernel#at_exit`, it would be preferable for cucumber to provide a hook for the same use cases except the exit status of the test suite would be preserved - anything that happens in the hook, you can't "break" the expected behaviour of cucumber.
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist:
- [x] I've added acceptance tests for my code
- [ ] I've added specs for my code
- [ ] I've completed the implementation for this feature
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The name of the hook has been discussed and agreed upon.
