### PR TITLE
fix backtrace when using html formatter

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -590,11 +590,11 @@ module Cucumber
       end
 
       def backtrace_line(line)
-        line.gsub(/^([^:]*\.(?:rb|feature|haml)):(\d*).*$/) do
+        line.gsub(/^([^:]*\.(?:rb|feature|haml)):(\d*).*$/) do |match|
           if ENV['TM_PROJECT_DIRECTORY']
-            "<a href=\"txmt://open?url=file://#{File.expand_path($1)}&line=#{$2}\">#{$1}:#{$2}</a> "
+            "<a href=\"txmt://open?url=file://#{File.expand_path($1)}&match=#{$2}\">#{$1}:#{$2}</a> "
           else
-            line
+            match
           end
         end
       end


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Fix an issue where the backtrace is repeated multiple times when using html formatter.

## Details

The method backtrace_line in html.rb was replacing each regex match with the entire backtrace, causing the backtrace to be repeated x times (x being the number of matches).

## Motivation and Context

Makes my cucumber output much shorter and cleaner for failing tests.

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

