### PR TITLE
Fix rubocop violations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,21 +32,6 @@ Lint/AssignmentInCondition:
 
 # Offense count: 1
 # Cop supports --auto-correct.
-# Configuration parameters: AlignWith, SupportedStyles.
-# SupportedStyles: either, start_of_block, start_of_line
-Lint/BlockAlignment:
-  Exclude:
-    - 'lib/cucumber/formatter/html.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AlignWith, SupportedStyles, AutoCorrect.
-# SupportedStyles: start_of_line, def
-Lint/DefEndAlignment:
-  Enabled: false
-
-# Offense count: 1
-# Cop supports --auto-correct.
 Lint/DeprecatedClassMethods:
   Exclude:
     - 'lib/cucumber/project_initializer.rb'

--- a/lib/cucumber/cli/profile_loader.rb
+++ b/lib/cucumber/cli/profile_loader.rb
@@ -11,7 +11,7 @@ module Cucumber
       end
 
       def args_from(profile)
-        unless cucumber_yml.has_key?(profile)
+        unless cucumber_yml.key?(profile)
           raise(ProfileNotFound, <<-END_OF_ERROR)
 Could not find profile: '#{profile}'
 
@@ -42,7 +42,7 @@ Defined profiles in cucumber.yml:
       end
 
       def has_profile?(profile)
-        cucumber_yml.has_key?(profile)
+        cucumber_yml.key?(profile)
       end
 
       def cucumber_yml_defined?

--- a/lib/cucumber/formatter/ansicolor.rb
+++ b/lib/cucumber/formatter/ansicolor.rb
@@ -9,7 +9,7 @@ if Cucumber::WINDOWS_MRI
   end
 end
 
-Cucumber::Term::ANSIColor.coloring = false if !STDOUT.tty? && !ENV.has_key?("AUTOTEST")
+Cucumber::Term::ANSIColor.coloring = false if !STDOUT.tty? && !ENV.key?("AUTOTEST")
 
 module Cucumber
   module Formatter

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -85,7 +85,7 @@ module Cucumber
         )
 
         @builder << '<html xmlns ="http://www.w3.org/1999/xhtml">'
-          @builder.head do
+        @builder.head do
           @builder.meta('http-equiv' => 'Content-Type', :content => 'text/html;charset=utf-8')
           @builder.title 'Cucumber'
           inline_css
@@ -590,7 +590,7 @@ module Cucumber
         (["#{exception.message}"] + exception.backtrace).join("\n")
       end
 
-     def backtrace_line(line)
+      def backtrace_line(line)
         if ENV['TM_PROJECT_DIRECTORY']
           line.gsub(/^([^:]*\.(?:rb|feature|haml)):(\d*).*$/) do
             "<a href=\"txmt://open?url=file://#{File.expand_path($1)}&line=#{$2}\">#{$1}:#{$2}</a> "

--- a/lib/cucumber/formatter/legacy_api/results.rb
+++ b/lib/cucumber/formatter/legacy_api/results.rb
@@ -13,7 +13,7 @@ module Cucumber
         def step_visited(step) #:nodoc:
           step_id = step.object_id
 
-          unless @inserted_steps.has_key?(step_id)
+          unless @inserted_steps.key?(step_id)
             @inserted_steps[step_id] = step
             steps.push(step)
           end
@@ -22,7 +22,7 @@ module Cucumber
         def scenario_visited(scenario) #:nodoc:
           scenario_id = scenario.object_id
 
-          unless @inserted_scenarios.has_key?(scenario_id)
+          unless @inserted_scenarios.key?(scenario_id)
             @inserted_scenarios[scenario_id] = scenario
             scenarios.push(scenario)
           end

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -556,7 +556,7 @@ module Cucumber
           raise "No headers matched #{pre.inspect}" if mapped_cells.empty?
           raise "#{mapped_cells.length} headers matched #{pre.inspect}: #{mapped_cells.map { |c| c.value }.inspect}" if mapped_cells.length > 1
           mapped_cells[0].value = post
-          if @conversion_procs.has_key?(pre)
+          if @conversion_procs.key?(pre)
             @conversion_procs[post] = @conversion_procs.delete(pre)
           end
         end


### PR DESCRIPTION
## Summary

Partial fix for #1021 

## Details

* ```Hash#has_key?``` => ```Hash#key?``` due to [DEPRECATION](https://redmine.ruby-lang.org/issues/5555#note-10)
* Lint/BlockAlignment
* Lint/DefEndAlignment