### PR TITLE
Fix #1017 - missing backtrace filter

### DIFF
--- a/lib/cucumber/formatter/backtrace_filter.rb
+++ b/lib/cucumber/formatter/backtrace_filter.rb
@@ -4,12 +4,24 @@ require 'cucumber/platform'
 
 module Cucumber
   module Formatter
-    BACKTRACE_FILTER_PATTERNS = \
-      [/vendor\/rails|lib\/cucumber|bin\/cucumber:|lib\/rspec|gems\/|minitest|test\/unit|.gem\/ruby|lib\/ruby/]
+    @backtrace_filters = %w(
+      /vendor/rails
+      lib/cucumber
+      bin/cucumber:
+      lib/rspec
+      gems/
+      minitest
+      test/unit
+      .gem/ruby
+      lib/ruby/
+      bin/bundle
+    )
 
-    if(::Cucumber::JRUBY)
-      BACKTRACE_FILTER_PATTERNS << /org\/jruby/
+    if ::Cucumber::JRUBY
+      @backtrace_filters << '/org/jruby/'
     end
+
+    BACKTRACE_FILTER_PATTERNS = Regexp.new(@backtrace_filters.join('|'))
 
     class BacktraceFilter
       def initialize(exception)
@@ -23,7 +35,7 @@ module Cucumber
         backtrace = @exception.backtrace.map { |line| line.gsub(pwd_pattern, "./") }
 
         filtered = (backtrace || []).reject do |line|
-          BACKTRACE_FILTER_PATTERNS.detect { |p| line =~ p }
+          line =~ BACKTRACE_FILTER_PATTERNS
         end
 
         if ::ENV['CUCUMBER_TRUNCATE_OUTPUT']

--- a/lib/cucumber/formatter/backtrace_filter.rb
+++ b/lib/cucumber/formatter/backtrace_filter.rb
@@ -14,11 +14,11 @@ module Cucumber
       test/unit
       .gem/ruby
       lib/ruby/
-      bin/bundle
+      rbenv/.*/bin/bundle
     )
 
     if ::Cucumber::JRUBY
-      @backtrace_filters << '/org/jruby/'
+      @backtrace_filters << 'org/jruby/'
     end
 
     BACKTRACE_FILTER_PATTERNS = Regexp.new(@backtrace_filters.join('|'))

--- a/spec/cucumber/formatter/backtrace_filter_spec.rb
+++ b/spec/cucumber/formatter/backtrace_filter_spec.rb
@@ -13,9 +13,9 @@ module Cucumber
                      _anything__gems/__anything_
                      _anything__minitest__anything_
                      _anything__test/unit__anything_
-                     _anything__.gem/ruby__anything_
+                     _anything__Xgem/ruby__anything_
                      _anything__lib/ruby/__anything_
-                     _anything__bin/bundle__anything_)
+                     _anything__.rbenv/versions/2.3/bin/bundle__anything_)
           @exception = Exception.new
           @exception.set_backtrace(trace)
         end

--- a/spec/cucumber/formatter/backtrace_filter_spec.rb
+++ b/spec/cucumber/formatter/backtrace_filter_spec.rb
@@ -1,0 +1,32 @@
+require 'cucumber/formatter/backtrace_filter'
+
+module Cucumber
+  module Formatter
+    describe BacktraceFilter do
+      context '#exception' do
+        before do
+          trace = %w(a b
+                     _anything__/vendor/rails__anything_
+                     _anything__lib/cucumber__anything_
+                     _anything__bin/cucumber:__anything_
+                     _anything__lib/rspec__anything_
+                     _anything__gems/__anything_
+                     _anything__minitest__anything_
+                     _anything__test/unit__anything_
+                     _anything__.gem/ruby__anything_
+                     _anything__lib/ruby/__anything_
+                     _anything__bin/bundle__anything_)
+          @exception = Exception.new
+          @exception.set_backtrace(trace)
+        end
+
+        it 'filters unnecessary traces' do
+          BacktraceFilter.new(@exception).exception
+          expect(@exception.backtrace).to eql %w(a b)
+        end
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
## Summary

- Add `.rbenv/.*/bin/bundle` to backtrace filters
- Refactor backtrace filtering
- Add unit tests for backtrace filtering

## Motivation and Context

It resolves https://github.com/cucumber/cucumber-ruby/issues/1017.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
