### PR TITLE
Refs #1021 - Fixes the rubocop violation 'Style/StringLiterals'

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1165,13 +1165,6 @@ Style/SpaceInsideStringInterpolation:
 Style/SpecialGlobalVars:
   Enabled: false
 
-# Offense count: 1205
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles, ConsistentQuotesInMultiline.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiterals:
-  Enabled: false
-
 # Offense count: 14
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/Gemfile
+++ b/Gemfile
@@ -1,21 +1,21 @@
-gem "cucumber-pro", "0.0.13", :group => :test
-source "https://rubygems.org"
+gem 'cucumber-pro', '0.0.13', :group => :test
+source 'https://rubygems.org'
 gemspec
 load File.expand_path('../Gemfile.local', __FILE__) if File.file? File.expand_path('../Gemfile.local', __FILE__)
 
 unless ENV['CUCUMBER_USE_RELEASED_CORE']
-  core_path = File.expand_path("../../cucumber-ruby-core", __FILE__)
-  wire_path = File.expand_path("../../cucumber-ruby-wire", __FILE__)
-  if File.exist?(core_path) && !ENV["cucumber_use_git_core"]
-    gem "cucumber-core", :path => core_path
+  core_path = File.expand_path('../../cucumber-ruby-core', __FILE__)
+  wire_path = File.expand_path('../../cucumber-ruby-wire', __FILE__)
+  if File.exist?(core_path) && !ENV['cucumber_use_git_core']
+    gem 'cucumber-core', :path => core_path
   else
-    gem "cucumber-core", :git => "https://github.com/cucumber/cucumber-ruby-core.git"
+    gem 'cucumber-core', :git => 'https://github.com/cucumber/cucumber-ruby-core.git'
   end
 
-  if File.exist?(wire_path) && !ENV["CUCUMBER_USE_GIT_CORE"]
-    gem "cucumber-wire", :path => wire_path
+  if File.exist?(wire_path) && !ENV['CUCUMBER_USE_GIT_CORE']
+    gem 'cucumber-wire', :path => wire_path
   else
-    gem "cucumber-wire", :git => "https://github.com/cucumber/cucumber-ruby-wire.git"
+    gem 'cucumber-wire', :git => 'https://github.com/cucumber/cucumber-ruby-wire.git'
   end
 end
 

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -1,15 +1,15 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = 'cucumber'
-  s.version     = File.read(File.expand_path("../lib/cucumber/version", __FILE__))
-  s.authors     = ["Aslak Hellesøy", "Matt Wynne", "Steve Tooke"]
+  s.version     = File.read(File.expand_path('../lib/cucumber/version', __FILE__))
+  s.authors     = ["Aslak Hellesøy", 'Matt Wynne', 'Steve Tooke']
   s.description = 'Behaviour Driven Development with elegance and joy'
   s.summary     = "cucumber-#{s.version}"
   s.email       = 'cukes@googlegroups.com'
   s.license     = 'MIT'
-  s.homepage    = "https://cucumber.io/"
+  s.homepage    = 'https://cucumber.io/'
   s.platform    = Gem::Platform::RUBY
-  s.required_ruby_version = ">= 1.9.3"
+  s.required_ruby_version = '>= 1.9.3'
   s.add_dependency 'cucumber-core', '~> 2.0'
   s.add_dependency 'builder', '>= 2.1.2'
   s.add_dependency 'diff-lcs', '>= 1.1.3'
@@ -39,10 +39,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test', '>= 0.6.1'
   s.add_development_dependency 'sinatra', '>= 1.3.2'
 
-  s.rubygems_version = ">= 1.6.1"
+  s.rubygems_version = '>= 1.6.1'
   s.files            = `git ls-files`.split("\n").reject {|path| path =~ /\.gitignore$/ }
   s.test_files       = `git ls-files -- {spec,features}/*`.split("\n")
   s.executables      = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.rdoc_options     = ["--charset=UTF-8"]
-  s.require_path     = "lib"
+  s.rdoc_options     = ['--charset=UTF-8']
+  s.require_path     = 'lib'
 end

--- a/examples/i18n/Rakefile
+++ b/examples/i18n/Rakefile
@@ -7,7 +7,7 @@ task :cucumber do
       if examples_working?(lang)
         Dir.chdir(f) do
           puts "DIR: #{f}"
-          rake("cucumber")
+          rake('cucumber')
         end
       else
         STDERR.puts %{

--- a/examples/i18n/zh-CN/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/zh-CN/features/step_definitions/calculator_steps.rb
@@ -17,7 +17,7 @@ end
 
 When(/按(.*)键/) do |op|
   if op == '加号'
-    @result = @calc.send "add"
+    @result = @calc.send 'add'
   end
 end
 

--- a/examples/test_unit/features/step_definitions/test_unit_steps.rb
+++ b/examples/test_unit/features/step_definitions/test_unit_steps.rb
@@ -11,7 +11,7 @@ begin
     a.should == b
   end
 rescue LoadError
-  STDERR.puts "***** You should install matchy *****"
+  STDERR.puts '***** You should install matchy *****'
   Then(/^I can assert that (\w+) == (\w+)$/) do |var_a, var_b|
     a = instance_variable_get("@#{var_a}")
     b = instance_variable_get("@#{var_b}")

--- a/examples/watir/features/support/screenshots.rb
+++ b/examples/watir/features/support/screenshots.rb
@@ -9,7 +9,7 @@ module Screenshots
   if Cucumber::OS_X
     def embed_screenshot(id)
       `screencapture -t png #{id}.png`
-      embed("#{id}.png", "image/png")
+      embed("#{id}.png", 'image/png')
     end
   elsif Cucumber::WINDOWS
     # http://wtr.rubyforge.org/rdoc/classes/Watir/ScreenCapture.html
@@ -17,12 +17,12 @@ module Screenshots
     include Watir::ScreenCapture
     def embed_screenshot(id)
       screen_capture("#{id}.jpg", true)
-      embed("#{id}.jpg", "image/jpeg")
+      embed("#{id}.jpg", 'image/jpeg')
     end
   else
     # Other platforms...
     def embed_screenshot(id)
-      STDERR.puts "Sorry - no screenshots on your platform yet."
+      STDERR.puts 'Sorry - no screenshots on your platform yet.'
     end
   end
 end

--- a/features/lib/step_definitions/aruba_steps.rb
+++ b/features/lib/step_definitions/aruba_steps.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 Given('a Gemfile with:') do |content|
-  path = File.expand_path(current_dir + "/Gemfile")
+  path = File.expand_path(current_dir + '/Gemfile')
   write_file path, content
-  set_env "BUNDLE_GEMFILE", path
+  set_env 'BUNDLE_GEMFILE', path
 end
 
 Then(/^it should (pass|fail)$/) do |result|

--- a/features/lib/step_definitions/cli_steps.rb
+++ b/features/lib/step_definitions/cli_steps.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 Then(/^I should see the CLI help$/) do
-  expect(all_output).to include("Usage:")
+  expect(all_output).to include('Usage:')
 end

--- a/features/lib/step_definitions/cucumber_steps.rb
+++ b/features/lib/step_definitions/cucumber_steps.rb
@@ -67,7 +67,7 @@ When(/^I run the feature with the (\w+) formatter$/) do |formatter|
 end
 
 Then(/^the stderr should contain a warning message$/) do
-  expect(all_stderr).to include("[warning]")
+  expect(all_stderr).to include('[warning]')
 end
 
 module CucumberHelper

--- a/features/lib/step_definitions/language_steps.rb
+++ b/features/lib/step_definitions/language_steps.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 Then(/^cucumber lists all the supported languages$/) do
-  sample_languages = ["Arabic", "български", "Pirate", "English", "日本語"]
+  sample_languages = ['Arabic', "български", 'Pirate', 'English', "日本語"]
   sample_languages.each do |language|
     expect(all_output.force_encoding('utf-8')).to include(language)
   end

--- a/features/lib/step_definitions/wire_steps.rb
+++ b/features/lib/step_definitions/wire_steps.rb
@@ -6,7 +6,7 @@ Given(/^there is a wire server (running |)on port (\d+) which understands the fo
   end
 
   @server = FakeWireServer.new(port.to_i, protocol)
-  start_wire_server if running.strip == "running"
+  start_wire_server if running.strip == 'running'
 end
 
 Given(/^the wire server takes (.*) seconds to respond to the invoke message$/) do |timeout|

--- a/gem_tasks/contributors.rake
+++ b/gem_tasks/contributors.rake
@@ -8,9 +8,9 @@ task :contributors do
 end
 
 task :codeswarm do
-  sh "code_swarm --reload" rescue nil # Fails because of encoding - which we'll fix
-  sh "iconv -f latin1 -t utf-8 .git/.code_swarm/log.xml > tmp.xml && mv tmp.xml .git/.code_swarm/log.xml"
+  sh 'code_swarm --reload' rescue nil # Fails because of encoding - which we'll fix
+  sh 'iconv -f latin1 -t utf-8 .git/.code_swarm/log.xml > tmp.xml && mv tmp.xml .git/.code_swarm/log.xml'
   sh "sed -e 's/Aslak\ Hellesøy@.BEKK.no/aslak.hellesoy@gmail.com/g' .git/.code_swarm/log.xml > tmp.xml && mv tmp.xml .git/.code_swarm/log.xml"
   sh "sed -e 's/josephwilk@joesniff.co.uk/joe@josephwilk.net/g' .git/.code_swarm/log.xml > tmp.xml && mv tmp.xml .git/.code_swarm/log.xml"
-  sh "code_swarm"
+  sh 'code_swarm'
 end

--- a/gem_tasks/environment.rake
+++ b/gem_tasks/environment.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 task :ruby_env do
   RUBY_APP = if RUBY_PLATFORM =~ /java/
-    "jruby"
+    'jruby'
   else
-    "ruby"
+    'ruby'
   end unless defined? RUBY_APP
 end

--- a/gem_tasks/examples.rake
+++ b/gem_tasks/examples.rake
@@ -6,7 +6,7 @@ task :examples do
     puts "Running #{example_dir}"
     Dir.chdir(example_dir) do
       raise "No Rakefile in #{Dir.pwd}" unless File.file?('Rakefile')
-      sh "rake cucumber"
+      sh 'rake cucumber'
     end
   end
 end

--- a/gem_tasks/fix_cr_lf.rake
+++ b/gem_tasks/fix_cr_lf.rake
@@ -6,6 +6,6 @@ task :fix_cr_lf do
     next if File.directory?(f) || f =~ /dos/
     s = IO.read(f)
     s.gsub!(/\r?\n/, "\n")
-    File.open(f, "w") { |io| io.write(s) }
+    File.open(f, 'w') { |io| io.write(s) }
   end
 end

--- a/gem_tasks/flog.rake
+++ b/gem_tasks/flog.rake
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-desc "Run flog over significant files"
+desc 'Run flog over significant files'
 task :flog do
-  sh "find lib/cucumber -name \\*.rb | grep -v parser\/feature\\.rb | xargs flog"
+  sh 'find lib/cucumber -name \\*.rb | grep -v parser/feature\\.rb | xargs flog'
 end

--- a/gem_tasks/rspec.rake
+++ b/gem_tasks/rspec.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rspec/core/rake_task'
 
-desc "Run RSpec"
+desc 'Run RSpec'
 RSpec::Core::RakeTask.new do |t|
   t.verbose = true
 end

--- a/lib/autotest/cucumber_mixin.rb
+++ b/lib/autotest/cucumber_mixin.rb
@@ -47,7 +47,7 @@ module Autotest::CucumberMixin
   end
 
   def all_features_good
-    features_to_run == ""
+    features_to_run == ''
   end
 
   def get_to_green
@@ -78,20 +78,20 @@ module Autotest::CucumberMixin
       self.results = []
       line = []
       begin
-        open("| #{cmd}", "r") do |f|
+        open("| #{cmd}", 'r') do |f|
           until f.eof? do
             c = f.getc or break
-            if RUBY_VERSION >= "1.9" then
+            if RUBY_VERSION >= '1.9' then
               print c
             else
               putc c
             end
             line << c
             if c == ?\n then
-              self.results << if RUBY_VERSION >= "1.9" then
+              self.results << if RUBY_VERSION >= '1.9' then
                                 line.join
                               else
-                                line.pack "c*"
+                                line.pack 'c*'
                               end
               line.clear
             end
@@ -111,18 +111,18 @@ module Autotest::CucumberMixin
 
     profile_loader = Cucumber::Cli::ProfileLoader.new
 
-    profile ||= "autotest-all" if profile_loader.has_profile?("autotest-all") && features_to_run == :all
-    profile ||= "autotest"     if profile_loader.has_profile?("autotest")
+    profile ||= 'autotest-all' if profile_loader.has_profile?('autotest-all') && features_to_run == :all
+    profile ||= 'autotest'     if profile_loader.has_profile?('autotest')
     profile ||= nil
 
     if profile
-      args = ["--profile", profile]
+      args = ['--profile', profile]
     else
-      args = %w{--format} << (features_to_run == :all ? "progress" : "pretty")
+      args = %w{--format} << (features_to_run == :all ? 'progress' : 'pretty')
     end
     # No --color option as some IDEs (Netbeans) don't output them very well ([31m1 failed step[0m)
     args += %w{--format rerun --out} << dirty_features_filename
-    args << (features_to_run == :all ? "" : features_to_run)
+    args << (features_to_run == :all ? '' : features_to_run)
 
     # Unless I do this, all the steps turn up undefined during the rerun...
     unless features_to_run == :all

--- a/lib/autotest/discover.rb
+++ b/lib/autotest/discover.rb
@@ -2,11 +2,11 @@
 Autotest.add_discovery do
   if File.directory?('features')
     if ENV['AUTOFEATURE'] =~ /true/i
-      "cucumber"
+      'cucumber'
     elsif ENV['AUTOFEATURE'] =~ /false/i
       # noop
     else
-      puts "(Not running features.  To run features in autotest, set AUTOFEATURE=true.)"
+      puts '(Not running features.  To run features in autotest, set AUTOFEATURE=true.)'
     end
   end
 end

--- a/lib/cucumber/cli/main.rb
+++ b/lib/cucumber/cli/main.rb
@@ -47,7 +47,7 @@ module Cucumber
         @err.puts("Couldn't open #{e.path}")
         exit_unable_to_finish
       rescue FeatureFolderNotFoundException => e
-        @err.puts(e.message + ". You can use `cucumber --init` to get started.")
+        @err.puts(e.message + '. You can use `cucumber --init` to get started.')
         exit_unable_to_finish
       rescue ProfilesNotDefinedError, YmlLoadError, ProfileNotFound => e
         @err.puts(e.message)

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -27,15 +27,15 @@ module Cucumber
         'summary'       => ['Cucumber::Formatter::Summary',   'Summary output of feature and scenarios']
       }
       max = BUILTIN_FORMATS.keys.map{|s| s.length}.max
-      FORMAT_HELP_MSG = ["Use --format rerun --out rerun.txt to write out failing",
-        "features. You can rerun them with cucumber @rerun.txt.",
-        "FORMAT can also be the fully qualified class name of",
+      FORMAT_HELP_MSG = ['Use --format rerun --out rerun.txt to write out failing',
+        'features. You can rerun them with cucumber @rerun.txt.',
+        'FORMAT can also be the fully qualified class name of',
         "your own custom formatter. If the class isn't loaded,",
-        "Cucumber will attempt to require a file with a relative",
-        "file name that is the underscore name of the class name.",
-        "Example: --format Foo::BarZap -> Cucumber will look for",
-        "foo/bar_zap.rb. You can place the file with this relative",
-        "path underneath your features/support directory or anywhere",
+        'Cucumber will attempt to require a file with a relative',
+        'file name that is the underscore name of the class name.',
+        'Example: --format Foo::BarZap -> Cucumber will look for',
+        'foo/bar_zap.rb. You can place the file with this relative',
+        'path underneath your features/support directory or anywhere',
         "on Ruby's LOAD_PATH, for example in a Ruby gem."
       ]
 
@@ -89,54 +89,54 @@ module Cucumber
 
         @args.options do |opts|
           opts.banner = banner
-          opts.on("-r LIBRARY|DIR", "--require LIBRARY|DIR", *require_files_msg) {|lib| require_files(lib) }
+          opts.on('-r LIBRARY|DIR', '--require LIBRARY|DIR', *require_files_msg) {|lib| require_files(lib) }
 
           if(Cucumber::JRUBY)
-            opts.on("-j DIR", "--jars DIR", "Load all the jars under DIR") {|jars| load_jars(jars) }
+            opts.on('-j DIR', '--jars DIR', 'Load all the jars under DIR') {|jars| load_jars(jars) }
           end
 
           opts.on("#{RETRY_FLAG} ATTEMPTS", *retry_msg) {|v| set_option :retry, v.to_i }
-          opts.on("--i18n LANG", *i18n_msg) {|lang| set_language lang }
-          opts.on(FAIL_FAST_FLAG, "Exit immediately following the first failing scenario") { set_option :fail_fast }
-          opts.on("-f FORMAT", "--format FORMAT", *format_msg, *FORMAT_HELP) {|v| add_option :formats, [v, @out_stream] }
+          opts.on('--i18n LANG', *i18n_msg) {|lang| set_language lang }
+          opts.on(FAIL_FAST_FLAG, 'Exit immediately following the first failing scenario') { set_option :fail_fast }
+          opts.on('-f FORMAT', '--format FORMAT', *format_msg, *FORMAT_HELP) {|v| add_option :formats, [v, @out_stream] }
           opts.on('--init', *init_msg) {|v| initialize_project }
-          opts.on("-o", "--out [FILE|DIR]", *out_msg) {|v| set_out_stream v }
-          opts.on("-t TAG_EXPRESSION", "--tags TAG_EXPRESSION", *tags_msg) {|v| add_option :tag_expressions, v }
-          opts.on("-n NAME", "--name NAME", *name_msg) {|v| add_option :name_regexps, /#{v}/ }
-          opts.on("-e", "--exclude PATTERN", *exclude_msg) {|v| add_option :excludes, Regexp.new(v) }
+          opts.on('-o', '--out [FILE|DIR]', *out_msg) {|v| set_out_stream v }
+          opts.on('-t TAG_EXPRESSION', '--tags TAG_EXPRESSION', *tags_msg) {|v| add_option :tag_expressions, v }
+          opts.on('-n NAME', '--name NAME', *name_msg) {|v| add_option :name_regexps, /#{v}/ }
+          opts.on('-e', '--exclude PATTERN', *exclude_msg) {|v| add_option :excludes, Regexp.new(v) }
           opts.on(PROFILE_SHORT_FLAG, "#{PROFILE_LONG_FLAG} PROFILE", *profile_short_flag_msg) {|v| add_profile v }
           opts.on(NO_PROFILE_SHORT_FLAG, NO_PROFILE_LONG_FLAG, *no_profile_short_flag_msg) {|v| disable_profile_loading }
-          opts.on("-c", "--[no-]color", *color_msg) {|v| set_color v }
-          opts.on("-d", "--dry-run", *dry_run_msg) { set_dry_run_and_duration }
-          opts.on("-m", "--no-multiline", "Don't print multiline strings and tables under steps.") { set_option :no_multiline }
-          opts.on("-s", "--no-source", "Don't print the file and line of the step definition with the steps.") { set_option :source, false }
-          opts.on("-i", "--no-snippets", "Don't print snippets for pending steps.") { set_option :snippets, false }
-          opts.on("-I", "--snippet-type TYPE", *snippet_type_msg) {|v| set_option :snippet_type, v.to_sym }
-          opts.on("-q", "--quiet", "Alias for --no-snippets --no-source.") { shut_up }
-          opts.on("--no-duration", "Don't print the duration at the end of the summary") { set_option :duration, false }
-          opts.on("-b", "--backtrace", "Show full backtrace for all errors.") { Cucumber.use_full_backtrace = true }
-          opts.on("-S", "--strict", "Fail if there are any undefined or pending steps.") { set_option :strict }
-          opts.on("-w", "--wip", "Fail if there are any passing scenarios.") { set_option :wip }
-          opts.on("-v", "--verbose", "Show the files and features loaded.") { set_option :verbose }
-          opts.on("-g", "--guess", "Guess best match for Ambiguous steps.") { set_option :guess }
-          opts.on("-l", "--lines LINES", *lines_msg) {|lines| set_option :lines, lines }
-          opts.on("-x", "--expand", "Expand Scenario Outline Tables in output.") { set_option :expand }
+          opts.on('-c', '--[no-]color', *color_msg) {|v| set_color v }
+          opts.on('-d', '--dry-run', *dry_run_msg) { set_dry_run_and_duration }
+          opts.on('-m', '--no-multiline', "Don't print multiline strings and tables under steps.") { set_option :no_multiline }
+          opts.on('-s', '--no-source', "Don't print the file and line of the step definition with the steps.") { set_option :source, false }
+          opts.on('-i', '--no-snippets', "Don't print snippets for pending steps.") { set_option :snippets, false }
+          opts.on('-I', '--snippet-type TYPE', *snippet_type_msg) {|v| set_option :snippet_type, v.to_sym }
+          opts.on('-q', '--quiet', 'Alias for --no-snippets --no-source.') { shut_up }
+          opts.on('--no-duration', "Don't print the duration at the end of the summary") { set_option :duration, false }
+          opts.on('-b', '--backtrace', 'Show full backtrace for all errors.') { Cucumber.use_full_backtrace = true }
+          opts.on('-S', '--strict', 'Fail if there are any undefined or pending steps.') { set_option :strict }
+          opts.on('-w', '--wip', 'Fail if there are any passing scenarios.') { set_option :wip }
+          opts.on('-v', '--verbose', 'Show the files and features loaded.') { set_option :verbose }
+          opts.on('-g', '--guess', 'Guess best match for Ambiguous steps.') { set_option :guess }
+          opts.on('-l', '--lines LINES', *lines_msg) {|lines| set_option :lines, lines }
+          opts.on('-x', '--expand', 'Expand Scenario Outline Tables in output.') { set_option :expand }
 
-          opts.on("--order TYPE[:SEED]", "Run examples in the specified order. Available types:",
+          opts.on('--order TYPE[:SEED]', 'Run examples in the specified order. Available types:',
             *<<-TEXT.split("\n")) do |order|
   [defined]     Run scenarios in the order they were defined (default).
   [random]      Shuffle scenarios before running.
 Specify SEED to reproduce the shuffling from a previous run.
   e.g. --order random:5738
 TEXT
-            @options[:order], @options[:seed] = *order.split(":")
+            @options[:order], @options[:seed] = *order.split(':')
             unless ORDER_TYPES.include?(@options[:order])
               fail "'#{@options[:order]}' is not a recognised order type. Please use one of #{ORDER_TYPES.join(", ")}."
             end
           end
 
-          opts.on_tail("--version", "Show version.") { exit_ok(Cucumber::VERSION) }
-          opts.on_tail("-h", "--help", "You're looking at it.") { exit_ok(opts.help) }
+          opts.on_tail('--version', 'Show version.') { exit_ok(Cucumber::VERSION) }
+          opts.on_tail('-h', '--help', "You're looking at it.") { exit_ok(opts.help) }
         end.parse!
 
         @args.map! { |a| "#{a}:#{@options[:lines]}" } if @options[:lines]
@@ -162,7 +162,7 @@ TEXT
       def check_formatter_stream_conflicts()
         streams = @options[:formats].uniq.map { |(_, stream)| stream }
         if streams != streams.uniq
-          raise "All but one formatter must use --out, only one can print to each stream (or STDOUT)"
+          raise 'All but one formatter must use --out, only one can print to each stream (or STDOUT)'
         end
       end
 
@@ -179,15 +179,15 @@ TEXT
 
       def color_msg
         [
-          "Whether or not to use ANSI color in the output. Cucumber decides",
-          "based on your platform and the output destination if not specified."
+          'Whether or not to use ANSI color in the output. Cucumber decides',
+          'based on your platform and the output destination if not specified.'
         ]
       end
 
       def dry_run_msg
         [
-          "Invokes formatters without executing the steps.",
-          "This also omits the loading of your support/env.rb file if it exists."
+          'Invokes formatters without executing the steps.',
+          'This also omits the loading of your support/env.rb file if it exists.'
         ]
       end
 
@@ -196,12 +196,12 @@ TEXT
       end
 
       def format_msg
-        [ "How to format features (Default: pretty). Available formats:" ]
+        [ 'How to format features (Default: pretty). Available formats:' ]
       end
 
       def i18n_msg
         [
-          "List keywords for in a particular language",
+          'List keywords for in a particular language',
           %{Run with "--i18n help" to see all languages}
         ]
       end
@@ -214,7 +214,7 @@ TEXT
       end
 
       def lines_msg
-        [ "Run given line numbers. Equivalent to FILE:LINE syntax" ]
+        [ 'Run given line numbers. Equivalent to FILE:LINE syntax' ]
       end
 
       def no_profile_short_flag_msg
@@ -225,23 +225,23 @@ TEXT
 
       def profile_short_flag_msg
         [
-          "Pull commandline arguments from cucumber.yml which can be defined as",
+          'Pull commandline arguments from cucumber.yml which can be defined as',
           "strings or arrays.  When a 'default' profile is defined and no profile",
-          "is specified it is always used. (Unless disabled, see -P below.)",
-          "When feature files are defined in a profile and on the command line",
-          "then only the ones from the command line are used."
+          'is specified it is always used. (Unless disabled, see -P below.)',
+          'When feature files are defined in a profile and on the command line',
+          'then only the ones from the command line are used.'
         ]
       end
 
       def retry_msg
-        [ "Specify the number of times to retry failing tests (default: 0)" ]
+        [ 'Specify the number of times to retry failing tests (default: 0)' ]
       end
 
       def name_msg
         [
-          "Only execute the feature elements which match part of the given name.",
-          "If this option is given more than once, it will match against all the",
-          "given names."
+          'Only execute the feature elements which match part of the given name.',
+          'If this option is given more than once, it will match against all the',
+          'given names.'
         ]
       end
 
@@ -252,60 +252,60 @@ TEXT
 
       def tags_msg
         [
-          "Only execute the features or scenarios with tags matching TAG_EXPRESSION.",
-          "Scenarios inherit tags declared on the Feature level. The simplest",
-          "TAG_EXPRESSION is simply a tag. Example: --tags @dev. When a tag in a tag",
-          "expression starts with a ~, this represents boolean NOT. Example: --tags ~@dev.",
-          "A tag expression can have several tags separated by a comma, which represents",
-          "logical OR. Example: --tags @dev,@wip. The --tags option can be specified",
-          "several times, and this represents logical AND. Example: --tags @foo,~@bar --tags @zap.",
-          "This represents the boolean expression (@foo || !@bar) && @zap.",
+          'Only execute the features or scenarios with tags matching TAG_EXPRESSION.',
+          'Scenarios inherit tags declared on the Feature level. The simplest',
+          'TAG_EXPRESSION is simply a tag. Example: --tags @dev. When a tag in a tag',
+          'expression starts with a ~, this represents boolean NOT. Example: --tags ~@dev.',
+          'A tag expression can have several tags separated by a comma, which represents',
+          'logical OR. Example: --tags @dev,@wip. The --tags option can be specified',
+          'several times, and this represents logical AND. Example: --tags @foo,~@bar --tags @zap.',
+          'This represents the boolean expression (@foo || !@bar) && @zap.',
           "\n",
-          "Beware that if you want to use several negative tags to exclude several tags",
-          "you have to use logical AND: --tags ~@fixme --tags ~@buggy.",
+          'Beware that if you want to use several negative tags to exclude several tags',
+          'you have to use logical AND: --tags ~@fixme --tags ~@buggy.',
           "\n",
-          "Positive tags can be given a threshold to limit the number of occurrences.",
-          "Example: --tags @qa:3 will fail if there are more than 3 occurrences of the @qa tag.",
-          "This can be practical if you are practicing Kanban or CONWIP."
+          'Positive tags can be given a threshold to limit the number of occurrences.',
+          'Example: --tags @qa:3 will fail if there are more than 3 occurrences of the @qa tag.',
+          'This can be practical if you are practicing Kanban or CONWIP.'
         ]
       end
 
       def out_msg
         [
-          "Write output to a file/directory instead of STDOUT. This option",
-          "applies to the previously specified --format, or the",
-          "default format if no format is specified. Check the specific",
+          'Write output to a file/directory instead of STDOUT. This option',
+          'applies to the previously specified --format, or the',
+          'default format if no format is specified. Check the specific',
           "formatter's docs to see whether to pass a file or a dir."
         ]
       end
 
       def require_files_msg
         [
-          "Require files before executing the features. If this",
-          "option is not specified, all *.rb files that are",
-          "siblings or below the features will be loaded auto-",
-          "matically. Automatic loading is disabled when this",
-          "option is specified, and all loading becomes explicit.",
-          "Files under directories named \"support\" are always",
-          "loaded first.",
-          "This option can be specified multiple times."
+          'Require files before executing the features. If this',
+          'option is not specified, all *.rb files that are',
+          'siblings or below the features will be loaded auto-',
+          'matically. Automatic loading is disabled when this',
+          'option is specified, and all loading becomes explicit.',
+          'Files under directories named "support" are always',
+          'loaded first.',
+          'This option can be specified multiple times.'
         ]
       end
 
       def snippet_type_msg
         [
-          "Use different snippet type (Default: regexp). Available types:",
+          'Use different snippet type (Default: regexp). Available types:',
           Cucumber::RbSupport::RbLanguage.cli_snippet_type_options
         ].flatten
       end
 
       def banner
-        ["Usage: cucumber [options] [ [FILE|DIR|URL][:LINE[:LINE]*] ]+", "",
-          "Examples:",
-          "cucumber examples/i18n/en/features",
-          "cucumber @rerun.txt (See --format rerun)",
-          "cucumber examples/i18n/it/features/somma.feature:6:98:113",
-          "cucumber -s -i http://rubyurl.com/eeCl", "", "",
+        ['Usage: cucumber [options] [ [FILE|DIR|URL][:LINE[:LINE]*] ]+', '',
+          'Examples:',
+          'cucumber examples/i18n/en/features',
+          'cucumber @rerun.txt (See --format rerun)',
+          'cucumber examples/i18n/it/features/somma.feature:6:98:113',
+          'cucumber -s -i http://rubyurl.com/eeCl', '', '',
         ].join("\n")
       end
 
@@ -396,7 +396,7 @@ TEXT
 
       def merge_profiles
         if @disable_profile_loading
-          @out_stream.puts "Disabling profiles..."
+          @out_stream.puts 'Disabling profiles...'
           return
         end
 
@@ -469,21 +469,21 @@ TEXT
         require 'gherkin/dialect'
         language = ::Gherkin::Dialect.for(lang)
         data = Cucumber::MultilineArgument::DataTable.from(
-          [["feature", to_keywords_string(language.feature_keywords)],
-          ["background", to_keywords_string(language.background_keywords)],
-          ["scenario", to_keywords_string(language.scenario_keywords)],
-          ["scenario_outline", to_keywords_string(language.scenario_outline_keywords)],
-          ["examples", to_keywords_string(language.examples_keywords)],
-          ["given", to_keywords_string(language.given_keywords)],
-          ["when", to_keywords_string(language.when_keywords)],
-          ["then", to_keywords_string(language.then_keywords)],
-          ["and", to_keywords_string(language.and_keywords)],
-          ["but", to_keywords_string(language.but_keywords)],
-          ["given (code)", to_code_keywords_string(language.given_keywords)],
-          ["when (code)", to_code_keywords_string(language.when_keywords)],
-          ["then (code)", to_code_keywords_string(language.then_keywords)],
-          ["and (code)", to_code_keywords_string(language.and_keywords)],
-          ["but (code)", to_code_keywords_string(language.but_keywords)]])
+          [['feature', to_keywords_string(language.feature_keywords)],
+          ['background', to_keywords_string(language.background_keywords)],
+          ['scenario', to_keywords_string(language.scenario_keywords)],
+          ['scenario_outline', to_keywords_string(language.scenario_outline_keywords)],
+          ['examples', to_keywords_string(language.examples_keywords)],
+          ['given', to_keywords_string(language.given_keywords)],
+          ['when', to_keywords_string(language.when_keywords)],
+          ['then', to_keywords_string(language.then_keywords)],
+          ['and', to_keywords_string(language.and_keywords)],
+          ['but', to_keywords_string(language.but_keywords)],
+          ['given (code)', to_code_keywords_string(language.given_keywords)],
+          ['when (code)', to_code_keywords_string(language.when_keywords)],
+          ['then (code)', to_code_keywords_string(language.then_keywords)],
+          ['and (code)', to_code_keywords_string(language.and_keywords)],
+          ['but (code)', to_code_keywords_string(language.but_keywords)]])
         @out_stream.write(data.to_s({ color: false, prefixes: Hash.new('') }))
         Kernel.exit(0)
       end

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -266,7 +266,7 @@ module Cucumber
     end
 
     def default_features_paths
-      ["features"]
+      ['features']
     end
 
     def with_default_features_path(paths)

--- a/lib/cucumber/constantize.rb
+++ b/lib/cucumber/constantize.rb
@@ -29,7 +29,7 @@ module Cucumber
       camel_cased_word.to_s.gsub(/::/, '/').
         gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
         gsub(/([a-z\d])([A-Z])/,'\1_\2').
-        tr("-", "_").
+        tr('-', '_').
         downcase
     end
 

--- a/lib/cucumber/core_ext/instance_exec.rb
+++ b/lib/cucumber/core_ext/instance_exec.rb
@@ -15,9 +15,9 @@ class Object #:nodoc:
       if check_arity && !cucumber_compatible_arity?(args, block)
         instance_exec do
           ari = block.arity
-          ari = ari < 0 ? (ari.abs-1).to_s+"+" : ari
-          s1 = ari == 1 ? "" : "s"
-          s2 = args.length == 1 ? "" : "s"
+          ari = ari < 0 ? (ari.abs-1).to_s+'+' : ari
+          s1 = ari == 1 ? '' : 's'
+          s2 = args.length == 1 ? '' : 's'
           raise Cucumber::ArityMismatchError.new(
             "Your block takes #{ari} argument#{s1}, but the Regexp matched #{args.length} argument#{s2}."
           )

--- a/lib/cucumber/core_ext/string.rb
+++ b/lib/cucumber/core_ext/string.rb
@@ -4,7 +4,7 @@ class String #:nodoc:
     if n >= 0
       gsub(/^/, ' ' * n)
     else
-      gsub(/^ {0,#{-n}}/, "")
+      gsub(/^ {0,#{-n}}/, '')
     end
   end
 end

--- a/lib/cucumber/filters/tag_limits.rb
+++ b/lib/cucumber/filters/tag_limits.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require "cucumber/filters/gated_receiver"
-require "cucumber/filters/tag_limits/test_case_index"
-require "cucumber/filters/tag_limits/verifier"
+require 'cucumber/filters/gated_receiver'
+require 'cucumber/filters/tag_limits/test_case_index'
+require 'cucumber/filters/tag_limits/verifier'
 
 module Cucumber
   module Filters

--- a/lib/cucumber/filters/tag_limits/verifier.rb
+++ b/lib/cucumber/filters/tag_limits/verifier.rb
@@ -28,7 +28,7 @@ module Cucumber
         attr_reader :tag_limits
 
         class Breach
-          INDENT = (" " * 2).freeze
+          INDENT = (' ' * 2).freeze
 
           def initialize(tag_name, limit, locations)
             @tag_name = tag_name

--- a/lib/cucumber/formatter/ansicolor.rb
+++ b/lib/cucumber/formatter/ansicolor.rb
@@ -9,7 +9,7 @@ if Cucumber::WINDOWS_MRI
   end
 end
 
-Cucumber::Term::ANSIColor.coloring = false if !STDOUT.tty? && !ENV.has_key?("AUTOTEST")
+Cucumber::Term::ANSIColor.coloring = false if !STDOUT.tty? && !ENV.has_key?('AUTOTEST')
 
 module Cucumber
   module Formatter
@@ -105,7 +105,7 @@ module Cucumber
         begin
           gem 'genki-ruby-terminfo'
           require 'terminfo'
-          case TermInfo.default_object.tigetnum("colors")
+          case TermInfo.default_object.tigetnum('colors')
           when 0
             raise "Your terminal doesn't support colours."
           when 1
@@ -118,9 +118,9 @@ module Cucumber
           end
         rescue Exception => e
           if e.class.name == 'TermInfo::TermInfoError'
-            STDERR.puts "*** WARNING ***"
+            STDERR.puts '*** WARNING ***'
             STDERR.puts "You have the genki-ruby-terminfo gem installed, but you haven't set your TERM variable."
-            STDERR.puts "Try setting it to TERM=xterm-256color to get grey colour in output."
+            STDERR.puts 'Try setting it to TERM=xterm-256color to get grey colour in output.'
             STDERR.puts "\n"
             alias grey white
           else
@@ -142,7 +142,7 @@ module Cucumber
       define_grey
 
       def cukes(n)
-        ("(::) " * n).strip
+        ('(::) ' * n).strip
       end
 
       def green_cukes(n)

--- a/lib/cucumber/formatter/backtrace_filter.rb
+++ b/lib/cucumber/formatter/backtrace_filter.rb
@@ -32,7 +32,7 @@ module Cucumber
         return @exception if ::Cucumber.use_full_backtrace
 
         pwd_pattern = /#{::Regexp.escape(::Dir.pwd)}\//m
-        backtrace = @exception.backtrace.map { |line| line.gsub(pwd_pattern, "./") }
+        backtrace = @exception.backtrace.map { |line| line.gsub(pwd_pattern, './') }
 
         filtered = (backtrace || []).reject do |line|
           line =~ BACKTRACE_FILTER_PATTERNS

--- a/lib/cucumber/formatter/console.rb
+++ b/lib/cucumber/formatter/console.rb
@@ -102,7 +102,7 @@ module Cucumber
       end
 
       def exception_message_string(e, indent)
-        message = "#{e.message} (#{e.class})".dup.force_encoding("UTF-8")
+        message = "#{e.message} (#{e.class})".dup.force_encoding('UTF-8')
         message = linebreaks(message, ENV['CUCUMBER_TRUNCATE_OUTPUT'].to_i)
 
         string = "#{message}\n#{e.backtrace.join("\n")}".indent(indent)
@@ -157,7 +157,7 @@ module Cucumber
       def do_print_passing_wip(passed_messages)
         if passed_messages.any?
           @io.puts format_string("\nThe --wip switch was used, so I didn't expect anything to pass. These scenarios passed:", :failed)
-          print_element_messages(passed_messages, :passed, "scenarios")
+          print_element_messages(passed_messages, :passed, 'scenarios')
         else
           @io.puts format_string("\nThe --wip switch was used, so the failures were expected. All is good.\n", :passed)
         end

--- a/lib/cucumber/formatter/console_counts.rb
+++ b/lib/cucumber/formatter/console_counts.rb
@@ -20,8 +20,8 @@ module Cucumber
 
       def to_s
         [
-          [scenario_count, status_counts(@test_case_summary)].compact.join(" "),
-          [step_count, status_counts(@test_step_summary)].compact.join(" ")
+          [scenario_count, status_counts(@test_case_summary)].compact.join(' '),
+          [step_count, status_counts(@test_step_summary)].compact.join(' ')
         ].join("\n")
       end
 
@@ -33,12 +33,12 @@ module Cucumber
 
       def scenario_count
         count = @test_case_summary.total
-        "#{count} scenario" + (count == 1 ? "" : "s")
+        "#{count} scenario" + (count == 1 ? '' : 's')
       end
 
       def step_count
         count = @test_step_summary.total
-        "#{count} step" + (count == 1 ? "" : "s")
+        "#{count} step" + (count == 1 ? '' : 's')
       end
 
       def status_counts(summary)

--- a/lib/cucumber/formatter/console_issues.rb
+++ b/lib/cucumber/formatter/console_issues.rb
@@ -15,7 +15,7 @@ module Cucumber
 
       def to_s
         return if @failures.empty?
-        result = [ format_string("Failing Scenarios:", :failed) ] + @failures.map { |failure|
+        result = [ format_string('Failing Scenarios:', :failed) ] + @failures.map { |failure|
           source = @config.source? ? format_string(" # #{failure.keyword}: #{failure.name}", :comment) : ''
           format_string("cucumber #{profiles_string}" + failure.location, :failed) + source
         }

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -41,8 +41,8 @@ module Cucumber
         case(mime_type)
         when /^image\/(png|gif|jpg|jpeg)/
           unless File.file?(src) or src =~ /^data:image\/(png|gif|jpg|jpeg);base64,/
-            type = mime_type =~ /;base[0-9]+$/ ? mime_type : mime_type + ";base64"
-            src = "data:" + type + "," + src
+            type = mime_type =~ /;base[0-9]+$/ ? mime_type : mime_type + ';base64'
+            src = 'data:' + type + ',' + src
           end
           embed_image(src, label)
         when /^text\/plain/
@@ -299,7 +299,7 @@ module Cucumber
           @builder.pre do |pre|
             # TODO: snippet text should be an event sent to the formatter so we don't 
             # have this couping to the runtime.
-            pre << @runtime.snippet_text(keyword,step_match.instance_variable_get("@name") || '', @step.multiline_arg)
+            pre << @runtime.snippet_text(keyword,step_match.instance_variable_get('@name') || '', @step.multiline_arg)
           end
         end
         @builder << '</li>'
@@ -412,7 +412,7 @@ module Cucumber
         return if @delayed_messages.empty?
 
         @builder.td(:class => 'message') do
-          @builder << @delayed_messages.join(", ")
+          @builder << @delayed_messages.join(', ')
         end
         empty_messages
       end
@@ -437,7 +437,7 @@ module Cucumber
             matches = message.match(/Showing <i>(.+)<\/i>(?:.+) #(\d+)/)
             backtrace += ["#{RAILS_ROOT}/#{matches[1]}:#{matches[2]}"] if matches
             matches = message.match(/<code>([^(\/)]+)<\//m)
-            message = matches ? matches[1] : ""
+            message = matches ? matches[1] : ''
           end
 
           unless exception.instance_of?(RuntimeError)
@@ -456,7 +456,7 @@ module Cucumber
           end
         end
         extra = extra_failure_content(backtrace)
-        @builder << extra unless extra == ""
+        @builder << extra unless extra == ''
       end
 
       def set_scenario_color(status)
@@ -472,7 +472,7 @@ module Cucumber
         @builder.script do
           @builder.text!("makeRed('cucumber-header');") unless @header_red
           @header_red = true
-          scenario_or_background = @in_background ? "background" : "scenario"
+          scenario_or_background = @in_background ? 'background' : 'scenario'
           @builder.text!("makeRed('#{scenario_or_background}_#{@scenario_number}');") unless @scenario_red
           @scenario_red = true
           if @options[:expand] and @inside_outline
@@ -484,7 +484,7 @@ module Cucumber
       def set_scenario_color_pending
         @builder.script do
           @builder.text!("makeYellow('cucumber-header');") unless @header_red
-          scenario_or_background = @in_background ? "background" : "scenario"
+          scenario_or_background = @in_background ? 'background' : 'scenario'
           @builder.text!("makeYellow('#{scenario_or_background}_#{@scenario_number}');") unless @scenario_red
         end
       end
@@ -607,11 +607,11 @@ module Cucumber
 
       def print_stat_string(features)
         string = String.new
-        string << dump_count(@runtime.scenarios.length, "scenario")
+        string << dump_count(@runtime.scenarios.length, 'scenario')
         scenario_count = print_status_counts{|status| @runtime.scenarios(status)}
         string << scenario_count if scenario_count
-        string << "<br />"
-        string << dump_count(@runtime.steps.length, "step")
+        string << '<br />'
+        string << dump_count(@runtime.steps.length, 'step')
         step_count = print_status_counts{|status| @runtime.steps(status)}
         string << step_count if step_count
       end
@@ -625,7 +625,7 @@ module Cucumber
       end
 
       def dump_count(count, what, state=nil)
-        [count, state, "#{what}#{count == 1 ? '' : 's'}"].compact.join(" ")
+        [count, state, "#{what}#{count == 1 ? '' : 's'}"].compact.join(' ')
       end
 
       def create_builder(io)
@@ -638,7 +638,7 @@ module Cucumber
 
       class SnippetExtractor #:nodoc:
         class NullConverter; def convert(code, pre); code; end; end #:nodoc:
-        begin; require 'syntax/convertors/html'; @@converter = Syntax::Convertors::HTML.for_syntax "ruby"; rescue LoadError => e; @@converter = NullConverter.new; end
+        begin; require 'syntax/convertors/html'; @@converter = Syntax::Convertors::HTML.for_syntax 'ruby'; rescue LoadError => e; @@converter = NullConverter.new; end
 
         def snippet(error)
           raw_code, line = snippet_for(error[0])

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -170,7 +170,7 @@ module Cucumber
       end
 
       def create_doc_string_hash(doc_string)
-        content_type = doc_string.content_type ? doc_string.content_type : ""
+        content_type = doc_string.content_type ? doc_string.content_type : ''
         {
           value: doc_string.content,
           content_type: content_type,
@@ -192,7 +192,7 @@ module Cucumber
       def add_failed_around_hook(result)
         @step_or_hook_hash = {}
         around_hooks << @step_or_hook_hash
-        @step_or_hook_hash[:match] = { location: "unknown_hook_location:1" }
+        @step_or_hook_hash[:match] = { location: 'unknown_hook_location:1' }
 
         @step_or_hook_hash[:result] = create_result_hash(result)
       end

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -23,7 +23,7 @@ module Cucumber
         config.on_event :test_case_finished, &method(:on_test_case_finished)
         config.on_event :test_step_finished, &method(:on_test_step_finished)
         config.on_event :test_run_finished, &method(:on_test_run_finished)
-        @reportdir = ensure_dir(config.out_stream, "junit")
+        @reportdir = ensure_dir(config.out_stream, 'junit')
         @config = config
         @features_data = Hash.new { |h,k| h[k] = {
           feature: nil,
@@ -92,7 +92,7 @@ module Cucumber
           :errors => feature_data[:errors],
           :skipped => feature_data[:skipped],
           :tests => feature_data[:tests],
-          :time => "%.6f" % feature_data[:time],
+          :time => '%.6f' % feature_data[:time],
           :name => feature_data[:feature].name ) do
           @testsuite << feature_data[:builder].target!
         end
@@ -103,7 +103,7 @@ module Cucumber
       def create_output_string(test_case, scenario, result, row_name)
         output = "#{test_case.keyword}: #{scenario}\n\n"
         return output if result.ok?(@config.strict?)
-        if test_case.keyword == "Scenario"
+        if test_case.keyword == 'Scenario'
           output += "#{@failing_step_source.keyword}" unless hook?(@failing_step_source)
           output += "#{@failing_step_source.name}\n"
         else
@@ -113,7 +113,7 @@ module Cucumber
       end
 
       def hook?(step)
-        ["Before hook", "After hook", "AfterStep hook"].include? step.name
+        ['Before hook', 'After hook', 'AfterStep hook'].include? step.name
       end
 
       def build_testcase(result, scenario_designation, output)
@@ -122,7 +122,7 @@ module Cucumber
         classname = @current_feature_data[:feature].name
         name = scenario_designation
 
-        @current_feature_data[:builder].testcase(:classname => classname, :name => name, :time => "%.6f" % duration) do
+        @current_feature_data[:builder].testcase(:classname => classname, :name => name, :time => '%.6f' % duration) do
           if !result.passed? && result.ok?(@config.strict?)
             @current_feature_data[:builder].skipped
             @current_feature_data[:skipped] += 1
@@ -182,8 +182,8 @@ module Cucumber
       attr_reader :scenario_name, :name_suffix, :row_name
 
       def initialize(test_case)
-        @name_suffix = ""
-        @row_name = ""
+        @name_suffix = ''
+        @row_name = ''
         test_case.describe_source_to self
       end
 
@@ -192,12 +192,12 @@ module Cucumber
       end
 
       def scenario(scenario)
-        @scenario_name = (scenario.name.nil? || scenario.name == "") ? "Unnamed scenario" : scenario.name
+        @scenario_name = (scenario.name.nil? || scenario.name == '') ? 'Unnamed scenario' : scenario.name
         self
       end
 
       def scenario_outline(outline)
-        @scenario_name = (outline.name.nil? || outline.name == "") ? "Unnamed scenario outline" : outline.name
+        @scenario_name = (outline.name.nil? || outline.name == '') ? 'Unnamed scenario outline' : outline.name
         self
       end
 

--- a/lib/cucumber/formatter/pretty.rb
+++ b/lib/cucumber/formatter/pretty.rb
@@ -211,7 +211,7 @@ module Cucumber
         cell_text = escape_cell(value.to_s || '')
         padded = cell_text + (' ' * (width - cell_text.unpack('U*').length))
         prefix = cell_prefix(status)
-        @io.print(' ' + format_string("#{prefix}#{padded}", status) + ::Cucumber::Term::ANSIColor.reset(" |"))
+        @io.print(' ' + format_string("#{prefix}#{padded}", status) + ::Cucumber::Term::ANSIColor.reset(' |'))
         @io.flush
       end
 

--- a/lib/cucumber/formatter/unicode.rb
+++ b/lib/cucumber/formatter/unicode.rb
@@ -15,7 +15,7 @@ if Cucumber::WINDOWS
       Cucumber::CODEPAGE = "cp#{$1.to_i}"
     end
   else
-    Cucumber::CODEPAGE = "cp1252"
+    Cucumber::CODEPAGE = 'cp1252'
     STDERR.puts("WARNING: Couldn't detect your output codepage. Assuming it is 1252. You may have to chcp 1252 or SET CUCUMBER_OUTPUT_ENCODING=cp1252.")
   end
 

--- a/lib/cucumber/formatter/usage.rb
+++ b/lib/cucumber/formatter/usage.rb
@@ -71,7 +71,7 @@ module Cucumber
           if @stepdef_to_match[stepdef_key].any?
             print_steps(stepdef_key)
           else
-            @io.puts("  " + format_string("NOT MATCHED BY ANY STEPS", :failed))
+            @io.puts('  ' + format_string('NOT MATCHED BY ANY STEPS', :failed))
           end
         end
         @io.puts
@@ -79,7 +79,7 @@ module Cucumber
       end
 
       def print_step_definition(stepdef_key)
-        @io.print format_string(sprintf("%.7f", stepdef_key.mean_duration), :skipped) + " " unless config.dry_run?
+        @io.print format_string(sprintf('%.7f', stepdef_key.mean_duration), :skipped) + ' ' unless config.dry_run?
         @io.print format_string(stepdef_key.regexp_source, stepdef_key.status)
         if config.source?
           indent = max_length - stepdef_key.regexp_source.unpack('U*').length
@@ -91,8 +91,8 @@ module Cucumber
 
       def print_steps(stepdef_key)
         @stepdef_to_match[stepdef_key].each do |step|
-          @io.print "  "
-          @io.print format_string(sprintf("%.7f", step[:duration]), :skipped) + " " unless config.dry_run?
+          @io.print '  '
+          @io.print format_string(sprintf('%.7f', step[:duration]), :skipped) + ' ' unless config.dry_run?
           @io.print format_step(step[:keyword], step[:step_match], step[:status], nil)
           if config.source?
             indent = max_length - (step[:keyword].unpack('U*').length + step[:step_match].format_args.unpack('U*').length)

--- a/lib/cucumber/gherkin/formatter/escaping.rb
+++ b/lib/cucumber/gherkin/formatter/escaping.rb
@@ -10,7 +10,7 @@ module Gherkin
       #
       # This is used in the pretty formatter.
       def escape_cell(s)
-        s.gsub(/\\(?!\|)/, "\\\\\\\\").gsub(/\n/, "\\n").gsub(/\|/, "\\|")
+        s.gsub(/\\(?!\|)/, '\\\\\\\\').gsub(/\n/, '\\n').gsub(/\|/, '\\|')
       end
     end
   end

--- a/lib/cucumber/hooks.rb
+++ b/lib/cucumber/hooks.rb
@@ -44,7 +44,7 @@ module Cucumber
       end
 
       def name
-        "After hook"
+        'After hook'
       end
 
       def match_locations?(queried_locations)
@@ -64,7 +64,7 @@ module Cucumber
       end
 
       def name
-        "Before hook"
+        'Before hook'
       end
 
       def match_locations?(queried_locations)
@@ -84,7 +84,7 @@ module Cucumber
       end
 
       def name
-        "AfterStep hook"
+        'AfterStep hook'
       end
 
       def match_locations?(queried_locations)

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -57,7 +57,7 @@ module Cucumber
       def_delegator :@ast_table, :location
 
       def self.default_arg_name #:nodoc:
-        "table"
+        'table'
       end
 
       class << self
@@ -68,7 +68,7 @@ module Cucumber
           when String
             parse(data, location)
           else
-            raise ArgumentError, "expected data to be a String or an Array."
+            raise ArgumentError, 'expected data to be a String or an Array.'
           end
         end
 
@@ -91,7 +91,7 @@ module Cucumber
       # @param header_mappings [Hash] see map_headers!
       # @param header_conversion_proc [Proc] see map_headers!
       def initialize(data, conversion_procs = NULL_CONVERSIONS.dup, header_mappings = {}, header_conversion_proc = nil)
-        raise ArgumentError, "data must be a Core::Ast::DataTable" unless data.kind_of? Core::Ast::DataTable
+        raise ArgumentError, 'data must be a Core::Ast::DataTable' unless data.kind_of? Core::Ast::DataTable
         ast_table = data
         # Verify that it's square
         ast_table.transpose
@@ -476,7 +476,7 @@ module Cucumber
         Formatter::LegacyApi::Ast::MultilineArg.for(self).accept(Formatter::Fanout.new([formatter]))
         Cucumber::Term::ANSIColor.coloring = c
         io.rewind
-        s = "\n" + io.read + (" " * (options[:indent] - 2))
+        s = "\n" + io.read + (' ' * (options[:indent] - 2))
         s
       end
 

--- a/lib/cucumber/platform.rb
+++ b/lib/cucumber/platform.rb
@@ -6,7 +6,7 @@ require 'cucumber/core/platform'
 
 module Cucumber
   unless defined?(Cucumber::VERSION)
-    VERSION       = File.read(File.expand_path("../version", __FILE__))
+    VERSION       = File.read(File.expand_path('../version', __FILE__))
     BINARY        = File.expand_path(File.dirname(__FILE__) + '/../../bin/cucumber')
     LIBDIR        = File.expand_path(File.dirname(__FILE__) + '/../../lib')
     RAILS         = defined?(Rails)
@@ -19,7 +19,7 @@ module Cucumber
       attr_accessor :use_full_backtrace
 
       # @private
-      def file_mode(m, encoding="UTF-8")
+      def file_mode(m, encoding='UTF-8')
         "#{m}:#{encoding}"
       end
     end

--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -35,7 +35,7 @@ module Cucumber
         attr_reader :args
 
         def initialize(libs, cucumber_opts, feature_files)
-          raise "libs must be an Array when running in-process" unless Array === libs
+          raise 'libs must be an Array when running in-process' unless Array === libs
           libs.reverse.each{|lib| $LOAD_PATH.unshift(lib)}
           @args = (
             cucumber_opts +
@@ -46,7 +46,7 @@ module Cucumber
         def run
           require 'cucumber/cli/main'
           failure = Cucumber::Cli::Main.execute(args)
-          raise "Cucumber failed" if failure
+          raise 'Cucumber failed' if failure
         end
       end
 
@@ -70,7 +70,7 @@ module Cucumber
         end
 
         def use_bundler
-          @bundler.nil? ? File.exist?("./Gemfile") && bundler_gem_available? : @bundler
+          @bundler.nil? ? File.exist?('./Gemfile') && bundler_gem_available? : @bundler
         end
 
         def bundler_gem_available?
@@ -90,7 +90,7 @@ module Cucumber
         end
 
         def run
-          sh cmd.join(" ") do |ok, res|
+          sh cmd.join(' ') do |ok, res|
             if !ok
               exit res.exitstatus
             end
@@ -128,7 +128,7 @@ module Cucumber
       attr_accessor :bundler
 
       # Define Cucumber Rake task
-      def initialize(task_name = "cucumber", desc = "Run Cucumber features")
+      def initialize(task_name = 'cucumber', desc = 'Run Cucumber features')
         @task_name, @desc = task_name, desc
         @fork = true
         @libs = ['lib']
@@ -154,7 +154,7 @@ module Cucumber
       end
 
       def cucumber_opts_with_profile #:nodoc:
-        Array(cucumber_opts).concat Array(@profile).flat_map {|p| ["--profile", p] }
+        Array(cucumber_opts).concat Array(@profile).flat_map {|p| ['--profile', p] }
       end
 
       def feature_files #:nodoc:

--- a/lib/cucumber/rb_support/rb_language.rb
+++ b/lib/cucumber/rb_support/rb_language.rb
@@ -17,7 +17,7 @@ module Cucumber
     # Raised if a World block returns Nil.
     class NilWorld < StandardError
       def initialize
-        super("World procs should never return nil")
+        super('World procs should never return nil')
       end
     end
 
@@ -103,7 +103,7 @@ module Cucumber
       end
 
       def load_code_file(code_file)
-        return unless File.extname(code_file) == ".rb"
+        return unless File.extname(code_file) == '.rb'
         load File.expand_path(code_file) # This will cause self.add_step_definition, self.add_hook, and self.add_transform to be called from RbDsl
       end
 
@@ -204,7 +204,7 @@ module Cucumber
             raise NilWorld.new
           rescue NilWorld => e
             e.backtrace.clear
-            e.backtrace.push(RbSupport.backtrace_line(proc, "World"))
+            e.backtrace.push(RbSupport.backtrace_line(proc, 'World'))
             raise e
           end
         else

--- a/lib/cucumber/rb_support/rb_step_definition.rb
+++ b/lib/cucumber/rb_support/rb_step_definition.rb
@@ -19,7 +19,7 @@ module Cucumber
 
       class MissingProc < StandardError
         def message
-          "Step definitions must always have a proc or symbol"
+          'Step definitions must always have a proc or symbol'
         end
       end
 
@@ -65,7 +65,7 @@ module Cucumber
           when Symbol
             lambda { self.send(target) }
           else
-            lambda { raise ArgumentError, "Target must be a symbol or a proc" }
+            lambda { raise ArgumentError, 'Target must be a symbol or a proc' }
           end
         end
       end

--- a/lib/cucumber/rb_support/rb_transform.rb
+++ b/lib/cucumber/rb_support/rb_transform.rb
@@ -14,7 +14,7 @@ module Cucumber
     class RbTransform
       class MissingProc < StandardError
         def message
-          "Transforms must always have a proc with at least one argument"
+          'Transforms must always have a proc with at least one argument'
         end
       end
 

--- a/lib/cucumber/rb_support/rb_world.rb
+++ b/lib/cucumber/rb_support/rb_world.rb
@@ -100,7 +100,7 @@ module Cucumber
       end
 
       # Mark the matched step as pending.
-      def pending(message = "TODO")
+      def pending(message = 'TODO')
         if block_given?
           begin
             yield
@@ -114,7 +114,7 @@ module Cucumber
       end
 
       # Skips this step and the remaining steps in the scenario
-      def skip_this_scenario(message = "Scenario skipped")
+      def skip_this_scenario(message = 'Scenario skipped')
         raise Core::Test::Result::Skipped, message
       end
 
@@ -125,7 +125,7 @@ module Cucumber
           modules += included_modules
         end
         modules << stringify_namespaced_modules
-        sprintf("#<%s:0x%x>", modules.join('+'), self.object_id)
+        sprintf('#<%s:0x%x>', modules.join('+'), self.object_id)
       end
 
       # see {#inspect}

--- a/lib/cucumber/rb_support/snippet.rb
+++ b/lib/cucumber/rb_support/snippet.rb
@@ -38,7 +38,7 @@ module Cucumber
         end
 
         def self.cli_option_string(type)
-          "%-7s: %-28s e.g. %s" % [type, description, example]
+          '%-7s: %-28s e.g. %s' % [type, description, example]
         end
 
         private
@@ -61,18 +61,18 @@ module Cucumber
           do_block << "do#{arguments}\n"
           multiline_argument.append_comment_to(do_block)
           do_block << "  pending # Write code here that turns the phrase above into concrete actions\n"
-          do_block << "end"
+          do_block << 'end'
           do_block
         end
 
         def arguments
           block_args = (0...number_of_arguments).map { |n| "arg#{n+1}" }
           multiline_argument.append_block_argument_to(block_args)
-          block_args.empty? ? "" : " |#{block_args.join(", ")}|"
+          block_args.empty? ? '' : " |#{block_args.join(", ")}|"
         end
 
         def self.example
-          new("Given", "missing step", MultilineArgument::None.new).step
+          new('Given', 'missing step', MultilineArgument::None.new).step
         end
 
       end
@@ -83,7 +83,7 @@ module Cucumber
         end
 
         def self.description
-          "Snippets with parentheses"
+          'Snippets with parentheses'
         end
       end
 
@@ -93,7 +93,7 @@ module Cucumber
         end
 
         def self.description
-          "Snippets without parentheses. Note that these cause a warning from modern versions of Ruby."
+          'Snippets without parentheses. Note that these cause a warning from modern versions of Ruby.'
         end
       end
 
@@ -103,7 +103,7 @@ module Cucumber
         end
 
         def self.description
-          "Snippets with percent regexp"
+          'Snippets with percent regexp'
         end
       end
 

--- a/lib/cucumber/rspec/doubles.rb
+++ b/lib/cucumber/rspec/doubles.rb
@@ -4,7 +4,7 @@ require 'rspec/mocks'
 World(RSpec::Mocks::ExampleMethods)
 
 Before do
-  if RSpec::Mocks::Version::STRING >= "2.9.9"
+  if RSpec::Mocks::Version::STRING >= '2.9.9'
     RSpec::Mocks.setup
   else
     RSpec::Mocks.setup(self)

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -14,7 +14,7 @@ require 'cucumber/step_match_search'
 module Cucumber
   module FixRuby21Bug9285
     def message
-      String(super).gsub("@ rb_sysopen ", "")
+      String(super).gsub('@ rb_sysopen ', '')
     end
   end
 
@@ -147,7 +147,7 @@ module Cucumber
       end
 
       def read
-        @file.read.encode("UTF-8")
+        @file.read.encode('UTF-8')
       end
 
       private

--- a/lib/simplecov_setup.rb
+++ b/lib/simplecov_setup.rb
@@ -14,6 +14,6 @@ if ENV['SIMPLECOV']
       add_filter '/features/'
     end
   rescue LoadError
-    warn("Unable to load simplecov")
+    warn('Unable to load simplecov')
   end
 end

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -38,7 +38,7 @@ module Cli
 
     attr_reader :out, :error
 
-    it "uses the default profile when no profile is defined" do
+    it 'uses the default profile when no profile is defined' do
       given_cucumber_yml_defined_as({'default' => '--require some_file'})
 
       config.parse!(%w{--format progress})
@@ -49,7 +49,7 @@ module Cli
     context '--profile' do
       include RSpec::WorkInProgress
 
-      it "expands args from profiles in the cucumber.yml file" do
+      it 'expands args from profiles in the cucumber.yml file' do
         given_cucumber_yml_defined_as({'bongo' => '--require from/yml'})
 
         config.parse!(%w{--format progress --profile bongo})
@@ -58,7 +58,7 @@ module Cli
         expect(config.options[:require]).to eq ['from/yml']
       end
 
-      it "expands args from the default profile when no flags are provided" do
+      it 'expands args from the default profile when no flags are provided' do
         given_cucumber_yml_defined_as({'default' => '--require from/yml'})
 
         config.parse!([])
@@ -66,7 +66,7 @@ module Cli
         expect(config.options[:require]).to eq ['from/yml']
       end
 
-      it "allows --strict to be set by a profile" do
+      it 'allows --strict to be set by a profile' do
         given_cucumber_yml_defined_as({'bongo' => '--strict'})
 
         config.parse!(%w{--profile bongo})
@@ -74,7 +74,7 @@ module Cli
         expect(config.options[:strict]).to be true
       end
 
-      it "parses ERB syntax in the cucumber.yml file" do
+      it 'parses ERB syntax in the cucumber.yml file' do
         given_cucumber_yml_defined_as("---\ndefault: \"<%=\"--require some_file\"%>\"\n")
 
         config.parse!([])
@@ -82,7 +82,7 @@ module Cli
         expect(config.options[:require]).to include('some_file')
       end
 
-      it "parses ERB in cucumber.yml that makes uses nested ERB sessions" do
+      it 'parses ERB in cucumber.yml that makes uses nested ERB sessions' do
         given_cucumber_yml_defined_as(<<ERB_YML)
 <%= ERB.new({'standard' => '--require some_file'}.to_yaml).result %>
 <%= ERB.new({'enhanced' => '--require other_file'}.to_yaml).result %>
@@ -93,7 +93,7 @@ ERB_YML
         expect(config.options[:require]).to include('some_file')
       end
 
-      it "provides a helpful error message when a specified profile does not exists in cucumber.yml" do
+      it 'provides a helpful error message when a specified profile does not exists in cucumber.yml' do
         given_cucumber_yml_defined_as({'default' => '--require from/yml', 'html_report' =>  '--format html'})
 
         expected_message = <<-END_OF_MESSAGE
@@ -107,7 +107,7 @@ END_OF_MESSAGE
         expect(-> { config.parse!(%w{--profile i_do_not_exist}) }).to raise_error(ProfileNotFound, expected_message)
       end
 
-      it "allows profiles to be defined in arrays" do
+      it 'allows profiles to be defined in arrays' do
         given_cucumber_yml_defined_as({'foo' => ['-f','progress']})
 
         config.parse!(%w{--profile foo})
@@ -115,34 +115,34 @@ END_OF_MESSAGE
         expect(config.options[:formats]).to eq [['progress', out]]
       end
 
-      it "disregards default STDOUT formatter defined in profile when another is passed in (via cmd line)" do
+      it 'disregards default STDOUT formatter defined in profile when another is passed in (via cmd line)' do
         given_cucumber_yml_defined_as({'foo' => %w[--format pretty]})
         config.parse!(%w{--format progress --profile foo})
 
         expect(config.options[:formats]).to eq [['progress', out]]
       end
 
-      ["--no-profile", "-P"].each do |flag|
+      ['--no-profile', '-P'].each do |flag|
         context 'when none is specified with #{flag}' do
-          it "disables profiles" do
+          it 'disables profiles' do
             given_cucumber_yml_defined_as({'default' => '-v --require file_specified_in_default_profile.rb'})
 
-            config.parse!("#{flag} --require some_file.rb".split(" "))
+            config.parse!("#{flag} --require some_file.rb".split(' '))
 
             expect(config.options[:require]).to eq ['some_file.rb']
           end
 
-          it "notifies the user that the profiles are being disabled" do
+          it 'notifies the user that the profiles are being disabled' do
             given_cucumber_yml_defined_as({'default' => '-v'})
 
-            config.parse!("#{flag} --require some_file.rb".split(" "))
+            config.parse!("#{flag} --require some_file.rb".split(' '))
 
             expect(out.string).to match(/Disabling profiles.../)
           end
         end
       end
 
-      it "issues a helpful error message when a specified profile exists but is nil or blank" do
+      it 'issues a helpful error message when a specified profile exists but is nil or blank' do
         [nil, '   '].each do |bad_input|
           given_cucumber_yml_defined_as({'foo' => bad_input})
 
@@ -152,7 +152,7 @@ END_OF_MESSAGE
         end
       end
 
-      it "issues a helpful error message when no YAML file exists and a profile is specified" do
+      it 'issues a helpful error message when no YAML file exists and a profile is specified' do
         expect(File).to receive(:exist?).with('cucumber.yml') { false }
 
         expected_error = /cucumber\.yml was not found/
@@ -160,10 +160,10 @@ END_OF_MESSAGE
         expect(-> { config.parse!(%w{--profile i_do_not_exist}) }).to raise_error(expected_error)
       end
 
-      it "issues a helpful error message when cucumber.yml is blank or malformed" do
+      it 'issues a helpful error message when cucumber.yml is blank or malformed' do
           expected_error_message = /cucumber\.yml was found, but was blank or malformed. Please refer to cucumber's documentation on correct profile usage./
 
-        ['', 'sfsadfs', "--- \n- an\n- array\n", "---dddfd"].each do |bad_input|
+        ['', 'sfsadfs', "--- \n- an\n- array\n", '---dddfd'].each do |bad_input|
           given_cucumber_yml_defined_as(bad_input)
 
           expect(-> { config.parse!([]) }).to raise_error(expected_error_message)
@@ -172,48 +172,48 @@ END_OF_MESSAGE
         end
       end
 
-      it "issues a helpful error message when cucumber.yml can not be parsed" do
+      it 'issues a helpful error message when cucumber.yml can not be parsed' do
         expected_error_message = /cucumber.yml was found, but could not be parsed. Please refer to cucumber's documentation on correct profile usage./
 
-        given_cucumber_yml_defined_as("input that causes an exception in YAML loading")
+        given_cucumber_yml_defined_as('input that causes an exception in YAML loading')
 
         expect(YAML).to receive(:load).and_raise(ArgumentError)
         expect(-> { config.parse!([]) }).to raise_error(expected_error_message)
       end
 
-      it "issues a helpful error message when cucumber.yml can not be parsed by ERB" do
+      it 'issues a helpful error message when cucumber.yml can not be parsed by ERB' do
         expected_error_message = /cucumber.yml was found, but could not be parsed with ERB.  Please refer to cucumber's documentation on correct profile usage./
-        given_cucumber_yml_defined_as("<% this_fails %>")
+        given_cucumber_yml_defined_as('<% this_fails %>')
 
         expect(-> { config.parse!([]) }).to raise_error(expected_error_message)
       end
     end
 
-    it "accepts --dry-run option" do
+    it 'accepts --dry-run option' do
       config.parse!(%w{--dry-run})
 
       expect(config.options[:dry_run]).to be true
     end
     
-    it "implies --no-duration with --dry-run option" do
+    it 'implies --no-duration with --dry-run option' do
       config.parse!(%w{--dry-run})
       
       expect(config.options[:duration]).to be false
     end
 
-    it "accepts --no-source option" do
+    it 'accepts --no-source option' do
       config.parse!(%w{--no-source})
 
       expect(config.options[:source]).to be false
     end
 
-    it "accepts --no-snippets option" do
+    it 'accepts --no-snippets option' do
       config.parse!(%w{--no-snippets})
 
       expect(config.options[:snippets]).to be false
     end
 
-    it "sets snippets and source and duration to false with --quiet option" do
+    it 'sets snippets and source and duration to false with --quiet option' do
       config.parse!(%w{--quiet})
 
       expect(config.options[:snippets]).to be false
@@ -221,100 +221,100 @@ END_OF_MESSAGE
       expect(config.options[:duration]).to be false
     end
     
-    it "sets duration to false with --no-duration" do
+    it 'sets duration to false with --no-duration' do
       config.parse!(%w{--no-duration})
       
       expect(config.options[:duration]).to be false
     end
 
-    it "accepts --verbose option" do
+    it 'accepts --verbose option' do
       config.parse!(%w{--verbose})
 
       expect(config.options[:verbose]).to be true
     end
 
-    it "accepts --out option" do
+    it 'accepts --out option' do
       config.parse!(%w{--out jalla.txt})
 
       expect(config.formats).to eq [['pretty', 'jalla.txt']]
     end
 
-    it "accepts multiple --out options" do
+    it 'accepts multiple --out options' do
       config.parse!(%w{--format progress --out file1 --out file2})
 
       expect(config.formats).to eq [['progress', 'file2']]
     end
 
-    it "accepts multiple --format options and put the STDOUT one first so progress is seen" do
+    it 'accepts multiple --format options and put the STDOUT one first so progress is seen' do
       config.parse!(%w{--format pretty --out pretty.txt --format progress})
 
       expect(config.formats).to eq [['progress', out], ['pretty', 'pretty.txt']]
     end
 
-    it "does not accept multiple --format options when both use implicit STDOUT" do
-      expect(-> { config.parse!(%w{--format pretty --format progress}) }).to raise_error("All but one formatter must use --out, only one can print to each stream (or STDOUT)")
+    it 'does not accept multiple --format options when both use implicit STDOUT' do
+      expect(-> { config.parse!(%w{--format pretty --format progress}) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
     end
 
-    it "does not accept multiple --format options when both use implicit STDOUT (using profile with no formatters)" do
+    it 'does not accept multiple --format options when both use implicit STDOUT (using profile with no formatters)' do
       given_cucumber_yml_defined_as({'default' => ['-q']})
-      expect(-> { config.parse!(%w{--format pretty --format progress}) }).to raise_error("All but one formatter must use --out, only one can print to each stream (or STDOUT)")
+      expect(-> { config.parse!(%w{--format pretty --format progress}) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
     end
 
-    it "accepts same --format options with implicit STDOUT, and keep only one" do
+    it 'accepts same --format options with implicit STDOUT, and keep only one' do
       config.parse!(%w{--format pretty --format pretty})
 
-      expect(config.formats).to eq [["pretty", out]]
+      expect(config.formats).to eq [['pretty', out]]
     end
 
-    it "does not accept multiple --out streams pointing to the same place" do
-      expect(-> { config.parse!(%w{--format pretty --out file1 --format progress --out file1}) }).to raise_error("All but one formatter must use --out, only one can print to each stream (or STDOUT)")
+    it 'does not accept multiple --out streams pointing to the same place' do
+      expect(-> { config.parse!(%w{--format pretty --out file1 --format progress --out file1}) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
     end
 
-    it "does not accept multiple --out streams pointing to the same place (one from profile, one from command line)" do
+    it 'does not accept multiple --out streams pointing to the same place (one from profile, one from command line)' do
       given_cucumber_yml_defined_as({'default' => ['-f','progress', '--out', 'file1']})
-      expect(-> { config.parse!(%w{--format pretty --out file1}) }).to raise_error("All but one formatter must use --out, only one can print to each stream (or STDOUT)")
+      expect(-> { config.parse!(%w{--format pretty --out file1}) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
     end
 
-    it "associates --out to previous --format" do
+    it 'associates --out to previous --format' do
       config.parse!(%w{--format progress --out file1 --format profile --out file2})
 
-      expect(config.formats).to eq [["progress", "file1"], ["profile" ,"file2"]]
+      expect(config.formats).to eq [['progress', 'file1'], ['profile' ,'file2']]
     end
 
-    it "accepts same --format options with same --out streams and keep only one" do
+    it 'accepts same --format options with same --out streams and keep only one' do
       config.parse!(%w{--format html --out file --format pretty --format html --out file})
 
-      expect(config.formats).to eq [["pretty", out], ["html", "file"]]
+      expect(config.formats).to eq [['pretty', out], ['html', 'file']]
     end
 
-    it "accepts same --format options with different --out streams" do
+    it 'accepts same --format options with different --out streams' do
       config.parse!(%w{--format html --out file1 --format html --out file2})
 
-      expect(config.formats).to eq [["html", "file1"], ["html", "file2"]]
+      expect(config.formats).to eq [['html', 'file1'], ['html', 'file2']]
     end
 
-    it "accepts --color option" do
+    it 'accepts --color option' do
       expect(Cucumber::Term::ANSIColor).to receive(:coloring=).with(true)
 
       config.parse!(['--color'])
     end
 
-    it "accepts --no-color option" do
+    it 'accepts --no-color option' do
       expect(Cucumber::Term::ANSIColor).to receive(:coloring=).with(false)
 
       config = Configuration.new(StringIO.new)
       config.parse!(['--no-color'])
     end
 
-    describe "--backtrace" do
+    describe '--backtrace' do
       before do
         Cucumber.use_full_backtrace = false
       end
 
-      it "shows full backtrace when --backtrace is present" do
+      it 'shows full backtrace when --backtrace is present' do
         Main.new(['--backtrace'])
         begin
-          expect("x").to eq "y"
+          expect('x').to eq 'y'
         rescue RSpec::Expectations::ExpectationNotMetError => e
           expect(e.backtrace[0]).not_to eq "#{__FILE__}:#{__LINE__ - 2}"
         end
@@ -325,45 +325,45 @@ END_OF_MESSAGE
       end
     end
 
-    it "accepts multiple --name options" do
-      config.parse!(['--name', "User logs in", '--name', "User signs up"])
+    it 'accepts multiple --name options' do
+      config.parse!(['--name', 'User logs in', '--name', 'User signs up'])
 
       expect(config.options[:name_regexps]).to include(/User logs in/)
       expect(config.options[:name_regexps]).to include(/User signs up/)
     end
 
-    it "accepts multiple -n options" do
-      config.parse!(['-n', "User logs in", '-n', "User signs up"])
+    it 'accepts multiple -n options' do
+      config.parse!(['-n', 'User logs in', '-n', 'User signs up'])
 
       expect(config.options[:name_regexps]).to include(/User logs in/)
       expect(config.options[:name_regexps]).to include(/User signs up/)
     end
 
-    it "should allow specifying environment variables on the command line" do
-      config.parse!(["foo=bar"])
+    it 'should allow specifying environment variables on the command line' do
+      config.parse!(['foo=bar'])
 
-      expect(ENV["foo"]).to eq "bar"
+      expect(ENV['foo']).to eq 'bar'
       expect(config.paths).not_to include('foo=bar')
     end
 
-    it "allows specifying environment variables in profiles" do
+    it 'allows specifying environment variables in profiles' do
       given_cucumber_yml_defined_as({'selenium' => 'RAILS_ENV=selenium'})
-      config.parse!(["--profile", "selenium"])
+      config.parse!(['--profile', 'selenium'])
 
-      expect(ENV["RAILS_ENV"]).to eq "selenium"
+      expect(ENV['RAILS_ENV']).to eq 'selenium'
       expect(config.paths).not_to include('RAILS_ENV=selenium')
     end
 
-    describe "#tag_expression" do
+    describe '#tag_expression' do
       include RSpec::WorkInProgress
 
-      it "returns an empty expression when no tags are specified" do
+      it 'returns an empty expression when no tags are specified' do
         config.parse!([])
 
         expect(config.tag_expression).to be_empty
       end
 
-      it "returns an expression when tags are specified" do
+      it 'returns an expression when tags are specified' do
         config.parse!(['--tags','@foo'])
 
         expect(config.tag_expression).not_to be_empty
@@ -371,62 +371,62 @@ END_OF_MESSAGE
     end
 
     describe '#tag_limits' do
-      it "returns an empty hash when no limits are specified" do
+      it 'returns an empty hash when no limits are specified' do
         config.parse!([])
 
         expect(config.tag_limits).to eq({ })
       end
 
-      it "returns a hash of limits when limits are specified" do
+      it 'returns a hash of limits when limits are specified' do
         config.parse!(['--tags','@foo:1'])
 
-        expect(config.tag_limits).to eq({ "@foo" => 1 })
+        expect(config.tag_limits).to eq({ '@foo' => 1 })
       end
     end
 
-    describe "#dry_run?" do
-      it "returns true when --dry-run was specified on in the arguments" do
+    describe '#dry_run?' do
+      it 'returns true when --dry-run was specified on in the arguments' do
         config.parse!(['--dry-run'])
 
         expect(config.dry_run?).to be true
       end
 
-      it "returns true when --dry-run was specified in yaml file" do
+      it 'returns true when --dry-run was specified in yaml file' do
         given_cucumber_yml_defined_as({'default' => '--dry-run'})
         config.parse!([])
 
         expect(config.dry_run?).to be true
       end
 
-      it "returns false by default" do
+      it 'returns false by default' do
         config.parse!([])
 
         expect(config.dry_run?).to be false
       end
     end
 
-    describe "#snippet_type" do
-      it "returns the snippet type when it was set" do
-        config.parse!(["--snippet-type", "classic"])
+    describe '#snippet_type' do
+      it 'returns the snippet type when it was set' do
+        config.parse!(['--snippet-type', 'classic'])
 
         expect(config.snippet_type).to eq :classic
       end
 
-      it "returns the snippet type when it was set with shorthand option" do
-        config.parse!(["-I", "classic"])
+      it 'returns the snippet type when it was set with shorthand option' do
+        config.parse!(['-I', 'classic'])
 
         expect(config.snippet_type).to eq :classic
       end
 
-      it "returns the default snippet type if it was not set" do
+      it 'returns the default snippet type if it was not set' do
         config.parse!([])
 
         expect(config.snippet_type).to eq :regexp
       end
     end
 
-    describe "#retry_attempts" do 
-      it "returns the specified number of retries" do 
+    describe '#retry_attempts' do 
+      it 'returns the specified number of retries' do 
         config.parse!(['--retry=3'])
         expect(config.retry_attempts).to eql 3
       end

--- a/spec/cucumber/cli/main_spec.rb
+++ b/spec/cucumber/cli/main_spec.rb
@@ -17,15 +17,15 @@ module Cucumber
       let(:kernel) { double(:kernel) }
       subject { Main.new(args, stdin, stdout, stderr, kernel)}
 
-      describe "#execute!" do
-        context "passed an existing runtime" do
+      describe '#execute!' do
+        context 'passed an existing runtime' do
           let(:existing_runtime) { double('runtime').as_null_object }
 
           def do_execute
             subject.execute!(existing_runtime)
           end
 
-          it "configures that runtime" do
+          it 'configures that runtime' do
             expected_configuration = double('Configuration').as_null_object
 
             allow(Configuration).to receive(:new) { expected_configuration }
@@ -35,7 +35,7 @@ module Cucumber
             do_execute
           end
 
-          it "uses that runtime for running and reporting results" do
+          it 'uses that runtime for running and reporting results' do
             expected_results = double('results', :failure? => true)
 
             expect(existing_runtime).to receive(:run!)
@@ -46,12 +46,12 @@ module Cucumber
           end
         end
 
-        context "interrupted with ctrl-c" do
+        context 'interrupted with ctrl-c' do
           after do
             Cucumber.wants_to_quit = false
           end
 
-          it "exits with error code" do
+          it 'exits with error code' do
             results = double('results', :failure? => false)
 
             allow_any_instance_of(Runtime).to receive(:run!)
@@ -71,7 +71,7 @@ module Cucumber
           configuration = double('configuration')
 
           allow(Configuration).to receive(:new) { configuration }
-          allow(configuration).to receive(:parse!).and_raise(exception_klass.new("error message"))
+          allow(configuration).to receive(:parse!).and_raise(exception_klass.new('error message'))
           allow(kernel).to receive(:exit).with(2)
 
           subject.execute!

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -49,7 +49,7 @@ module Cucumber
         end
 
         context '-r or --require' do
-          it "collects all specified files into an array" do
+          it 'collects all specified files into an array' do
             after_parsing('--require some_file.rb -r another_file.rb') do
               expect(options[:require]).to eq ['some_file.rb', 'another_file.rb']
             end
@@ -60,33 +60,33 @@ module Cucumber
           context "with LANG specified as 'help'" do
             include RSpec::WorkInProgress
 
-            it "lists all known languages" do
+            it 'lists all known languages' do
               when_parsing '--i18n help' do
                 expect(Kernel).to receive(:exit)
               end
             end
 
-            it "exits the program" do
+            it 'exits the program' do
               when_parsing('--i18n help') { expect(Kernel).to receive(:exit) }
             end
           end
 
-          context "with invalid LANG" do 
+          context 'with invalid LANG' do 
             include RSpec::WorkInProgress
 
-            it "exits" do 
+            it 'exits' do 
               when_parsing '--i18n foo' do 
                 expect(Kernel).to receive(:exit)
               end
             end
 
-            it "says the language was invalid" do 
+            it 'says the language was invalid' do 
               after_parsing '--i18n foo' do 
                 expect(@output_stream.string).to include("Invalid language 'foo'. Available languages are:")
               end
             end
 
-            it "displays the language table" do 
+            it 'displays the language table' do 
               after_parsing '--i18n foo' do 
                 ::Gherkin::DIALECTS.keys.map do |key|
                   expect(@output_stream.string).to include("#{key}");
@@ -97,7 +97,7 @@ module Cucumber
         end
 
         context '-f FORMAT or --format FORMAT' do
-          it "defaults the output for the formatter to the output stream (STDOUT)" do
+          it 'defaults the output for the formatter to the output stream (STDOUT)' do
             after_parsing('-f pretty') { expect(options[:formats]).to eq [['pretty', output_stream]] }
           end
         end
@@ -106,7 +106,7 @@ module Cucumber
           it "defaults the formatter to 'pretty' when not specified earlier" do
             after_parsing('-o file.txt') { expect(options[:formats]).to eq [['pretty', 'file.txt']] }
           end
-          it "sets the output for the formatter defined immediatly before it" do
+          it 'sets the output for the formatter defined immediatly before it' do
             after_parsing('-f profile --out file.txt -f pretty -o file2.txt') do
               expect(options[:formats]).to eq [['profile', 'file.txt'], ['pretty', 'file2.txt']]
             end
@@ -114,58 +114,58 @@ module Cucumber
         end
 
         context 'handling multiple formatters' do
-          it "catches multiple command line formatters using the same stream" do
-            expect{ options.parse!(prepare_args('-f pretty -f progress')) }.to raise_error("All but one formatter must use --out, only one can print to each stream (or STDOUT)")
+          it 'catches multiple command line formatters using the same stream' do
+            expect{ options.parse!(prepare_args('-f pretty -f progress')) }.to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
           end
 
-          it "catches multiple profile formatters using the same stream" do
+          it 'catches multiple profile formatters using the same stream' do
             given_cucumber_yml_defined_as({'default' => '-f progress -f pretty'})
             options = Options.new(output_stream, error_stream, :default_profile => 'default')
 
-            expect{ options.parse!(%w{}) }.to raise_error("All but one formatter must use --out, only one can print to each stream (or STDOUT)")
+            expect{ options.parse!(%w{}) }.to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
           end
 
-          it "profiles does not affect the catching of multiple command line formatters using the same stream" do
+          it 'profiles does not affect the catching of multiple command line formatters using the same stream' do
             given_cucumber_yml_defined_as({'default' => '-q'})
             options = Options.new(output_stream, error_stream, :default_profile => 'default')
 
-            expect{ options.parse!(%w{-f progress -f pretty}) }.to raise_error("All but one formatter must use --out, only one can print to each stream (or STDOUT)")
+            expect{ options.parse!(%w{-f progress -f pretty}) }.to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
           end
 
-          it "merges profile formatters and command line formatters" do
+          it 'merges profile formatters and command line formatters' do
             given_cucumber_yml_defined_as({'default' => '-f junit -o result.xml'})
             options = Options.new(output_stream, error_stream, :default_profile => 'default')
 
             options.parse!(%w{-f pretty})
             
-            expect(options[:formats]).to eq [['pretty', output_stream], ["junit", "result.xml"]]
+            expect(options[:formats]).to eq [['pretty', output_stream], ['junit', 'result.xml']]
           end
         end
 
         context '-t TAGS --tags TAGS' do
-          it "designates tags prefixed with ~ as tags to be excluded" do
+          it 'designates tags prefixed with ~ as tags to be excluded' do
             after_parsing('--tags ~@foo,@bar') { expect(options[:tag_expressions]).to eq ['~@foo,@bar'] }
           end
 
-          it "stores tags passed with different --tags seperately" do
+          it 'stores tags passed with different --tags seperately' do
             after_parsing('--tags @foo --tags @bar') { expect(options[:tag_expressions]).to eq ['@foo', '@bar'] }
           end
         end
 
         context '-n NAME or --name NAME' do
-          it "stores the provided names as regular expressions" do
+          it 'stores the provided names as regular expressions' do
             after_parsing('-n foo --name bar') { expect(options[:name_regexps]).to eq [/foo/,/bar/] }
           end
         end
 
         context '-e PATTERN or --exclude PATTERN' do
-          it "stores the provided exclusions as regular expressions" do
+          it 'stores the provided exclusions as regular expressions' do
             after_parsing('-e foo --exclude bar') { expect(options[:excludes]).to eq [/foo/,/bar/] }
           end
         end
 
         context '-l LINES or --lines LINES' do
-          it "adds line numbers to args" do
+          it 'adds line numbers to args' do
             options.parse!(%w{-l24 FILE})
 
             expect(options.instance_variable_get(:@args)).to eq ['FILE:24']
@@ -173,7 +173,7 @@ module Cucumber
         end
 
         context '-p PROFILE or --profile PROFILE' do
-          it "uses the default profile passed in during initialization if none are specified by the user" do
+          it 'uses the default profile passed in during initialization if none are specified by the user' do
             given_cucumber_yml_defined_as({'default' => '--require some_file'})
 
             options = Options.new(output_stream, error_stream, :default_profile => 'default')
@@ -182,7 +182,7 @@ module Cucumber
             expect(options[:require]).to include('some_file')
           end
 
-          it "merges all uniq values from both cmd line and the profile" do
+          it 'merges all uniq values from both cmd line and the profile' do
             given_cucumber_yml_defined_as('foo' => %w[--verbose])
             options.parse!(%w[--wip --profile foo])
 
@@ -197,77 +197,77 @@ module Cucumber
             expect(options[:paths]).to eq %w[my.feature]
           end
 
-          it "combines the require files of both" do
+          it 'combines the require files of both' do
             given_cucumber_yml_defined_as('bar' => %w[--require features -r dog.rb])
             options.parse!(%w[--require foo.rb -p bar])
 
             expect(options[:require]).to eq %w[foo.rb features dog.rb]
           end
 
-          it "combines the tag names of both" do
+          it 'combines the tag names of both' do
             given_cucumber_yml_defined_as('baz' => %w[-t @bar])
             options.parse!(%w[--tags @foo -p baz])
 
-            expect(options[:tag_expressions]).to eq ["@foo", "@bar"]
+            expect(options[:tag_expressions]).to eq ['@foo', '@bar']
           end
 
-          it "only takes the paths from the original options, and disgregards the profiles" do
+          it 'only takes the paths from the original options, and disgregards the profiles' do
             given_cucumber_yml_defined_as('baz' => %w[features])
             options.parse!(%w[my.feature -p baz])
 
             expect(options[:paths]).to eq ['my.feature']
           end
 
-          it "uses the paths from the profile when none are specified originally" do
+          it 'uses the paths from the profile when none are specified originally' do
             given_cucumber_yml_defined_as('baz' => %w[some.feature])
             options.parse!(%w[-p baz])
 
             expect(options[:paths]).to eq ['some.feature']
           end
 
-          it "combines environment variables from the profile but gives precendene to cmd line args" do
+          it 'combines environment variables from the profile but gives precendene to cmd line args' do
             given_cucumber_yml_defined_as('baz' => %w[FOO=bar CHEESE=swiss])
             options.parse!(%w[-p baz CHEESE=cheddar BAR=foo])
 
             expect(options[:env_vars]).to eq({ 'BAR' => 'foo', 'FOO' => 'bar', 'CHEESE' => 'cheddar' })
           end
 
-          it "disregards STDOUT formatter defined in profile when another is passed in (via cmd line)" do
+          it 'disregards STDOUT formatter defined in profile when another is passed in (via cmd line)' do
             given_cucumber_yml_defined_as({'foo' => %w[--format pretty]})
             options.parse!(%w{--format progress --profile foo})
 
             expect(options[:formats]).to eq [['progress', output_stream]]
           end
 
-          it "includes any non-STDOUT formatters from the profile" do
+          it 'includes any non-STDOUT formatters from the profile' do
             given_cucumber_yml_defined_as({'html' => %w[--format html -o features.html]})
             options.parse!(%w{--format progress --profile html})
 
             expect(options[:formats]).to eq [['progress', output_stream], ['html', 'features.html']]
           end
 
-          it "does not include STDOUT formatters from the profile if there is a STDOUT formatter in command line" do
+          it 'does not include STDOUT formatters from the profile if there is a STDOUT formatter in command line' do
             given_cucumber_yml_defined_as({'html' => %w[--format html -o features.html --format pretty]})
             options.parse!(%w{--format progress --profile html})
 
             expect(options[:formats]).to eq [['progress', output_stream], ['html', 'features.html']]
           end
 
-          it "includes any STDOUT formatters from the profile if no STDOUT formatter was specified in command line" do
+          it 'includes any STDOUT formatters from the profile if no STDOUT formatter was specified in command line' do
             given_cucumber_yml_defined_as({'html' => %w[--format html]})
             options.parse!(%w{--format rerun -o rerun.txt --profile html})
 
             expect(options[:formats]).to eq [['html', output_stream], ['rerun', 'rerun.txt']]
           end
 
-          it "assumes all of the formatters defined in the profile when none are specified on cmd line" do
+          it 'assumes all of the formatters defined in the profile when none are specified on cmd line' do
             given_cucumber_yml_defined_as({'html' => %w[--format progress --format html -o features.html]})
             options.parse!(%w{--profile html})
 
             expect(options[:formats]).to eq [['progress', output_stream], ['html', 'features.html']]
           end
 
-          it "only reads cucumber.yml once" do
+          it 'only reads cucumber.yml once' do
             original_parse_count = $cucumber_yml_read_count
             $cucumber_yml_read_count = 0
 
@@ -286,7 +286,7 @@ module Cucumber
             end
           end
 
-          it "respects --quiet when defined in the profile" do
+          it 'respects --quiet when defined in the profile' do
             given_cucumber_yml_defined_as('foo' => '-q')
             options.parse!(%w[-p foo])
 
@@ -295,7 +295,7 @@ module Cucumber
             expect(options[:duration]).to be false
           end
           
-          it "uses --no-duration when defined in the profile" do
+          it 'uses --no-duration when defined in the profile' do
             given_cucumber_yml_defined_as('foo' => '--no-duration')
             options.parse!(%w[-p foo])
 
@@ -304,18 +304,18 @@ module Cucumber
         end
 
         context '-P or --no-profile' do
-          it "disables profiles" do
+          it 'disables profiles' do
             given_cucumber_yml_defined_as({'default' => '-v --require file_specified_in_default_profile.rb'})
 
-            after_parsing("-P --require some_file.rb") do
+            after_parsing('-P --require some_file.rb') do
               expect(options[:require]).to eq ['some_file.rb']
             end
           end
 
-          it "notifies the user that the profiles are being disabled" do
+          it 'notifies the user that the profiles are being disabled' do
             given_cucumber_yml_defined_as({'default' => '-v'})
 
-            after_parsing("--no-profile --require some_file.rb") do
+            after_parsing('--no-profile --require some_file.rb') do
               expect(output_stream.string).to match(/Disabling profiles.../)
             end
           end
@@ -323,7 +323,7 @@ module Cucumber
 
         context '-b or --backtrace' do
           it "turns on cucumber's full backtrace" do
-            when_parsing("-b") do
+            when_parsing('-b') do
               expect(Cucumber).to receive(:use_full_backtrace=).with(true)
             end
           end
@@ -336,13 +336,13 @@ module Cucumber
             end
           end
 
-          it "exits the program" do
+          it 'exits the program' do
             when_parsing('--version') { expect(Kernel).to receive(:exit) }
           end
         end
 
         context 'environment variables (i.e. MODE=webrat)' do
-          it "places all of the environment variables into a hash" do
+          it 'places all of the environment variables into a hash' do
             after_parsing('MODE=webrat FOO=bar') do
               expect(options[:env_vars]).to eq({ 'MODE' => 'webrat', 'FOO' => 'bar' })
             end
@@ -351,32 +351,32 @@ module Cucumber
 
         context '--retry ATTEMPTS' do
           it 'is 0 by default' do 
-            after_parsing("") do 
+            after_parsing('') do 
               expect(options[:retry]).to eql 0
             end
           end
 
           it 'sets the options[:retry] value' do 
-            after_parsing("--retry 4") do 
+            after_parsing('--retry 4') do 
               expect(options[:retry]).to eql 4
             end
           end
         end
 
-        it "assigns any extra arguments as paths to features" do
+        it 'assigns any extra arguments as paths to features' do
           after_parsing('-f pretty my_feature.feature my_other_features') do
             expect(options[:paths]).to eq ['my_feature.feature', 'my_other_features']
           end
         end
 
-        it "does not mistake environment variables as feature paths" do
+        it 'does not mistake environment variables as feature paths' do
           after_parsing('my_feature.feature FOO=bar') do
             expect(options[:paths]).to eq ['my_feature.feature']
           end
         end
 
         context '--snippet-type' do
-          it "parses the snippet type argument" do
+          it 'parses the snippet type argument' do
             after_parsing('--snippet-type classic') do
               expect(options[:snippet_type]).to eq :classic
             end
@@ -384,22 +384,22 @@ module Cucumber
         end
       end
 
-      describe "dry-run" do
-        it "has the default value for snippets" do
+      describe 'dry-run' do
+        it 'has the default value for snippets' do
           given_cucumber_yml_defined_as({'foo' => %w[--dry-run]})
           options.parse!(%w{--dry-run})
 
           expect(options[:snippets]).to be true
         end
 
-        it "sets snippets to false when no-snippets provided after dry-run" do
+        it 'sets snippets to false when no-snippets provided after dry-run' do
           given_cucumber_yml_defined_as({'foo' => %w[--dry-run --no-snippets]})
           options.parse!(%w{--dry-run --no-snippets})
 
           expect(options[:snippets]).to be false
         end
 
-        it "sets snippets to false when no-snippets provided before dry-run" do
+        it 'sets snippets to false when no-snippets provided before dry-run' do
           given_cucumber_yml_defined_as({'foo' => %w[--no-snippet --dry-run]})
           options.parse!(%w{--no-snippets --dry-run})
 

--- a/spec/cucumber/cli/profile_loader_spec.rb
+++ b/spec/cucumber/cli/profile_loader_spec.rb
@@ -18,7 +18,7 @@ module Cucumber
         ProfileLoader.new
       end
 
-      it "treats backslashes as literals in rerun.txt when on Windows (JRuby or MRI)" do
+      it 'treats backslashes as literals in rerun.txt when on Windows (JRuby or MRI)' do
         given_cucumber_yml_defined_as({'default' => '--format "pretty" features\sync_imap_mailbox.feature:16:22'})
         if(Cucumber::WINDOWS)
           expect(loader.args_from('default')).to eq ['--format','pretty','features\sync_imap_mailbox.feature:16:22']
@@ -27,13 +27,13 @@ module Cucumber
         end
       end
 
-      it "treats forward slashes as literals" do
+      it 'treats forward slashes as literals' do
         given_cucumber_yml_defined_as({'default' => '--format "ugly" features/sync_imap_mailbox.feature:16:22'})
 
         expect(loader.args_from('default')).to eq ['--format','ugly','features/sync_imap_mailbox.feature:16:22']
       end
 
-      it "treats percent sign as ERB code block after YAML directive" do
+      it 'treats percent sign as ERB code block after YAML directive' do
         yml = <<-HERE
 ---
 % x = '--format "pretty" features/sync_imap_mailbox.feature:16:22'

--- a/spec/cucumber/cli/rerun_spec.rb
+++ b/spec/cucumber/cli/rerun_spec.rb
@@ -7,77 +7,77 @@ module Cucumber
 
       let(:rerun_file) { RerunFile.new('@rerun.txt') }
 
-      it "expects rerun files to have a leading @" do
+      it 'expects rerun files to have a leading @' do
         allow(File).to receive(:file?) { true }
         expect(RerunFile.can_read?('rerun.txt')).to eq false
         expect(RerunFile.can_read?('@rerun.txt')).to eq true
       end
 
-      it "does not treat directories as rerun files" do
+      it 'does not treat directories as rerun files' do
         allow(File).to receive(:file?) { false }
         expect(RerunFile.can_read?('@rerun.txt')).to eq false
       end
 
-      it "removes leading @ character from filename" do
+      it 'removes leading @ character from filename' do
         expect(rerun_file.path).to eq 'rerun.txt'
       end
 
-      context "rerun file containing single feature" do
+      context 'rerun file containing single feature' do
         before(:each) do
-          allow(IO).to receive(:read).and_return("cucumber.feature")
+          allow(IO).to receive(:read).and_return('cucumber.feature')
         end
 
-        it "produces an array containing a single feature file path" do
+        it 'produces an array containing a single feature file path' do
           expect(rerun_file.features).to eq %w(cucumber.feature)
         end
       end
 
-      context "contains multiple features on multiple lines" do
+      context 'contains multiple features on multiple lines' do
         before(:each) do
           allow(IO).to receive(:read).and_return("cucumber.feature\nfoo.feature")
         end
 
-        it "produces an array containing multiple feature file paths" do
+        it 'produces an array containing multiple feature file paths' do
           expect(rerun_file.features).to eq %w(cucumber.feature foo.feature)
         end
       end
 
-      context "contains multiple features on same line" do
+      context 'contains multiple features on same line' do
         before(:each) do
-          allow(IO).to receive(:read).and_return("cucumber.feature foo.feature")
+          allow(IO).to receive(:read).and_return('cucumber.feature foo.feature')
         end
 
-        it "produces an array containing multiple feature file paths" do
+        it 'produces an array containing multiple feature file paths' do
           expect(rerun_file.features).to eq %w(cucumber.feature foo.feature)
         end
       end
 
-      context "contains multiple scenarios on same line" do
+      context 'contains multiple scenarios on same line' do
         before(:each) do
-          allow(IO).to receive(:read).and_return("cucumber.feature:8 foo.feature:8:16")
+          allow(IO).to receive(:read).and_return('cucumber.feature:8 foo.feature:8:16')
         end
 
-        it "produces an array containing multiple feature file paths with scenario lines" do
+        it 'produces an array containing multiple feature file paths with scenario lines' do
           expect(rerun_file.features).to eq %w(cucumber.feature:8 foo.feature:8:16)
         end
       end
 
-      context "contains features with spaces in file names" do
+      context 'contains features with spaces in file names' do
         before(:each) do
-          allow(IO).to receive(:read).and_return("cucumber test.feature:8 foo.feature:8:16")
+          allow(IO).to receive(:read).and_return('cucumber test.feature:8 foo.feature:8:16')
         end
 
-        it "produces an array containing multiple feature file paths with scenario lines" do
+        it 'produces an array containing multiple feature file paths with scenario lines' do
           expect(rerun_file.features).to eq ['cucumber test.feature:8', 'foo.feature:8:16']
         end
       end
 
-      context "contains multiple scenarios without spaces between them" do
+      context 'contains multiple scenarios without spaces between them' do
         before(:each) do
-          allow(IO).to receive(:read).and_return("cucumber test.feature:8foo.feature:8:16")
+          allow(IO).to receive(:read).and_return('cucumber test.feature:8foo.feature:8:16')
         end
 
-        it "produces an array containing multiple feature file paths with scenario lines" do
+        it 'produces an array containing multiple feature file paths with scenario lines' do
           expect(rerun_file.features).to eq ['cucumber test.feature:8', 'foo.feature:8:16']
         end
       end

--- a/spec/cucumber/configuration_spec.rb
+++ b/spec/cucumber/configuration_spec.rb
@@ -3,25 +3,25 @@ require 'spec_helper'
 
 module Cucumber
   describe Configuration do
-    describe ".default" do
+    describe '.default' do
       subject { Configuration.default }
 
-      it "has an autoload_code_paths containing the standard support and step_definitions folders" do
+      it 'has an autoload_code_paths containing the standard support and step_definitions folders' do
         expect(subject.autoload_code_paths).to include('features/support')
         expect(subject.autoload_code_paths).to include('features/step_definitions')
       end
     end
 
-    describe "with custom user options" do
+    describe 'with custom user options' do
       let(:user_options) { { :autoload_code_paths => ['foo/bar/baz'] } }
       subject { Configuration.new(user_options) }
 
-      it "allows you to override the defaults" do
+      it 'allows you to override the defaults' do
         expect(subject.autoload_code_paths).to eq ['foo/bar/baz']
       end
     end
 
-    context "selecting files to load" do
+    context 'selecting files to load' do
 
       def given_the_following_files(*files)
         allow(File).to receive(:directory?) { true }
@@ -29,114 +29,114 @@ module Cucumber
         allow(Dir).to receive(:[]) { files }
       end
 
-      it "requires env.rb files first" do
+      it 'requires env.rb files first' do
         configuration = Configuration.new
-        given_the_following_files("/features/support/a_file.rb","/features/support/env.rb")
+        given_the_following_files('/features/support/a_file.rb','/features/support/env.rb')
 
         expect(configuration.support_to_load).to eq [
-          "/features/support/env.rb",
-          "/features/support/a_file.rb"
+          '/features/support/env.rb',
+          '/features/support/a_file.rb'
         ]
       end
 
-      it "does not require env.rb files when dry run" do
+      it 'does not require env.rb files when dry run' do
         configuration = Configuration.new(dry_run: true)
-        given_the_following_files("/features/support/a_file.rb","/features/support/env.rb")
+        given_the_following_files('/features/support/a_file.rb','/features/support/env.rb')
 
         expect(configuration.support_to_load).to eq [
-          "/features/support/a_file.rb"
+          '/features/support/a_file.rb'
         ]
       end
 
-      it "requires step defs in vendor/{plugins,gems}/*/cucumber/*.rb" do
-        given_the_following_files("/vendor/gems/gem_a/cucumber/bar.rb",
-                                  "/vendor/plugins/plugin_a/cucumber/foo.rb")
+      it 'requires step defs in vendor/{plugins,gems}/*/cucumber/*.rb' do
+        given_the_following_files('/vendor/gems/gem_a/cucumber/bar.rb',
+                                  '/vendor/plugins/plugin_a/cucumber/foo.rb')
 
         configuration = Configuration.new
 
         expect(configuration.step_defs_to_load).to eq [
-          "/vendor/gems/gem_a/cucumber/bar.rb",
-          "/vendor/plugins/plugin_a/cucumber/foo.rb"
+          '/vendor/gems/gem_a/cucumber/bar.rb',
+          '/vendor/plugins/plugin_a/cucumber/foo.rb'
         ]
       end
 
-      describe "--exclude" do
+      describe '--exclude' do
 
-        it "excludes a ruby file from requiring when the name matches exactly" do
-          given_the_following_files("/features/support/a_file.rb","/features/support/env.rb")
+        it 'excludes a ruby file from requiring when the name matches exactly' do
+          given_the_following_files('/features/support/a_file.rb','/features/support/env.rb')
 
           configuration = Configuration.new(excludes: [/a_file.rb/])
 
           expect(configuration.all_files_to_load).to eq [
-            "/features/support/env.rb"
+            '/features/support/env.rb'
           ]
         end
 
-        it "excludes all ruby files that match the provided patterns from requiring" do
-          given_the_following_files("/features/support/foof.rb","/features/support/bar.rb",
-                                    "/features/support/food.rb","/features/blah.rb",
-                                    "/features/support/fooz.rb")
+        it 'excludes all ruby files that match the provided patterns from requiring' do
+          given_the_following_files('/features/support/foof.rb','/features/support/bar.rb',
+                                    '/features/support/food.rb','/features/blah.rb',
+                                    '/features/support/fooz.rb')
 
           configuration = Configuration.new(excludes: [/foo[df]/, /blah/])
 
           expect(configuration.all_files_to_load).to eq [
-            "/features/support/bar.rb",
-            "/features/support/fooz.rb"
+            '/features/support/bar.rb',
+            '/features/support/fooz.rb'
           ]
         end
       end
 
     end
 
-    context "selecting feature files" do
+    context 'selecting feature files' do
 
-      it "preserves the order of the feature files" do
+      it 'preserves the order of the feature files' do
         configuration = Configuration.new(paths: %w{b.feature c.feature a.feature})
 
-        expect(configuration.feature_files).to eq ["b.feature", "c.feature", "a.feature"]
+        expect(configuration.feature_files).to eq ['b.feature', 'c.feature', 'a.feature']
       end
 
-      it "searchs for all features in the specified directory" do
+      it 'searchs for all features in the specified directory' do
         allow(File).to receive(:directory?) { true }
-        allow(Dir).to receive(:[]).with("feature_directory/**/*.feature") { ["cucumber.feature"] }
+        allow(Dir).to receive(:[]).with('feature_directory/**/*.feature') { ['cucumber.feature'] }
 
         configuration = Configuration.new(paths: %w{feature_directory/})
 
-        expect(configuration.feature_files).to eq ["cucumber.feature"]
+        expect(configuration.feature_files).to eq ['cucumber.feature']
       end
 
-      it "defaults to the features directory when no feature file are provided" do
+      it 'defaults to the features directory when no feature file are provided' do
         allow(File).to receive(:directory?) { true }
-        allow(Dir).to receive(:[]).with("features/**/*.feature") { ["cucumber.feature"] }
+        allow(Dir).to receive(:[]).with('features/**/*.feature') { ['cucumber.feature'] }
 
         configuration = Configuration.new(paths: [])
 
-        expect(configuration.feature_files).to eq ["cucumber.feature"]
+        expect(configuration.feature_files).to eq ['cucumber.feature']
       end
 
-      it "gets the feature files from the rerun file" do
+      it 'gets the feature files from the rerun file' do
         allow(File).to receive(:directory?).and_return(false)
         allow(File).to receive(:file?).and_return(true)
         allow(IO).to receive(:read).and_return(
           "cucumber.feature:1:3\ncucumber.feature:5 cucumber.feature:10\n"\
           "domain folder/different cuke.feature:134 domain folder/cuke.feature:1\n"\
-          "domain folder/different cuke.feature:4:5 bar.feature")
+          'domain folder/different cuke.feature:4:5 bar.feature')
 
         configuration = Configuration.new(paths: %w{@rerun.txt})
 
         expect(configuration.feature_files).to eq [
-          "cucumber.feature:1:3",
-          "cucumber.feature:5",
-          "cucumber.feature:10",
-          "domain folder/different cuke.feature:134",
-          "domain folder/cuke.feature:1",
-          "domain folder/different cuke.feature:4:5",
-          "bar.feature"]
+          'cucumber.feature:1:3',
+          'cucumber.feature:5',
+          'cucumber.feature:10',
+          'domain folder/different cuke.feature:134',
+          'domain folder/cuke.feature:1',
+          'domain folder/different cuke.feature:4:5',
+          'bar.feature']
       end
     end
 
-    describe "#with_options" do
-      it "returns a copy of the configuration with new options" do
+    describe '#with_options' do
+      it 'returns a copy of the configuration with new options' do
         old_out_stream = double('Old out_stream')
         new_out_stream = double('New out_stream')
         config = Configuration.new(out_stream: old_out_stream).with_options(out_stream: new_out_stream)

--- a/spec/cucumber/constantize_spec.rb
+++ b/spec/cucumber/constantize_spec.rb
@@ -7,13 +7,13 @@ module Cucumber
   describe Constantize do
     include Constantize
 
-    it "loads html formatter" do
+    it 'loads html formatter' do
       clazz = constantize('Cucumber::Formatter::Html')
 
       expect(clazz.name).to eq 'Cucumber::Formatter::Html'
     end
 
-    it "fails to load a made up class" do
+    it 'fails to load a made up class' do
       expect { constantize('My::MadeUp::ClassName') }.to raise_error(LoadError)
     end
   end

--- a/spec/cucumber/file_specs_spec.rb
+++ b/spec/cucumber/file_specs_spec.rb
@@ -3,57 +3,57 @@ require 'cucumber/file_specs'
 
 module Cucumber
   describe FileSpecs do
-    let(:file_specs) { FileSpecs.new(["features/foo.feature:1:2:3", "features/bar.feature:4:5:6"]) }
+    let(:file_specs) { FileSpecs.new(['features/foo.feature:1:2:3', 'features/bar.feature:4:5:6']) }
     let(:locations) { file_specs.locations }
     let(:files) { file_specs.files }
 
-    it "parses locations from multiple files" do
+    it 'parses locations from multiple files' do
       expect(locations.length).to eq 6
       expect(locations).to eq [
-        Cucumber::Core::Ast::Location.new("features/foo.feature", 1),
-        Cucumber::Core::Ast::Location.new("features/foo.feature", 2),
-        Cucumber::Core::Ast::Location.new("features/foo.feature", 3),
-        Cucumber::Core::Ast::Location.new("features/bar.feature", 4),
-        Cucumber::Core::Ast::Location.new("features/bar.feature", 5),
-        Cucumber::Core::Ast::Location.new("features/bar.feature", 6),
+        Cucumber::Core::Ast::Location.new('features/foo.feature', 1),
+        Cucumber::Core::Ast::Location.new('features/foo.feature', 2),
+        Cucumber::Core::Ast::Location.new('features/foo.feature', 3),
+        Cucumber::Core::Ast::Location.new('features/bar.feature', 4),
+        Cucumber::Core::Ast::Location.new('features/bar.feature', 5),
+        Cucumber::Core::Ast::Location.new('features/bar.feature', 6),
       ]
     end
 
-    it "parses file names from multiple file specs" do
+    it 'parses file names from multiple file specs' do
       expect(files.length).to eq 2
       expect(files).to eq [
-        "features/foo.feature",
-        "features/bar.feature",
+        'features/foo.feature',
+        'features/bar.feature',
       ]
     end
 
-    context "when files are not unique" do
-      let(:file_specs) { FileSpecs.new(["features/foo.feature:4", "features/foo.feature:34"]) }
+    context 'when files are not unique' do
+      let(:file_specs) { FileSpecs.new(['features/foo.feature:4', 'features/foo.feature:34']) }
 
-      it "parses unique file names" do
+      it 'parses unique file names' do
         expect(files.length).to eq 1
-        expect(files).to eq ["features/foo.feature"]
+        expect(files).to eq ['features/foo.feature']
       end
     end
 
-    context "when no line number is specified" do
-      let(:file_specs) { FileSpecs.new(["features/foo.feature", "features/bar.feature:34"]) }
+    context 'when no line number is specified' do
+      let(:file_specs) { FileSpecs.new(['features/foo.feature', 'features/bar.feature:34']) }
 
-      it "returns a wildcard location for that file" do
+      it 'returns a wildcard location for that file' do
         expect(locations).to eq [
-          Cucumber::Core::Ast::Location.new("features/foo.feature"),
-          Cucumber::Core::Ast::Location.new("features/bar.feature", 34),
+          Cucumber::Core::Ast::Location.new('features/foo.feature'),
+          Cucumber::Core::Ast::Location.new('features/bar.feature', 34),
         ]
       end
     end
 
-    context "when the same file is referenced more than once" do
-      let(:file_specs) { FileSpecs.new(["features/foo.feature:10", "features/foo.feature:1"]) }
+    context 'when the same file is referenced more than once' do
+      let(:file_specs) { FileSpecs.new(['features/foo.feature:10', 'features/foo.feature:1']) }
 
-      it "returns locations in the order specified" do
+      it 'returns locations in the order specified' do
         expect(locations).to eq [
-          Cucumber::Core::Ast::Location.new("features/foo.feature", 10),
-          Cucumber::Core::Ast::Location.new("features/foo.feature", 1),
+          Cucumber::Core::Ast::Location.new('features/foo.feature', 10),
+          Cucumber::Core::Ast::Location.new('features/foo.feature', 1),
         ]
       end
     end

--- a/spec/cucumber/filters/activate_steps_spec.rb
+++ b/spec/cucumber/filters/activate_steps_spec.rb
@@ -14,7 +14,7 @@ describe Cucumber::Filters::ActivateSteps do
   let(:step_match_search) { Proc.new { [step_match] } }
   let(:configuration) { double(dry_run?: false, notify: nil) }
 
-  context "a scenario with a single step" do
+  context 'a scenario with a single step' do
     let(:doc) do
       gherkin do
         feature do
@@ -25,14 +25,14 @@ describe Cucumber::Filters::ActivateSteps do
       end
     end
 
-    it "activates each step" do
+    it 'activates each step' do
       expect(step_match).to receive(:activate) do |test_step|
         expect(test_step.name).to eq 'a passing step'
       end
       compile [doc], receiver, [filter]
     end
 
-    it "notifies with a StepMatch event" do
+    it 'notifies with a StepMatch event' do
       expect(configuration).to receive(:notify) do |message, test_step, step_match|
         expect(message).to eq :step_match
         expect(test_step.name).to eq 'a passing step'
@@ -42,7 +42,7 @@ describe Cucumber::Filters::ActivateSteps do
     end
   end
 
-  context "a scenario outline" do
+  context 'a scenario outline' do
     let(:doc) do
       gherkin do
         feature do
@@ -58,7 +58,7 @@ describe Cucumber::Filters::ActivateSteps do
       end
     end
 
-    it "activates each step" do
+    it 'activates each step' do
       expect(step_match).to receive(:activate) do |test_step|
         expect(test_step.name).to eq 'a passing step'
       end
@@ -66,7 +66,7 @@ describe Cucumber::Filters::ActivateSteps do
     end
   end
 
-  context "undefined step" do
+  context 'undefined step' do
     let(:step_match_search) { Proc.new { [] } }
 
     let(:doc) do
@@ -79,20 +79,20 @@ describe Cucumber::Filters::ActivateSteps do
       end
     end
 
-    it "does not activate the step" do
+    it 'does not activate the step' do
       expect(receiver).to receive(:test_case) do |test_case|
         expect(test_case.test_steps[0].execute).to be_undefined
       end
       compile [doc], receiver, [filter]
     end
 
-    it "does not notify" do
+    it 'does not notify' do
       expect(configuration).not_to receive(:notify)
       compile [doc], receiver, [filter]
     end
   end
 
-  context "dry run" do
+  context 'dry run' do
     let(:configuration) { double(dry_run?: true, notify: nil) }
 
     let(:doc) do
@@ -105,14 +105,14 @@ describe Cucumber::Filters::ActivateSteps do
       end
     end
 
-    it "activates each step with a skipping action" do
+    it 'activates each step with a skipping action' do
       expect(receiver).to receive(:test_case) do |test_case|
         expect(test_case.test_steps[0].execute).to be_skipped
       end
       compile [doc], receiver, [filter]
     end
 
-    it "notifies with a StepMatch event" do
+    it 'notifies with a StepMatch event' do
       expect(configuration).to receive(:notify) do |message, test_step, step_match|
         expect(message).to eq :step_match
         expect(test_step.name).to eq 'a passing step'
@@ -122,7 +122,7 @@ describe Cucumber::Filters::ActivateSteps do
     end
   end
 
-  context "undefined step in a dry run" do
+  context 'undefined step in a dry run' do
     let(:step_match_search) { Proc.new { [] } }
     let(:configuration) { double(dry_run?: true, notify: nil) }
 
@@ -136,14 +136,14 @@ describe Cucumber::Filters::ActivateSteps do
       end
     end
 
-    it "does not activate the step" do
+    it 'does not activate the step' do
       expect(receiver).to receive(:test_case) do |test_case|
         expect(test_case.test_steps[0].execute).to be_undefined
       end
       compile [doc], receiver, [filter]
     end
 
-    it "does not notify" do
+    it 'does not notify' do
       expect(configuration).not_to receive(:notify)
       compile [doc], receiver, [filter]
     end

--- a/spec/cucumber/filters/gated_receiver_spec.rb
+++ b/spec/cucumber/filters/gated_receiver_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require "cucumber/filters/gated_receiver"
+require 'cucumber/filters/gated_receiver'
 
 describe Cucumber::Filters::GatedReceiver do
   subject(:gated_receiver) { Cucumber::Filters::GatedReceiver.new(receiver) }
@@ -7,8 +7,8 @@ describe Cucumber::Filters::GatedReceiver do
   let(:receiver) { double(:receiver) }
   let(:test_cases){ [double(:test_case), double(:test_case)] }
 
-  describe "#test_case" do
-    it "does not immediately describe the test case to the receiver" do
+  describe '#test_case' do
+    it 'does not immediately describe the test case to the receiver' do
       test_cases.each do |test_case|
         expect(test_case).to_not receive(:describe_to).with(receiver)
       end
@@ -19,7 +19,7 @@ describe Cucumber::Filters::GatedReceiver do
     end
   end
 
-  describe "#done" do
+  describe '#done' do
     before do
       test_cases.each do |test_case|
         gated_receiver.test_case(test_case)
@@ -32,7 +32,7 @@ describe Cucumber::Filters::GatedReceiver do
       allow(receiver).to receive(:done)
     end
 
-    it "describes all test cases to the receiver" do
+    it 'describes all test cases to the receiver' do
       test_cases.each do |test_case|
         expect(test_case).to receive(:describe_to).with(receiver)
       end
@@ -40,7 +40,7 @@ describe Cucumber::Filters::GatedReceiver do
       gated_receiver.done
     end
 
-    it "calls done on the receiver" do
+    it 'calls done on the receiver' do
       expect(receiver).to receive(:done)
       gated_receiver.done
     end

--- a/spec/cucumber/filters/retry_spec.rb
+++ b/spec/cucumber/filters/retry_spec.rb
@@ -23,20 +23,20 @@ describe Cucumber::Filters::Retry do
   it { is_expected.to respond_to(:with_receiver) }
   it { is_expected.to respond_to(:done) }
 
-  context "passing test case" do
+  context 'passing test case' do
     let(:result) { Cucumber::Core::Test::Result::Passed.new(0) }
 
-    it "describes the test case once" do
+    it 'describes the test case once' do
       expect(receiver).to receive(:test_case).with(test_case).once
       test_case.describe_to filter
       configuration.notify :test_case_finished, test_case, result
     end
   end
 
-  context "consistently failing test case" do
+  context 'consistently failing test case' do
     let(:result) { Cucumber::Core::Test::Result::Failed.new(0, StandardError.new) }
 
-    it "describes the test case the specified number of times" do
+    it 'describes the test case the specified number of times' do
       expect(receiver).to receive(:test_case) {|test_case|
         configuration.notify :test_case_finished, test_case, result
       }.exactly(3).times
@@ -45,9 +45,9 @@ describe Cucumber::Filters::Retry do
     end
   end
 
-  context "flaky test cases" do
+  context 'flaky test cases' do
 
-    context "a little flaky" do
+    context 'a little flaky' do
       let(:results) {
         [
           Cucumber::Core::Test::Result::Failed.new(0, StandardError.new),
@@ -55,7 +55,7 @@ describe Cucumber::Filters::Retry do
         ]
       }
 
-      it "describes the test case twice" do
+      it 'describes the test case twice' do
         expect(receiver).to receive(:test_case) {|test_case|
           configuration.notify :test_case_finished, test_case, results.shift
         }.exactly(2).times
@@ -64,7 +64,7 @@ describe Cucumber::Filters::Retry do
       end
     end
 
-    context "really flaky" do
+    context 'really flaky' do
       let(:results) {
         [
           Cucumber::Core::Test::Result::Failed.new(0, StandardError.new),
@@ -73,7 +73,7 @@ describe Cucumber::Filters::Retry do
         ]
       }
 
-      it "describes the test case 3 times" do
+      it 'describes the test case 3 times' do
         expect(receiver).to receive(:test_case) {|test_case|
           configuration.notify :test_case_finished, test_case, results.shift
         }.exactly(3).times

--- a/spec/cucumber/filters/tag_limits/test_case_index_spec.rb
+++ b/spec/cucumber/filters/tag_limits/test_case_index_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require "cucumber/filters/tag_limits"
+require 'cucumber/filters/tag_limits'
 
 describe Cucumber::Filters::TagLimits::TestCaseIndex do
   subject(:index) { Cucumber::Filters::TagLimits::TestCaseIndex.new }
@@ -11,8 +11,8 @@ describe Cucumber::Filters::TagLimits::TestCaseIndex do
     ]
   end
 
-  let(:tag_one) { double(:tag_one, name: "@one") }
-  let(:tag_two) { double(:tag_two, name: "@two") }
+  let(:tag_one) { double(:tag_one, name: '@one') }
+  let(:tag_two) { double(:tag_two, name: '@two') }
 
   let(:a_location_of_tag_one) { double(:a_location_of_tag_one) }
   let(:a_location_of_tag_one_and_tag_two) { double(:a_location_of_tag_one_and_tag_two) }
@@ -23,17 +23,17 @@ describe Cucumber::Filters::TagLimits::TestCaseIndex do
     end
   end
 
-  describe "#count_by_tag_name" do
-    it "returns the number of test cases with the tag" do
-      expect(index.count_by_tag_name("@one")).to eq(2)
-      expect(index.count_by_tag_name("@two")).to eq(1)
+  describe '#count_by_tag_name' do
+    it 'returns the number of test cases with the tag' do
+      expect(index.count_by_tag_name('@one')).to eq(2)
+      expect(index.count_by_tag_name('@two')).to eq(1)
     end
   end
 
-  describe "#locations_by_tag_name" do
-    it "returns the locations of test cases with the tag" do
-      expect(index.locations_of_tag_name("@one")).to eq([a_location_of_tag_one, a_location_of_tag_one_and_tag_two])
-      expect(index.locations_of_tag_name("@two")).to eq([a_location_of_tag_one_and_tag_two])
+  describe '#locations_by_tag_name' do
+    it 'returns the locations of test cases with the tag' do
+      expect(index.locations_of_tag_name('@one')).to eq([a_location_of_tag_one, a_location_of_tag_one_and_tag_two])
+      expect(index.locations_of_tag_name('@two')).to eq([a_location_of_tag_one_and_tag_two])
     end
   end
 end

--- a/spec/cucumber/filters/tag_limits/verifier_spec.rb
+++ b/spec/cucumber/filters/tag_limits/verifier_spec.rb
@@ -1,54 +1,54 @@
 # frozen_string_literal: true
-require "cucumber/filters/tag_limits"
+require 'cucumber/filters/tag_limits'
 
 describe Cucumber::Filters::TagLimits::Verifier do
-  describe "#verify!" do
+  describe '#verify!' do
     subject(:verifier) { Cucumber::Filters::TagLimits::Verifier.new(tag_limits) }
     let(:test_case_index) { double(:test_case_index) }
 
-    context "the tag counts exceed the tag limits" do
+    context 'the tag counts exceed the tag limits' do
       let(:tag_limits) do
         {
-          "@exceed_me" => 1
+          '@exceed_me' => 1
         }
       end
 
       let(:locations) do
         [
-          double(:location, to_s: "path/to/some.feature:3"),
-          double(:location, to_s: "path/to/some/other.feature:8"),
+          double(:location, to_s: 'path/to/some.feature:3'),
+          double(:location, to_s: 'path/to/some/other.feature:8'),
         ]
       end
 
       before do
-        allow(test_case_index).to receive(:count_by_tag_name).with("@exceed_me") { 2 }
-        allow(test_case_index).to receive(:locations_of_tag_name).with("@exceed_me") { locations }
+        allow(test_case_index).to receive(:count_by_tag_name).with('@exceed_me') { 2 }
+        allow(test_case_index).to receive(:locations_of_tag_name).with('@exceed_me') { locations }
       end
 
-      it "raises a TagLimitExceeded error with the locations of the tags" do
+      it 'raises a TagLimitExceeded error with the locations of the tags' do
         expect {
           verifier.verify!(test_case_index)
         }.to raise_error(
           Cucumber::Filters::TagLimitExceededError,
           "@exceed_me occurred 2 times, but the limit was set to 1\n" +
           "  path/to/some.feature:3\n" +
-          "  path/to/some/other.feature:8"
+          '  path/to/some/other.feature:8'
         )
       end
     end
 
-    context "the tag counts do not exceed the tag limits" do
+    context 'the tag counts do not exceed the tag limits' do
       let(:tag_limits) do
         {
-          "@dont_exceed_me" => 2
+          '@dont_exceed_me' => 2
         }
       end
 
       before do
-        allow(test_case_index).to receive(:count_by_tag_name).with("@dont_exceed_me") { 1 }
+        allow(test_case_index).to receive(:count_by_tag_name).with('@dont_exceed_me') { 1 }
       end
 
-      it "does not raise an error" do
+      it 'does not raise an error' do
         expect {
           verifier.verify!(test_case_index)
         }.to_not raise_error

--- a/spec/cucumber/filters/tag_limits_spec.rb
+++ b/spec/cucumber/filters/tag_limits_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require "cucumber/filters/tag_limits"
+require 'cucumber/filters/tag_limits'
 
 describe Cucumber::Filters::TagLimits do
   subject(:filter) { Cucumber::Filters::TagLimits.new(tag_limits, receiver) }
@@ -16,24 +16,24 @@ describe Cucumber::Filters::TagLimits do
     allow(Cucumber::Filters::TagLimits::TestCaseIndex).to receive(:new) { test_case_index }
   end
 
-  describe "#test_case" do
+  describe '#test_case' do
     before do
       allow(test_case_index).to receive(:add)
       allow(gated_receiver).to receive(:test_case)
     end
 
-    it "indexes the test case" do
+    it 'indexes the test case' do
       expect(test_case_index).to receive(:add).with(test_case)
       filter.test_case(test_case)
     end
 
-    it "adds the test case to the gated receiver" do
+    it 'adds the test case to the gated receiver' do
       expect(gated_receiver).to receive(:test_case).with(test_case)
       filter.test_case(test_case)
     end
   end
 
-  describe "#done" do
+  describe '#done' do
     let(:verifier) { double(:verifier) }
 
     before do
@@ -41,17 +41,17 @@ describe Cucumber::Filters::TagLimits do
       allow(gated_receiver).to receive(:done)
     end
 
-    it "verifies tag limits have not been exceeded" do
+    it 'verifies tag limits have not been exceeded' do
       expect(verifier).to receive(:verify!).with(test_case_index)
       filter.done
     end
 
-    context "the verifier verifies successfully" do
+    context 'the verifier verifies successfully' do
       before do
         allow(verifier).to receive(:verify!).with(test_case_index)
       end
 
-      it "calls done on the receiver gate" do
+      it 'calls done on the receiver gate' do
         expect(gated_receiver).to receive(:done)
         filter.done
       end

--- a/spec/cucumber/formatter/ansicolor_spec.rb
+++ b/spec/cucumber/formatter/ansicolor_spec.rb
@@ -7,26 +7,26 @@ module Cucumber
     describe ANSIColor do
       include ANSIColor
 
-      it "wraps passed_param with bold green and reset to green" do
-        expect(passed_param("foo")).to eq "\e[32m\e[1mfoo\e[0m\e[0m\e[32m"
+      it 'wraps passed_param with bold green and reset to green' do
+        expect(passed_param('foo')).to eq "\e[32m\e[1mfoo\e[0m\e[0m\e[32m"
       end
 
-      it "wraps passed in green" do
-        expect(passed("foo")).to eq "\e[32mfoo\e[0m"
+      it 'wraps passed in green' do
+        expect(passed('foo')).to eq "\e[32mfoo\e[0m"
       end
 
-      it "does not reset passed if there are no arguments" do
+      it 'does not reset passed if there are no arguments' do
         expect(passed).to eq "\e[32m"
       end
 
-      it "wraps comments in grey" do
-        expect(comment("foo")).to eq "\e[90mfoo\e[0m"
+      it 'wraps comments in grey' do
+        expect(comment('foo')).to eq "\e[90mfoo\e[0m"
       end
 
-      it "does not generate ansi codes when colors are disabled" do
+      it 'does not generate ansi codes when colors are disabled' do
         ::Cucumber::Term::ANSIColor.coloring = false
 
-        expect(passed("foo")).to eq "foo"
+        expect(passed('foo')).to eq 'foo'
       end
     end
   end

--- a/spec/cucumber/formatter/console_counts_spec.rb
+++ b/spec/cucumber/formatter/console_counts_spec.rb
@@ -4,7 +4,7 @@ require 'cucumber/formatter/console_counts'
 module Cucumber
   module Formatter
     describe ConsoleCounts do
-      it "works for zero" do
+      it 'works for zero' do
         config = Configuration.new
         counts = ConsoleCounts.new(config)
         expect(counts.to_s).to eq "0 scenarios\n0 steps"

--- a/spec/cucumber/formatter/duration_spec.rb
+++ b/spec/cucumber/formatter/duration_spec.rb
@@ -7,15 +7,15 @@ module Cucumber
     describe Duration do
       include Duration
 
-      it "formats ms" do
+      it 'formats ms' do
         expect(format_duration(0.002103)).to eq '0m0.002s'
       end
 
-      it "formats m" do
+      it 'formats m' do
         expect(format_duration(61.002503)).to eq'1m1.003s'
       end
 
-      it "formats h" do
+      it 'formats h' do
         expect(format_duration(3661.002503)).to eq '61m1.003s'
       end
     end

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -24,13 +24,13 @@ module Cucumber
         @formatter = Html.new(runtime, @out, {})
       end
 
-      it "does not raise an error when visiting a blank feature name" do
+      it 'does not raise an error when visiting a blank feature name' do
         expect(-> {
-          @formatter.feature_name("Feature", "")
+          @formatter.feature_name('Feature', '')
         }).not_to raise_error
       end
 
-      describe "when writing the report to a file" do
+      describe 'when writing the report to a file' do
         before(:each) do
           allow(@out).to receive(:respond_to?).with(:path).and_return(true)
           expect(@out).to receive(:path).and_return('out/file.html')
@@ -38,7 +38,7 @@ module Cucumber
           @doc = Nokogiri.HTML(@out.string)
         end
 
-        describe "with a step that embeds a snapshot" do
+        describe 'with a step that embeds a snapshot' do
           define_steps do
             Given(/snap/) {
               RSpec::Mocks.allow_message(File, :file?) { true }
@@ -52,19 +52,19 @@ module Cucumber
               Given snap
             FEATURE
 
-          it "converts the snapshot path to a relative path" do
-            expect(@doc.css('.embed img').first.attributes['src'].to_s).to eq "snapshot.jpeg"
+          it 'converts the snapshot path to a relative path' do
+            expect(@doc.css('.embed img').first.attributes['src'].to_s).to eq 'snapshot.jpeg'
           end
         end
       end
 
-      describe "given a single feature" do
+      describe 'given a single feature' do
         before(:each) do
           run_defined_feature
           @doc = Nokogiri.HTML(@out.string)
         end
 
-        describe "basic feature" do
+        describe 'basic feature' do
           define_feature <<-FEATURE
             Feature: Bananas
               In order to find my inner monkey
@@ -72,12 +72,12 @@ module Cucumber
               I must eat bananas
           FEATURE
 
-          it "should output a main container div" do
+          it 'should output a main container div' do
             expect(@out.string).to match(/\<div class="cucumber"\>/)
           end
         end
 
-        describe "with a comment" do
+        describe 'with a comment' do
           define_feature <<-FEATURE
             # Healthy
             Feature: Foo
@@ -88,16 +88,16 @@ module Cucumber
           it { expect(@out.string).to match(/^\<!DOCTYPE/) }
           it { expect(@out.string).to match(/\<\/html\>$/) }
 
-          it "nests the comment within the feature" do
+          it 'nests the comment within the feature' do
             expect(@doc).to have_css_node('.feature .comment', /Healthy/)
           end
 
-          it "properly closes the comment" do
+          it 'properly closes the comment' do
             expect(@out.string).to match(%r{<pre class="comment"># Healthy<br/></pre>})
           end
         end
 
-        describe "with a comment at scenario level" do
+        describe 'with a comment at scenario level' do
           define_feature <<-FEATURE
             Feature: Foo
               # Healthy Scenario
@@ -108,7 +108,7 @@ module Cucumber
           it { expect(@doc).to have_css_node('.scenario .comment', /Healthy Scenario/) }
         end
 
-        describe "with a tag" do
+        describe 'with a tag' do
           define_feature <<-FEATURE
             @foo
             Feature: can't have standalone tag :)
@@ -119,7 +119,7 @@ module Cucumber
           it { expect(@doc).to have_css_node('.feature .tag', /foo/) }
         end
 
-        describe "with a narrative" do
+        describe 'with a narrative' do
           define_feature <<-FEATURE
             Feature: Bananas
               In order to find my inner monkey
@@ -134,7 +134,7 @@ module Cucumber
           it { expect(@doc).to have_css_node('.feature .narrative', /must eat bananas/) }
         end
 
-        describe "with a background" do
+        describe 'with a background' do
           define_feature <<-FEATURE
             Feature: Bananas
 
@@ -148,7 +148,7 @@ module Cucumber
           it { expect(@doc).to have_css_node('.feature .background', /there are bananas/) }
         end
 
-        describe "with a scenario" do
+        describe 'with a scenario' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -160,7 +160,7 @@ module Cucumber
           it { expect(@doc).to have_css_node('.feature .scenario .step', /there are bananas/) }
         end
 
-        describe "with a scenario outline" do
+        describe 'with a scenario outline' do
           define_feature <<-FEATURE
           Feature: Fud Pyramid
 
@@ -184,7 +184,7 @@ module Cucumber
           it { expect(@doc).to have_css_node('.feature .scenario.outline table td', /carrots/) }
         end
 
-        describe "with a step with a py string" do
+        describe 'with a step with a py string' do
           define_feature <<-FEATURE
           Feature: Traveling circus
 
@@ -198,7 +198,7 @@ module Cucumber
           it { expect(@doc).to have_css_node('.feature .scenario .val', /foo/) }
         end
 
-        describe "with a multiline step arg" do
+        describe 'with a multiline step arg' do
           define_steps do
             Given(/there are monkeys:/) { |table| }
           end
@@ -216,7 +216,7 @@ module Cucumber
           it { expect(@out.string.include?('makeYellow(\'scenario_1\')')).to be false }
         end
 
-        describe "with a table in the background and the scenario" do
+        describe 'with a table in the background and the scenario' do
           define_feature <<-FEATURE
           Feature: accountant monkey
 
@@ -233,7 +233,7 @@ module Cucumber
           it { expect(@doc.css('td').length).to eq 8 }
         end
 
-        describe "with a py string in the background and the scenario" do
+        describe 'with a py string in the background and the scenario' do
           define_feature <<-FEATURE
           Feature: py strings
 
@@ -253,7 +253,7 @@ module Cucumber
           it { expect(@doc.css('.feature .scenario pre.val').length).to eq 1 }
         end
 
-        describe "with a step that fails in the scenario" do
+        describe 'with a step that fails in the scenario' do
           define_steps do
             Given(/boo/) { raise StandardError, 'eek'.freeze }
           end
@@ -274,7 +274,7 @@ module Cucumber
           end
         end
 
-        describe "with a step that fails in the background" do
+        describe 'with a step that fails in the background' do
           define_steps do
             Given(/boo/) { raise 'eek' }
           end
@@ -296,8 +296,8 @@ module Cucumber
           it { expect(@doc).not_to have_css_node('.feature .scenario .backtrace', //) }
         end
 
-        context "with a before hook that fails" do
-          describe "in a scenario" do
+        context 'with a before hook that fails' do
+          describe 'in a scenario' do
             define_steps do
               Before { raise 'eek' }
               Given(/yay/) {}
@@ -314,7 +314,7 @@ module Cucumber
             it { expect(@doc).to have_css_node('.feature .scenario .step.skipped', /yay/) }
           end
 
-          describe "in a scenario outline" do
+          describe 'in a scenario outline' do
             define_steps do
               Before { raise 'eek' }
               Given(/yay/) {}
@@ -336,7 +336,7 @@ module Cucumber
 
         end
 
-        describe "with a step that embeds a snapshot" do
+        describe 'with a step that embeds a snapshot' do
           define_steps do
             Given(/snap/) {
               RSpec::Mocks.allow_message(File, :file?) { true }
@@ -350,10 +350,10 @@ module Cucumber
               Given snap
             FEATURE
 
-          it { expect(@doc.css('.embed img').first.attributes['src'].to_s).to eq "snapshot.jpeg" }
+          it { expect(@doc.css('.embed img').first.attributes['src'].to_s).to eq 'snapshot.jpeg' }
         end
 
-        describe "with a step that embeds a text" do
+        describe 'with a step that embeds a text' do
           define_steps do
             Given(/log/) { embed('log.txt', 'text/plain') }
           end
@@ -364,10 +364,10 @@ module Cucumber
               Given log
             FEATURE
 
-          it { expect(@doc.at('a#text_0')['href'].to_s).to eq "log.txt" }
+          it { expect(@doc.at('a#text_0')['href'].to_s).to eq 'log.txt' }
         end
 
-        describe "with a step that embeds a snapshot content manually" do
+        describe 'with a step that embeds a snapshot content manually' do
           define_steps do
             Given(/snap/) { embed('data:image/png;base64,YWJj', 'image/png') }
           end
@@ -378,10 +378,10 @@ module Cucumber
               Given snap
             FEATURE
 
-          it { expect(@doc.css('.embed img').first.attributes['src'].to_s).to eq "data:image/png;base64,YWJj" }
+          it { expect(@doc.css('.embed img').first.attributes['src'].to_s).to eq 'data:image/png;base64,YWJj' }
         end
 
-        describe "with a step that embeds a snapshot content" do
+        describe 'with a step that embeds a snapshot content' do
           define_steps do
             Given(/snap/) { embed('YWJj', 'image/png;base64') }
           end
@@ -392,10 +392,10 @@ module Cucumber
               Given snap
             FEATURE
 
-          it { expect(@doc.css('.embed img').first.attributes['src'].to_s).to eq "data:image/png;base64,YWJj" }
+          it { expect(@doc.css('.embed img').first.attributes['src'].to_s).to eq 'data:image/png;base64,YWJj' }
         end
 
-        describe "with an undefined Given step then an undefined And step" do
+        describe 'with an undefined Given step then an undefined And step' do
           define_feature(<<-FEATURE)
           Feature:
             Scenario:
@@ -403,10 +403,10 @@ module Cucumber
               And another undefined step
             FEATURE
 
-          it { expect(@doc.css('pre').map { |pre| /^(Given|And)/.match(pre.text)[1] }).to eq ["Given", "Given"] }
+          it { expect(@doc.css('pre').map { |pre| /^(Given|And)/.match(pre.text)[1] }).to eq ['Given', 'Given'] }
         end
 
-        describe "with an undefined When step then an undefined And step" do
+        describe 'with an undefined When step then an undefined And step' do
           define_feature(<<-FEATURE)
           Feature:
             Scenario:
@@ -415,10 +415,10 @@ module Cucumber
               And another undefined step
             FEATURE
 
-          it { expect(@doc.css('pre').map { |pre| /^(Given|When|And)/.match(pre.text)[1] }).to eq ["Given", "When", "When"] }
+          it { expect(@doc.css('pre').map { |pre| /^(Given|When|And)/.match(pre.text)[1] }).to eq ['Given', 'When', 'When'] }
         end
 
-        describe "with an passing Then step and an undefined And step" do
+        describe 'with an passing Then step and an undefined And step' do
           define_feature <<-FEATURE
           Feature:
             Scenario:
@@ -431,11 +431,11 @@ module Cucumber
             Given(/^this step passes$/) {}
           end
 
-          it { expect(@doc.css('pre').map { |pre| /^(Given|Then)/.match(pre.text)[1] }).to eq ["Then"] }
+          it { expect(@doc.css('pre').map { |pre| /^(Given|Then)/.match(pre.text)[1] }).to eq ['Then'] }
         end
 
-        describe "with a output from hooks" do
-          describe "in a scenario" do
+        describe 'with a output from hooks' do
+          describe 'in a scenario' do
             define_feature <<-FEATURE
           Feature:
             Scenario:
@@ -444,26 +444,26 @@ module Cucumber
 
             define_steps do
               Before do
-                puts "Before hook"
+                puts 'Before hook'
               end
               AfterStep do
-                puts "AfterStep hook"
+                puts 'AfterStep hook'
               end
               After do
-                puts "After hook"
+                puts 'After hook'
               end
               Given(/^this step passes$/) {}
             end
 
             it 'should have ccs nodes ".step.message" for all the hooks' do
               expect(@doc.css('.step.message').length).to eq 3
-              expect(@doc.css('.step.message')[0].text).to eq "Before hook"
-              expect(@doc.css('.step.message')[1].text).to eq "AfterStep hook"
-              expect(@doc.css('.step.message')[2].text).to eq "After hook"
+              expect(@doc.css('.step.message')[0].text).to eq 'Before hook'
+              expect(@doc.css('.step.message')[1].text).to eq 'AfterStep hook'
+              expect(@doc.css('.step.message')[2].text).to eq 'After hook'
             end
           end
 
-          describe "in a scenario outline" do
+          describe 'in a scenario outline' do
             define_feature <<-FEATURE
           Feature:
             Scenario Outline:
@@ -475,13 +475,13 @@ module Cucumber
 
             define_steps do
               Before do
-                puts "Before hook"
+                puts 'Before hook'
               end
               AfterStep do
-                puts "AfterStep hook"
+                puts 'AfterStep hook'
               end
               After do
-                puts "After hook"
+                puts 'After hook'
               end
               Given(/^this step passes$/) {}
             end
@@ -490,7 +490,7 @@ module Cucumber
           end
         end
       end
-      context "in --expand mode" do
+      context 'in --expand mode' do
         let(:options)   { { expand: true } }
         before(:each) do
           @out = StringIO.new
@@ -498,7 +498,7 @@ module Cucumber
           run_defined_feature
           @doc = Nokogiri.HTML(@out.string)
         end
-        describe "with undefined * steps in a Scenario Outline" do
+        describe 'with undefined * steps in a Scenario Outline' do
           define_feature <<-FEATURE
           Feature:
             Scenario Outline:
@@ -514,10 +514,10 @@ module Cucumber
               Given(/^this step passes$/) {}
             end
 
-          it { expect(@doc.css('pre').map { |pre| /^(Given|Then|When)/.match(pre.text)[1] }).to eq ["Given", "Given"] }
+          it { expect(@doc.css('pre').map { |pre| /^(Given|Then|When)/.match(pre.text)[1] }).to eq ['Given', 'Given'] }
         end
 
-        describe "with a scenario outline and a before hook that fails" do
+        describe 'with a scenario outline and a before hook that fails' do
           define_steps do
             Before { raise 'eek' }
             Given(/yay/) {}

--- a/spec/cucumber/formatter/json_spec.rb
+++ b/spec/cucumber/formatter/json_spec.rb
@@ -11,21 +11,21 @@ module Cucumber
       extend SpecHelperDsl
       include SpecHelper
 
-      context "Given a single feature" do
+      context 'Given a single feature' do
         before(:each) do
           @out = StringIO.new
           @formatter = Json.new(actual_runtime.configuration.with_options(out_stream: @out))
           run_defined_feature
         end
 
-        describe "with a scenario with no steps" do
+        describe 'with a scenario with no steps' do
           define_feature <<-FEATURE
           Feature: Banana party
 
             Scenario: Monkey eats bananas
             FEATURE
 
-          it "outputs the json data" do
+          it 'outputs the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -43,7 +43,7 @@ module Cucumber
           end
         end
 
-        describe "with a scenario with an undefined step" do
+        describe 'with a scenario with an undefined step' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -51,7 +51,7 @@ module Cucumber
               Given there are bananas
             FEATURE
 
-          it "outputs the json data" do
+          it 'outputs the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -75,7 +75,7 @@ module Cucumber
           end
         end
 
-        describe "with a scenario with a passed step" do
+        describe 'with a scenario with a passed step' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -87,7 +87,7 @@ module Cucumber
             Given(/^there are bananas$/) {}
           end
 
-          it "outputs the json data" do
+          it 'outputs the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -112,7 +112,7 @@ module Cucumber
           end
         end
 
-        describe "with a scenario with a failed step" do
+        describe 'with a scenario with a failed step' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -121,10 +121,10 @@ module Cucumber
             FEATURE
 
           define_steps do
-            Given(/^there are bananas$/) { raise "no bananas" }
+            Given(/^there are bananas$/) { raise 'no bananas' }
           end
 
-          it "outputs the json data" do
+          it 'outputs the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -150,7 +150,7 @@ module Cucumber
           end
         end
 
-        describe "with a scenario with a pending step" do
+        describe 'with a scenario with a pending step' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -162,7 +162,7 @@ module Cucumber
             Given(/^there are bananas$/) { pending }
           end
 
-          it "outputs the json data" do
+          it 'outputs the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -188,7 +188,7 @@ module Cucumber
           end
         end
 
-        describe "with a scenario outline with one example" do
+        describe 'with a scenario outline with one example' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -204,7 +204,7 @@ module Cucumber
             Given(/^there are bananas$/) {}
           end
 
-          it "outputs the json data" do
+          it 'outputs the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -229,7 +229,7 @@ module Cucumber
           end
         end
 
-        describe "with tags in the feature file" do
+        describe 'with tags in the feature file' do
           define_feature <<-FEATURE
           @f
           Feature: Banana party
@@ -252,7 +252,7 @@ module Cucumber
             Given(/^there are bananas$/) {}
           end
 
-          it "the tags are included in the json data" do
+          it 'the tags are included in the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -302,7 +302,7 @@ module Cucumber
           end
         end
 
-        describe "with comments in the feature file" do
+        describe 'with comments in the feature file' do
           define_feature <<-FEATURE
           #feature comment
           Feature: Banana party
@@ -333,7 +333,7 @@ module Cucumber
             Then(/^the monkey eats bananas$/) {}
           end
 
-          it "the comments are included in the json data" do
+          it 'the comments are included in the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -413,7 +413,7 @@ module Cucumber
           end
         end
 
-        describe "with a scenario with a step with a doc string" do
+        describe 'with a scenario with a step with a doc string' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -428,7 +428,7 @@ module Cucumber
             Given(/^there are bananas$/) { |s| s }
           end
 
-          it "includes the doc string in the json data" do
+          it 'includes the doc string in the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -456,7 +456,7 @@ module Cucumber
           end
         end
 
-        describe "with a scenario with a step that use puts" do
+        describe 'with a scenario with a step that use puts' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -465,10 +465,10 @@ module Cucumber
             FEATURE
 
           define_steps do
-            Given(/^there are bananas$/) { puts "from step" }
+            Given(/^there are bananas$/) { puts 'from step' }
           end
 
-          it "includes the output from the step in the json data" do
+          it 'includes the output from the step in the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -494,7 +494,7 @@ module Cucumber
           end
         end
 
-        describe "with a background" do
+        describe 'with a background' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -508,7 +508,7 @@ module Cucumber
               Then the monkey eats more bananas
             FEATURE
 
-          it "includes the background in the json data each time it is executed" do
+          it 'includes the background in the json data each time it is executed' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -566,7 +566,7 @@ module Cucumber
           end
         end
 
-        describe "with a scenario with a step that embeds data directly" do
+        describe 'with a scenario with a step that embeds data directly' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -575,11 +575,11 @@ module Cucumber
             FEATURE
 
           define_steps do
-            Given(/^there are bananas$/) { data = "YWJj"
-              embed data, "mime-type;base64" }
+            Given(/^there are bananas$/) { data = 'YWJj'
+              embed data, 'mime-type;base64' }
           end
 
-          it "includes the data from the step in the json data" do
+          it 'includes the data from the step in the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -606,7 +606,7 @@ module Cucumber
           end
         end
 
-        describe "with a scenario with a step that embeds a file" do
+        describe 'with a scenario with a step that embeds a file' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -619,12 +619,12 @@ module Cucumber
               RSpec::Mocks.allow_message(File, :file?) { true }
               f1 = RSpec::Mocks::Double.new
               RSpec::Mocks.allow_message(File, :open)  { |&block| block.call(f1) }
-              RSpec::Mocks.allow_message(f1, :read)  { "foo" }
+              RSpec::Mocks.allow_message(f1, :read)  { 'foo' }
               embed('out/snapshot.jpeg', 'image/png')
             }
           end
 
-          it "includes the file content in the json data" do
+          it 'includes the file content in the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -651,7 +651,7 @@ module Cucumber
           end
         end
 
-        describe "with a scenario with hooks" do
+        describe 'with a scenario with hooks' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -670,7 +670,7 @@ module Cucumber
             Given(/^there are bananas$/) {}
           end
 
-          it "includes all hooks except the around hook in the json data" do
+          it 'includes all hooks except the around hook in the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -716,7 +716,7 @@ module Cucumber
           end
         end
 
-        describe "with a scenario when only an around hook is failing" do
+        describe 'with a scenario when only an around hook is failing' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -725,11 +725,11 @@ module Cucumber
             FEATURE
 
           define_steps do
-            Around() { |scenario, block| block.call; raise RuntimeError, "error" }
+            Around() { |scenario, block| block.call; raise RuntimeError, 'error' }
             Given(/^there are bananas$/) {}
           end
 
-          it "includes the around hook result in the json data" do
+          it 'includes the around hook result in the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",
@@ -759,7 +759,7 @@ module Cucumber
           end
         end
 
-        describe "with a scenario with a step with a data table" do
+        describe 'with a scenario with a step with a data table' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -773,7 +773,7 @@ module Cucumber
             Given(/^there are bananas$/) { |s| s }
           end
 
-          it "includes the doc string in the json data" do
+          it 'includes the doc string in the json data' do
             expect(load_normalised_json(@out)).to eq MultiJson.load(%{
               [{"id": "banana-party",
                 "uri": "spec.feature",

--- a/spec/cucumber/formatter/junit_spec.rb
+++ b/spec/cucumber/formatter/junit_spec.rb
@@ -20,7 +20,7 @@ module Cucumber
         end
       end
 
-      context "With no options" do
+      context 'With no options' do
         before(:each) do
           allow(File).to receive(:directory?) { true }
           @formatter = TestDoubleJunitFormatter.new(actual_runtime.configuration.with_options(out_stream: ''))
@@ -30,7 +30,7 @@ module Cucumber
           $stdout = STDOUT
         end
 
-        describe "is able to strip control chars from cdata" do
+        describe 'is able to strip control chars from cdata' do
           before(:each) do
             run_defined_feature
             @doc = Nokogiri.XML(@formatter.written_files.values.first)
@@ -43,7 +43,7 @@ module Cucumber
             "
           class Junit
             def before_step(step)
-              if step.name.match("a passing ctrl scenario")
+              if step.name.match('a passing ctrl scenario')
                 Interceptor::Pipe.unwrap! :stdout
                 @fake_io = $stdout = StringIO.new
                 $stdout.sync = true
@@ -52,7 +52,7 @@ module Cucumber
             end
 
             def after_step(step)
-              if step.name.match("a passing ctrl scenario")
+              if step.name.match('a passing ctrl scenario')
                 @interceptedout.write("boo\b\cx\e\a\f boo ")
                 $stdout = STDOUT
                 @fake_io.close
@@ -63,27 +63,27 @@ module Cucumber
           it { expect(@doc.xpath('//testsuite/testcase/system-out').first.content).to match(/\s+boo boo\s+/) }
         end
 
-        describe "a feature with no name" do
+        describe 'a feature with no name' do
           define_feature <<-FEATURE
             Feature:
               Scenario: Passing
                 Given a passing scenario
           FEATURE
 
-          it "raises an exception" do
+          it 'raises an exception' do
             expect(-> {
               run_defined_feature
             }).to raise_error(Junit::UnNamedFeatureError)
           end
         end
 
-        describe "given a single feature" do
+        describe 'given a single feature' do
           before(:each) do
             run_defined_feature
             @doc = Nokogiri.XML(@formatter.written_files.values.first)
           end
 
-          describe "with a single scenario" do
+          describe 'with a single scenario' do
             define_feature <<-FEATURE
               Feature: One passing scenario, one failing scenario
 
@@ -110,7 +110,7 @@ module Cucumber
             end
           end
 
-          describe "with a scenario in a subdirectory" do
+          describe 'with a scenario in a subdirectory' do
             define_feature %{
               Feature: One passing scenario, one failing scenario
 
@@ -123,7 +123,7 @@ module Cucumber
             end
           end
 
-          describe "with a scenario outline table" do
+          describe 'with a scenario outline table' do
             define_steps do
               Given(/.*/) {  }
             end
@@ -155,7 +155,7 @@ module Cucumber
             it { expect(@doc.to_s).not_to match(/type="skipped"/)}
           end
 
-          describe "scenario with skipped test in junit report" do
+          describe 'scenario with skipped test in junit report' do
             define_feature <<-FEATURE
               Feature: junit report with skipped test
 
@@ -171,7 +171,7 @@ module Cucumber
             it { expect(@doc.to_s).to match(/skipped="2"/)}
           end
 
-          describe "with a regular data table scenario" do
+          describe 'with a regular data table scenario' do
             define_steps do
               Given(/the following items on a shortlist/) { |table| }
               When(/I go.*/) {  }
@@ -197,7 +197,7 @@ module Cucumber
         end
       end
       
-      context "In --expand mode" do
+      context 'In --expand mode' do
         let(:runtime)   { Runtime.new({:expand => true}) }
         before(:each) do
           allow(File).to receive(:directory?) { true }
@@ -208,13 +208,13 @@ module Cucumber
           $stdout = STDOUT
         end
 
-        describe "given a single feature" do
+        describe 'given a single feature' do
           before(:each) do
             run_defined_feature
             @doc = Nokogiri.XML(@formatter.written_files.values.first)
           end
           
-          describe "with a scenario outline table" do
+          describe 'with a scenario outline table' do
             define_steps do
               Given(/.*/) {  }
             end

--- a/spec/cucumber/formatter/legacy_api/adapter_spec.rb
+++ b/spec/cucumber/formatter/legacy_api/adapter_spec.rb
@@ -2076,7 +2076,7 @@ module Cucumber
 
       describe 'before_step_result message' do
         context 'when the step matches' do
-          it "sends the step match to the formatter" do
+          it 'sends the step match to the formatter' do
             expect(formatter).to receive(:before_step_result) do |_, step_match, *|
               expect(step_match).to be_a SimpleStepMatch
             end
@@ -2091,7 +2091,7 @@ module Cucumber
         end
 
         context "when the step doesn't match" do
-          it "sends a null object to the formatter" do
+          it 'sends a null object to the formatter' do
           end
         end
       end
@@ -2109,7 +2109,7 @@ module Cucumber
         end
       end
 
-      context "after_feature_element callback" do
+      context 'after_feature_element callback' do
         it 'passes an object reflecting the status of the scenario' do
           expect( formatter ).to receive(:after_feature_element).once do |scenario|
             expect( scenario ).to be_failed

--- a/spec/cucumber/formatter/pretty_spec.rb
+++ b/spec/cucumber/formatter/pretty_spec.rb
@@ -10,32 +10,32 @@ module Cucumber
       extend SpecHelperDsl
       include SpecHelper
 
-      context "With no options" do
+      context 'With no options' do
         before(:each) do
           Cucumber::Term::ANSIColor.coloring = false
           @out = StringIO.new
           @formatter = Pretty.new(runtime, @out, {})
         end
 
-        describe "given a single feature" do
+        describe 'given a single feature' do
           before(:each) do
             run_defined_feature
           end
 
-          describe "with a scenario with no steps" do
+          describe 'with a scenario with no steps' do
             define_feature <<-FEATURE
           Feature: Banana party
 
             Scenario: Monkey eats banana
             FEATURE
 
-            it "outputs the scenario name" do
-              expect(@out.string).to include "Scenario: Monkey eats banana"
+            it 'outputs the scenario name' do
+              expect(@out.string).to include 'Scenario: Monkey eats banana'
             end
           end
 
 
-          describe "with a scenario" do
+          describe 'with a scenario' do
             define_feature <<-FEATURE
           Feature: Banana party
 
@@ -43,16 +43,16 @@ module Cucumber
               Given there are bananas
             FEATURE
 
-            it "outputs the scenario name" do
-              expect(@out.string).to include "Scenario: Monkey eats banana"
+            it 'outputs the scenario name' do
+              expect(@out.string).to include 'Scenario: Monkey eats banana'
             end
 
-            it "outputs the step" do
-              expect(@out.string).to include "Given there are bananas"
+            it 'outputs the step' do
+              expect(@out.string).to include 'Given there are bananas'
             end
           end
 
-          describe "with a background" do
+          describe 'with a background' do
             define_feature <<-FEATURE
 Feature: Banana party
 
@@ -63,20 +63,20 @@ Feature: Banana party
     Given there are bananas
             FEATURE
 
-            it "outputs the gherkin" do
+            it 'outputs the gherkin' do
               expect(@out.string).to include(self.class.feature_content)
             end
 
-            it "outputs the scenario name" do
-              expect(@out.string).to include "Scenario: Monkey eats banana"
+            it 'outputs the scenario name' do
+              expect(@out.string).to include 'Scenario: Monkey eats banana'
             end
 
-            it "outputs the step" do
-              expect(@out.string).to include "Given there are bananas"
+            it 'outputs the step' do
+              expect(@out.string).to include 'Given there are bananas'
             end
           end
 
-          describe "with a scenario outline" do
+          describe 'with a scenario outline' do
             define_feature <<-FEATURE
           Feature: Fud Pyramid
 
@@ -93,7 +93,7 @@ Feature: Banana party
                | carrots  |
             FEATURE
 
-            it "outputs the scenario outline" do
+            it 'outputs the scenario outline' do
               lines = <<-OUTPUT
               Examples: Fruit
                | Things  |
@@ -109,12 +109,12 @@ Feature: Banana party
               end
             end
 
-            it "has 4 undefined scenarios" do
-              expect(@out.string).to include "4 scenarios (4 undefined)"
+            it 'has 4 undefined scenarios' do
+              expect(@out.string).to include '4 scenarios (4 undefined)'
             end
 
-            it "has 4 undefined steps" do
-              expect(@out.string).to include "4 steps (4 undefined)"
+            it 'has 4 undefined steps' do
+              expect(@out.string).to include '4 steps (4 undefined)'
             end
 
             context 'when the examples table header is wider than the rows' do
@@ -129,7 +129,7 @@ Feature: Banana party
                | Hominidae       |
               FEATURE
 
-              it "outputs the scenario outline" do
+              it 'outputs the scenario outline' do
                 lines = <<-OUTPUT
               Examples:
                | Types of monkey |
@@ -143,7 +143,7 @@ Feature: Banana party
           end
 
           # To ensure https://rspec.lighthouseapp.com/projects/16211/tickets/475 remains fixed.
-          describe "with a scenario outline with a pystring" do
+          describe 'with a scenario outline with a pystring' do
             define_feature <<-FEATURE
           Feature:
             Scenario Outline: Monkey eats a balanced diet
@@ -157,7 +157,7 @@ Feature: Banana party
                | apples |
             FEATURE
 
-            it "outputs the scenario outline" do
+            it 'outputs the scenario outline' do
               lines = <<-OUTPUT
               Given a multiline string:
                 """
@@ -174,7 +174,7 @@ Feature: Banana party
             end
           end
 
-          describe "with a step with a py string" do
+          describe 'with a step with a py string' do
             define_feature <<-FEATURE
           Feature: Traveling circus
 
@@ -185,7 +185,7 @@ Feature: Banana party
                """
             FEATURE
 
-            it "displays the pystring nested" do
+            it 'displays the pystring nested' do
               expect(@out.string).to include <<OUTPUT
       """
       foo
@@ -194,7 +194,7 @@ OUTPUT
             end
           end
 
-          describe "with a multiline step arg" do
+          describe 'with a multiline step arg' do
             define_feature <<-FEATURE
           Feature: Traveling circus
 
@@ -205,7 +205,7 @@ OUTPUT
                | bar  |
             FEATURE
 
-            it "displays the multiline string" do
+            it 'displays the multiline string' do
               expect(@out.string).to include <<OUTPUT
     Given there are monkeys:
       | name |
@@ -215,7 +215,7 @@ OUTPUT
             end
           end
 
-          describe "with a table in the background and the scenario" do
+          describe 'with a table in the background and the scenario' do
             define_feature <<-FEATURE
           Feature: accountant monkey
 
@@ -229,7 +229,7 @@ OUTPUT
                | g | h |
             FEATURE
 
-            it "displays the table for the background" do
+            it 'displays the table for the background' do
               expect(@out.string).to include <<OUTPUT
     Given table:
       | a | b |
@@ -237,7 +237,7 @@ OUTPUT
 OUTPUT
             end
 
-            it "displays the table for the scenario" do
+            it 'displays the table for the scenario' do
               expect(@out.string).to include <<OUTPUT
     Given another table:
       | e | f |
@@ -246,7 +246,7 @@ OUTPUT
             end
           end
 
-          describe "with a py string in the background and the scenario" do
+          describe 'with a py string in the background and the scenario' do
             define_feature <<-FEATURE
           Feature: py strings
 
@@ -262,7 +262,7 @@ OUTPUT
                 """
             FEATURE
 
-            it "displays the background py string" do
+            it 'displays the background py string' do
               expect(@out.string).to include <<OUTPUT
     Given stuff:
       """
@@ -271,7 +271,7 @@ OUTPUT
 OUTPUT
             end
 
-            it "displays the scenario py string" do
+            it 'displays the scenario py string' do
               expect(@out.string).to include <<OUTPUT
     Given more stuff:
       """
@@ -281,7 +281,7 @@ OUTPUT
             end
           end
 
-          describe "with output from hooks" do
+          describe 'with output from hooks' do
             define_feature <<-FEATURE
           Feature:
             Scenario:
@@ -295,18 +295,18 @@ OUTPUT
 
             define_steps do
               Before do
-                puts "Before hook"
+                puts 'Before hook'
               end
               AfterStep do
-                puts "AfterStep hook"
+                puts 'AfterStep hook'
               end
               After do
-                puts "After hook"
+                puts 'After hook'
               end
               Given(/^this step passes$/) {}
             end
 
-            it "displays hook output appropriately " do
+            it 'displays hook output appropriately ' do
               expect( @out.string ).to include <<OUTPUT
 Feature: 
 
@@ -329,7 +329,7 @@ OUTPUT
             end
           end
 
-          describe "with background and output from hooks" do
+          describe 'with background and output from hooks' do
             define_feature <<-FEATURE
           Feature:
             Background:
@@ -340,18 +340,18 @@ OUTPUT
 
             define_steps do
               Before do
-                puts "Before hook"
+                puts 'Before hook'
               end
               AfterStep do
-                puts "AfterStep hook"
+                puts 'AfterStep hook'
               end
               After do
-                puts "After hook"
+                puts 'After hook'
               end
               Given(/^this step passes$/) {}
             end
 
-            it "displays hook output appropriately " do
+            it 'displays hook output appropriately ' do
               expect( @out.string ).to include <<OUTPUT
 Feature: 
 
@@ -371,7 +371,7 @@ OUTPUT
             end
           end
 
-          describe "with tags on all levels" do
+          describe 'with tags on all levels' do
             define_feature <<-FEATURE
           @tag1
           Feature:
@@ -388,7 +388,7 @@ OUTPUT
             FEATURE
 
 
-            it "includes the tags in the output " do
+            it 'includes the tags in the output ' do
               expect( @out.string ).to include <<OUTPUT
 @tag1
 Feature: 
@@ -409,7 +409,7 @@ OUTPUT
             end
           end
 
-          describe "with comments on all levels" do
+          describe 'with comments on all levels' do
             define_feature <<-FEATURE
           #comment1
           Feature:
@@ -436,7 +436,7 @@ OUTPUT
             FEATURE
 
 
-            it "includes the all comments except for data table rows in the output " do
+            it 'includes the all comments except for data table rows in the output ' do
               expect( @out.string ).to include <<OUTPUT
 #comment1
 Feature: 
@@ -469,19 +469,19 @@ OUTPUT
         end
       end
 
-      context "With --no-multiline passed as an option" do
+      context 'With --no-multiline passed as an option' do
         before(:each) do
           Cucumber::Term::ANSIColor.coloring = false
           @out = StringIO.new
           @formatter = Pretty.new(runtime, @out, {:no_multiline => true})
         end
 
-        describe "given a single feature" do
+        describe 'given a single feature' do
           before(:each) do
             run_defined_feature
           end
 
-          describe "with a scenario" do
+          describe 'with a scenario' do
             define_feature <<-FEATURE
           Feature: Banana party
 
@@ -489,16 +489,16 @@ OUTPUT
               Given there are bananas
             FEATURE
 
-            it "outputs the scenario name" do
-              expect(@out.string).to include "Scenario: Monkey eats banana"
+            it 'outputs the scenario name' do
+              expect(@out.string).to include 'Scenario: Monkey eats banana'
             end
 
-            it "outputs the step" do
-              expect(@out.string).to include "Given there are bananas"
+            it 'outputs the step' do
+              expect(@out.string).to include 'Given there are bananas'
             end
           end
 
-          describe "with a scenario outline" do
+          describe 'with a scenario outline' do
             define_feature <<-FEATURE
           Feature: Fud Pyramid
 
@@ -515,7 +515,7 @@ OUTPUT
                | carrots  |
             FEATURE
 
-            it "outputs the scenario outline" do
+            it 'outputs the scenario outline' do
               lines = <<-OUTPUT
               Examples: Fruit
                | Things  |
@@ -531,16 +531,16 @@ OUTPUT
               end
             end
 
-            it "has 4 undefined scenarios" do
-              expect(@out.string).to include "4 scenarios (4 undefined)"
+            it 'has 4 undefined scenarios' do
+              expect(@out.string).to include '4 scenarios (4 undefined)'
             end
 
-            it "has 4 undefined steps" do
-              expect(@out.string).to include "4 steps (4 undefined)"
+            it 'has 4 undefined steps' do
+              expect(@out.string).to include '4 steps (4 undefined)'
             end
           end
 
-          describe "with a step with a py string" do
+          describe 'with a step with a py string' do
             define_feature <<-FEATURE
           Feature: Traveling circus
 
@@ -551,7 +551,7 @@ OUTPUT
                """
             FEATURE
 
-            it "does not display the pystring" do
+            it 'does not display the pystring' do
               expect(@out.string).not_to include <<OUTPUT
       """
       foo
@@ -560,7 +560,7 @@ OUTPUT
             end
           end
 
-          describe "with a multiline step arg" do
+          describe 'with a multiline step arg' do
             define_feature <<-FEATURE
           Feature: Traveling circus
 
@@ -571,7 +571,7 @@ OUTPUT
                | bar  |
             FEATURE
 
-            it "does not display the multiline string" do
+            it 'does not display the multiline string' do
               expect(@out.string).not_to include <<OUTPUT
       | name |
       | foo  |
@@ -580,7 +580,7 @@ OUTPUT
             end
           end
 
-          describe "with a table in the background and the scenario" do
+          describe 'with a table in the background and the scenario' do
             define_feature <<-FEATURE
           Feature: accountant monkey
 
@@ -594,13 +594,13 @@ OUTPUT
                | g | h |
             FEATURE
 
-            it "does not display the table for the background" do
+            it 'does not display the table for the background' do
               expect(@out.string).not_to include <<OUTPUT
       | a | b |
       | c | d |
 OUTPUT
             end
-            it "does not display the table for the scenario" do
+            it 'does not display the table for the scenario' do
               expect(@out.string).not_to include <<OUTPUT
       | e | f |
       | g | h |
@@ -608,7 +608,7 @@ OUTPUT
             end
           end
 
-          describe "with a py string in the background and the scenario" do
+          describe 'with a py string in the background and the scenario' do
             define_feature <<-FEATURE
           Feature: py strings
 
@@ -624,14 +624,14 @@ OUTPUT
                 """
             FEATURE
 
-            it "does not display the background py string" do
+            it 'does not display the background py string' do
               expect(@out.string).not_to include <<OUTPUT
       """
       foo
       """
 OUTPUT
             end
-            it "does not display the scenario py string" do
+            it 'does not display the scenario py string' do
               expect(@out.string).not_to include <<OUTPUT
       """
       bar
@@ -642,7 +642,7 @@ OUTPUT
         end
       end
 
-      context "In --expand mode" do
+      context 'In --expand mode' do
         let(:options) { { expand: true } }
         before(:each) do
           Cucumber::Term::ANSIColor.coloring = false
@@ -650,12 +650,12 @@ OUTPUT
           @formatter = Pretty.new(runtime, @out, {})
         end
 
-        describe "given a single feature" do
+        describe 'given a single feature' do
           before(:each) do
             run_defined_feature
           end
 
-          describe "with a scenario outline" do
+          describe 'with a scenario outline' do
             define_feature <<-FEATURE
           Feature: Fud Pyramid
 
@@ -672,7 +672,7 @@ OUTPUT
                | carrots  |
             FEATURE
 
-            it "outputs the instantiated scenarios" do
+            it 'outputs the instantiated scenarios' do
               lines = <<-OUTPUT
               Examples: Fruit
                 Scenario: | apples |
@@ -691,7 +691,7 @@ OUTPUT
             end
           end
 
-          describe "with a scenario outline in en-lol" do
+          describe 'with a scenario outline in en-lol' do
             define_feature <<-FEATURE
           # language: en-lol
           OH HAI: STUFFING
@@ -707,7 +707,7 @@ OUTPUT
                |    3     |  2  |    1    |
             FEATURE
 
-            it "outputs localized text" do
+            it 'outputs localized text' do
               lines = <<-OUTPUT
           OH HAI: STUFFING
 
@@ -731,7 +731,7 @@ OUTPUT
         end
       end
 
-      context "In --expand mode with --source as an option" do
+      context 'In --expand mode with --source as an option' do
         let(:options) { { expand: true } }
         before(:each) do
           Cucumber::Term::ANSIColor.coloring = false
@@ -739,12 +739,12 @@ OUTPUT
           @formatter = Pretty.new(runtime, @out, {:source => true})
         end
 
-        describe "given a single feature" do
+        describe 'given a single feature' do
           before(:each) do
             run_defined_feature
           end
 
-          describe "with a scenario outline" do
+          describe 'with a scenario outline' do
             define_feature <<-FEATURE
           Feature: Fud Pyramid
 
@@ -761,7 +761,7 @@ OUTPUT
                | carrots  |
             FEATURE
 
-            it "includes the source in the output" do
+            it 'includes the source in the output' do
               lines = <<-OUTPUT
               Scenario Outline: Monkey eats a balanced diet # spec.feature:3
                 Given there are <Things>                    # spec.feature:4
@@ -781,7 +781,7 @@ OUTPUT
               end
             end
 
-            context "With very wide cells" do
+            context 'With very wide cells' do
               define_feature <<-FEATURE
             Feature: Monkey Business
 
@@ -793,7 +793,7 @@ OUTPUT
                  | Hominidae       | Very long cell content |
               FEATURE
 
-              it "the scenario line controls the source indentation" do
+              it 'the scenario line controls the source indentation' do
                 lines = <<-OUTPUT
               Examples:
                  Scenario: | Hominidae | Very long cell content | # spec.feature:8
@@ -809,7 +809,7 @@ OUTPUT
         end
       end
 
-      context "snippets contain relevant keyword replacements" do
+      context 'snippets contain relevant keyword replacements' do
 
         before(:each) do
           Cucumber::Term::ANSIColor.coloring = false
@@ -818,7 +818,7 @@ OUTPUT
           run_defined_feature
         end
 
-        describe "With a scenario that has undefined steps" do
+        describe 'With a scenario that has undefined steps' do
           define_feature <<-FEATURE
           Feature: Banana party
 
@@ -832,12 +832,12 @@ OUTPUT
             FEATURE
 
           it "containes snippets with 'And' or 'But' replaced by previous step name" do
-            expect(@out.string).to include("Given(/^there are bananas and apples$/)")
-            expect(@out.string).to include("Given(/^other monkeys are around$/)")
-            expect(@out.string).to include("When(/^one monkey eats a banana$/)")
-            expect(@out.string).to include("When(/^the other monkeys eat all the apples$/)")
-            expect(@out.string).to include("Then(/^bananas remain$/)")
-            expect(@out.string).to include("Then(/^there are no apples left$/)")
+            expect(@out.string).to include('Given(/^there are bananas and apples$/)')
+            expect(@out.string).to include('Given(/^other monkeys are around$/)')
+            expect(@out.string).to include('When(/^one monkey eats a banana$/)')
+            expect(@out.string).to include('When(/^the other monkeys eat all the apples$/)')
+            expect(@out.string).to include('Then(/^bananas remain$/)')
+            expect(@out.string).to include('Then(/^there are no apples left$/)')
           end
         end
 
@@ -854,12 +854,12 @@ OUTPUT
               * there are no apples left
           FEATURE
           it "replaces the first step with 'Given'" do
-            expect(@out.string).to include("Given(/^there are bananas and apples$/)")
+            expect(@out.string).to include('Given(/^there are bananas and apples$/)')
           end
           it "uses actual keywords as the 'previous' keyword for future replacements" do
-            expect(@out.string).to include("Given(/^other monkeys are around$/)")
-            expect(@out.string).to include("When(/^the other monkeys eat all the apples$/)")
-            expect(@out.string).to include("Then(/^there are no apples left$/)")
+            expect(@out.string).to include('Given(/^other monkeys are around$/)')
+            expect(@out.string).to include('When(/^the other monkeys eat all the apples$/)')
+            expect(@out.string).to include('Then(/^there are no apples left$/)')
           end
         end
 
@@ -875,8 +875,8 @@ OUTPUT
           define_steps do
             Given(/^this step passes$/) {}
           end
-          it "uses actual keyword of the previous passing step for the undefined step" do
-            expect(@out.string).to include("Then(/^this step is undefined$/)")
+          it 'uses actual keyword of the previous passing step for the undefined step' do
+            expect(@out.string).to include('Then(/^this step is undefined$/)')
           end
         end
 
@@ -896,12 +896,12 @@ OUTPUT
             Given(/^this step passes$/) {}
           end
           it "uses 'Given' as actual keyword the step in each scenario" do
-            expect(@out.string).to include("Given(/^this step is undefined$/)")
-            expect(@out.string).to include("Given(/^this step is also undefined$/)")
+            expect(@out.string).to include('Given(/^this step is undefined$/)')
+            expect(@out.string).to include('Given(/^this step is also undefined$/)')
           end
         end
 
-        describe "with a scenario in en-lol" do
+        describe 'with a scenario in en-lol' do
           define_feature <<-FEATURE
           # language: en-lol
           OH HAI: STUFFING
@@ -910,8 +910,8 @@ OUTPUT
               I CAN HAZ IN TEH BEGINNIN CUCUMBRZ
               AN I EAT CUCUMBRZ
             FEATURE
-          it "uses actual keyword of the previous passing step for the undefined step" do
-            expect(@out.string).to include("ICANHAZ(/^I EAT CUCUMBRZ$/)")
+          it 'uses actual keyword of the previous passing step for the undefined step' do
+            expect(@out.string).to include('ICANHAZ(/^I EAT CUCUMBRZ$/)')
           end
         end
       end

--- a/spec/cucumber/formatter/progress_spec.rb
+++ b/spec/cucumber/formatter/progress_spec.rb
@@ -16,12 +16,12 @@ module Cucumber
         @formatter = Progress.new(actual_runtime.configuration.with_options(out_stream: @out))
       end
 
-      describe "given a single feature" do
+      describe 'given a single feature' do
         before(:each) do
           run_defined_feature
         end
 
-        describe "with a scenario" do
+        describe 'with a scenario' do
           define_feature <<-FEATURE
             Feature: Banana party
 
@@ -29,12 +29,12 @@ module Cucumber
                 Given there are bananas
           FEATURE
 
-          it "outputs the undefined step" do
+          it 'outputs the undefined step' do
             expect(@out.string).to include "U\n"
           end
         end
 
-        describe "with a background" do
+        describe 'with a background' do
           define_feature <<-FEATURE
             Feature: Banana party
 
@@ -45,12 +45,12 @@ module Cucumber
                 Given there are bananas
           FEATURE
 
-          it "outputs the two undefined steps" do
+          it 'outputs the two undefined steps' do
             expect(@out.string).to include "UU\n"
           end
         end
 
-        describe "with a scenario outline" do
+        describe 'with a scenario outline' do
           define_feature <<-FEATURE
             Feature: Fud Pyramid
 
@@ -67,23 +67,23 @@ module Cucumber
                  | carrots  |
           FEATURE
 
-          it "outputs each undefined step" do
+          it 'outputs each undefined step' do
             expect(@out.string).to include "UUUU\n"
           end
 
-          it "has 4 undefined scenarios" do
-            expect(@out.string).to include "4 scenarios (4 undefined)"
+          it 'has 4 undefined scenarios' do
+            expect(@out.string).to include '4 scenarios (4 undefined)'
           end
 
-          it "has 4 undefined steps" do
-            expect(@out.string).to include "4 steps (4 undefined)"
+          it 'has 4 undefined steps' do
+            expect(@out.string).to include '4 steps (4 undefined)'
           end
 
         end
 
-        describe "with hooks" do
+        describe 'with hooks' do
 
-          describe "all hook passes" do
+          describe 'all hook passes' do
             define_feature <<-FEATURE
           Feature:
             Scenario:
@@ -100,7 +100,7 @@ module Cucumber
               Given(/^this step passes$/) {}
             end
 
-            it "only steps generate output" do
+            it 'only steps generate output' do
               lines = <<-OUTPUT
               .
               1 scenario (1 passed)
@@ -112,7 +112,7 @@ module Cucumber
             end
           end
 
-          describe "with a failing before hook" do
+          describe 'with a failing before hook' do
             define_feature <<-FEATURE
           Feature:
             Scenario:
@@ -121,12 +121,12 @@ module Cucumber
 
             define_steps do
               Before do
-                fail "hook failed" 
+                fail 'hook failed' 
               end
               Given(/^this step passes$/) {}
             end
 
-            it "the failing hook generate output" do
+            it 'the failing hook generate output' do
               lines = <<-OUTPUT
               F-
               1 scenario (1 failed)
@@ -138,7 +138,7 @@ module Cucumber
             end
           end
 
-          describe "with a failing after hook" do
+          describe 'with a failing after hook' do
             define_feature <<-FEATURE
           Feature:
             Scenario:
@@ -147,12 +147,12 @@ module Cucumber
 
             define_steps do
               After do
-                fail "hook failed" 
+                fail 'hook failed' 
               end
               Given(/^this step passes$/) {}
             end
 
-            it "the failing hook generate output" do
+            it 'the failing hook generate output' do
               lines = <<-OUTPUT
               .F
               1 scenario (1 failed)

--- a/spec/cucumber/formatter/spec_helper.rb
+++ b/spec/cucumber/formatter/spec_helper.rb
@@ -52,7 +52,7 @@ module Cucumber
       end
 
       def gherkin
-        self.class.feature_content || raise("No feature content defined!")
+        self.class.feature_content || raise('No feature content defined!')
       end
 
       def runtime

--- a/spec/cucumber/hooks_spec.rb
+++ b/spec/cucumber/hooks_spec.rb
@@ -2,15 +2,15 @@
 require 'cucumber/hooks'
 module Cucumber::Hooks
   shared_examples_for 'a source node' do
-    it "responds to name" do
+    it 'responds to name' do
       expect( subject.name ).to be_a(String)
     end
 
-    it "responds to location" do
+    it 'responds to location' do
       expect( subject.location ).to eq(location)
     end
 
-    it "responds to match_locations?" do
+    it 'responds to match_locations?' do
       expect( subject.match_locations? [location] ).to be_truthy
       expect( subject.match_locations? [] ).to be_falsey
     end

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -13,30 +13,30 @@ module Cucumber
         ])
       end
 
-      it "should have rows" do
+      it 'should have rows' do
         expect( @table.cells_rows[0].map{|cell| cell.value} ).to eq %w{one four seven}
       end
 
-      it "should have columns" do
+      it 'should have columns' do
         expect( @table.columns[1].map{|cell| cell.value} ).to eq %w{four 55555}
       end
 
-      it "should have same cell objects in rows and columns" do
+      it 'should have same cell objects in rows and columns' do
         # 666666
         expect( @table.cells_rows[1][2] ).to equal(@table.columns[2][1])
       end
 
-      it "should be convertible to an array of hashes" do
+      it 'should be convertible to an array of hashes' do
         expect( @table.hashes ).to eq [
           {'one' => '4444', 'four' => '55555', 'seven' => '666666'}
         ]
       end
 
-      it "should accept symbols as keys for the hashes" do
+      it 'should accept symbols as keys for the hashes' do
         expect( @table.hashes.first[:one] ).to eq '4444'
       end
 
-      it "should return the row values in order" do
+      it 'should return the row values in order' do
         expect( @table.rows.first ).to eq %w{4444 55555 666666}
       end
 
@@ -56,12 +56,12 @@ module Cucumber
       end
 
       describe '#map_column!' do
-        it "should allow mapping columns" do
+        it 'should allow mapping columns' do
           @table.map_column!('one') { |v| v.to_i }
           expect( @table.hashes.first['one'] ).to eq 4444
         end
 
-        it "applies the block once to each value" do
+        it 'applies the block once to each value' do
           headers = ['header']
           rows = ['value']
           table = DataTable.from [headers, rows]
@@ -71,43 +71,43 @@ module Cucumber
           expect( count ).to eq rows.size
         end
 
-        it "should allow mapping columns and take a symbol as the column name" do
+        it 'should allow mapping columns and take a symbol as the column name' do
           @table.map_column!(:one) { |v| v.to_i }
           expect( @table.hashes.first['one'] ).to eq 4444
         end
 
-        it "should allow mapping columns and modify the rows as well" do
+        it 'should allow mapping columns and modify the rows as well' do
           @table.map_column!(:one) { |v| v.to_i }
           expect( @table.rows.first ).to include(4444)
           expect( @table.rows.first ).to_not include('4444')
         end
 
-        it "should pass silently if a mapped column does not exist in non-strict mode" do
+        it 'should pass silently if a mapped column does not exist in non-strict mode' do
           expect {
             @table.map_column!('two', false) { |v| v.to_i }
             @table.hashes
           }.not_to raise_error
         end
 
-        it "should fail if a mapped column does not exist in strict mode" do
+        it 'should fail if a mapped column does not exist in strict mode' do
           expect {
             @table.map_column!('two', true) { |v| v.to_i }
             @table.hashes
           }.to raise_error('The column named "two" does not exist')
         end
 
-        it "should return the table" do
+        it 'should return the table' do
           expect( (@table.map_column!(:one) { |v| v.to_i }) ).to eq @table
         end
       end
 
       describe '#map_column' do
-        it "should allow mapping columns" do
+        it 'should allow mapping columns' do
           new_table = @table.map_column('one') { |v| v.to_i }
           expect( new_table.hashes.first['one'] ).to eq 4444
         end
 
-        it "applies the block once to each value" do
+        it 'applies the block once to each value' do
           headers = ['header']
           rows = ['value']
           table = DataTable.from [headers, rows]
@@ -117,37 +117,37 @@ module Cucumber
           expect( count ).to eq rows.size
         end
 
-        it "should allow mapping columns and take a symbol as the column name" do
+        it 'should allow mapping columns and take a symbol as the column name' do
           new_table = @table.map_column(:one) { |v| v.to_i }
           expect( new_table.hashes.first['one'] ).to eq 4444
         end
 
-        it "should allow mapping columns and modify the rows as well" do
+        it 'should allow mapping columns and modify the rows as well' do
           new_table = @table.map_column(:one) { |v| v.to_i }
           expect( new_table.rows.first ).to include(4444)
           expect( new_table.rows.first ).to_not include('4444')
         end
 
-        it "should pass silently if a mapped column does not exist in non-strict mode" do
+        it 'should pass silently if a mapped column does not exist in non-strict mode' do
           expect {
             new_table = @table.map_column('two', false) { |v| v.to_i }
             new_table.hashes
           }.not_to raise_error
         end
 
-        it "should fail if a mapped column does not exist in strict mode" do
+        it 'should fail if a mapped column does not exist in strict mode' do
           expect {
             new_table = @table.map_column('two', true) { |v| v.to_i }
             new_table.hashes
           }.to raise_error('The column named "two" does not exist')
         end
 
-        it "should return a new table" do
+        it 'should return a new table' do
           expect( (@table.map_column(:one) { |v| v.to_i }) ).to_not eq @table
         end
       end
 
-      describe "#match" do
+      describe '#match' do
         before(:each) do
           @table = DataTable.from([
             %w{one four seven},
@@ -155,18 +155,18 @@ module Cucumber
           ])
         end
 
-        it "returns nil if headers do not match" do
+        it 'returns nil if headers do not match' do
           expect( @table.match('does,not,match') ).to be_nil
         end
-        it "requires a table: prefix on match" do
+        it 'requires a table: prefix on match' do
           expect( @table.match('table:one,four,seven') ).to_not be_nil
         end
-        it "does not match if no table: prefix on match" do
+        it 'does not match if no table: prefix on match' do
           expect( @table.match('one,four,seven') ).to be_nil
         end
       end
 
-      describe "#transpose" do
+      describe '#transpose' do
         before(:each) do
           @table = DataTable.from([
             %w{one 1111},
@@ -174,14 +174,14 @@ module Cucumber
           ])
         end
 
-        it "should be convertible in to an array where each row is a hash" do
+        it 'should be convertible in to an array where each row is a hash' do
           expect( @table.transpose.hashes[0] ).to eq('one' => '1111', 'two' => '22222')
         end
       end
 
-      describe "#rows_hash" do
+      describe '#rows_hash' do
 
-        it "should return a hash of the rows" do
+        it 'should return a hash of the rows' do
           table = DataTable.from([
             %w{one 1111},
             %w{two 22222}
@@ -199,7 +199,7 @@ module Cucumber
           }.to raise_error('The table must have exactly 2 columns')
         end
 
-        it "should support header and column mapping" do
+        it 'should support header and column mapping' do
           table = DataTable.from([
             %w{one 1111},
             %w{two 22222}
@@ -218,30 +218,30 @@ module Cucumber
           ])
         end
 
-        it "renames the columns to the specified values in the provided hash" do
+        it 'renames the columns to the specified values in the provided hash' do
           @table.map_headers!('one' => :three)
           expect( @table.hashes.first[:three] ).to eq '4444'
         end
 
-        it "allows renaming columns using regexp" do
+        it 'allows renaming columns using regexp' do
           @table.map_headers!(/one|uno/ => :three)
           expect( @table.hashes.first[:three] ).to eq '4444'
         end
 
-        it "copies column mappings" do
+        it 'copies column mappings' do
           @table.map_column!('one') { |v| v.to_i }
           @table.map_headers!('one' => 'three')
           expect( @table.hashes.first['three'] ).to eq 4444
         end
 
-        it "takes a block and operates on all the headers with it" do
+        it 'takes a block and operates on all the headers with it' do
           table.map_headers! do |header|
             header.downcase
           end
           expect( table.hashes.first.keys ).to match %w[hello world]
         end
 
-        it "treats the mappings in the provided hash as overrides when used with a block" do
+        it 'treats the mappings in the provided hash as overrides when used with a block' do
           table.map_headers!('WORLD' => 'foo') do |header|
             header.downcase
           end
@@ -258,23 +258,23 @@ module Cucumber
           ])
         end
 
-        it "renames the columns to the specified values in the provided hash" do
+        it 'renames the columns to the specified values in the provided hash' do
           table2 = @table.map_headers('one' => :three)
           expect( table2.hashes.first[:three] ).to eq '4444'
         end
 
-        it "allows renaming columns using regexp" do
+        it 'allows renaming columns using regexp' do
           table2 = @table.map_headers(/one|uno/ => :three)
           expect( table2.hashes.first[:three] ).to eq '4444'
         end
 
-        it "copies column mappings" do
+        it 'copies column mappings' do
           @table.map_column!('one') { |v| v.to_i }
           table2 = @table.map_headers('one' => 'three')
           expect( table2.hashes.first['three'] ).to eq 4444
         end
 
-        it "takes a block and operates on all the headers with it" do
+        it 'takes a block and operates on all the headers with it' do
           table2 = table.map_headers do |header|
             header.downcase
           end
@@ -282,7 +282,7 @@ module Cucumber
           expect( table2.hashes.first.keys ).to match %w[hello world]
         end
 
-        it "treats the mappings in the provided hash as overrides when used with a block" do
+        it 'treats the mappings in the provided hash as overrides when used with a block' do
           table2 = table.map_headers('WORLD' => 'foo') do |header|
             header.downcase
           end
@@ -291,8 +291,8 @@ module Cucumber
         end
       end
 
-      describe "diff!" do
-        it "should detect a complex diff" do
+      describe 'diff!' do
+        it 'should detect a complex diff' do
           t1 = DataTable.from(%{
             | 1         | 22          | 333         | 4444         |
             | 55555     | 666666      | 7777777     | 88888888     |
@@ -318,7 +318,7 @@ module Cucumber
           }
         end
 
-        it "should not change table when diffed with identical" do
+        it 'should not change table when diffed with identical' do
           t = DataTable.from(%{
             |a|b|c|
             |d|e|f|
@@ -332,8 +332,8 @@ module Cucumber
           }
         end
 
-        context "in case of duplicate header values" do
-          it "raises no error for two identical tables" do
+        context 'in case of duplicate header values' do
+          it 'raises no error for two identical tables' do
             t = DataTable.from(%{
             |a|a|c|
             |d|e|f|
@@ -347,7 +347,7 @@ module Cucumber
           }
           end
 
-          it "detects a diff in one cell" do
+          it 'detects a diff in one cell' do
             t1 = DataTable.from(%{
             |a|a|c|
             |d|e|f|
@@ -367,7 +367,7 @@ module Cucumber
           }
           end
 
-          it "detects missing columns" do
+          it 'detects missing columns' do
             t1 = DataTable.from(%{
             |a|a|b|c|
             |d|d|e|f|
@@ -386,7 +386,7 @@ module Cucumber
           }
           end
 
-          it "detects surplus columns" do
+          it 'detects surplus columns' do
             t1 = DataTable.from(%{
             |a|b|c|
             |d|e|f|
@@ -406,7 +406,7 @@ module Cucumber
           end
         end
 
-        it "should inspect missing and surplus cells" do
+        it 'should inspect missing and surplus cells' do
           t1 = DataTable.from([
             ['name',  'male', 'lastname', 'swedish'],
             ['aslak', 'true', 'hellesøy', 'false']
@@ -424,7 +424,7 @@ module Cucumber
           }
         end
 
-        it "should allow column mapping of target before diffing" do
+        it 'should allow column mapping of target before diffing' do
           t1 = DataTable.from([
             ['name',  'male'],
             ['aslak', 'true']
@@ -441,7 +441,7 @@ module Cucumber
           }
         end
 
-        it "should allow column mapping of argument before diffing" do
+        it 'should allow column mapping of argument before diffing' do
           t1 = DataTable.from([
             ['name',  'male'],
             ['aslak', true]
@@ -460,7 +460,7 @@ module Cucumber
           }
         end
 
-        it "should allow header mapping before diffing" do
+        it 'should allow header mapping before diffing' do
           t1 = DataTable.from([
             ['Name',  'Male'],
             ['aslak', 'true']
@@ -478,7 +478,7 @@ module Cucumber
           }
         end
 
-        it "should detect seemingly identical tables as different" do
+        it 'should detect seemingly identical tables as different' do
           t1 = DataTable.from([
             ['X',  'Y'],
             ['2', '1']
@@ -495,7 +495,7 @@ module Cucumber
           }
         end
 
-        it "should not allow mappings that match more than 1 column" do
+        it 'should not allow mappings that match more than 1 column' do
           t1 = DataTable.from([
             ['Cuke',  'Duke'],
             ['Foo', 'Bar']
@@ -506,7 +506,7 @@ module Cucumber
           end.to raise_error(%{2 headers matched /uk/: ["Cuke", "Duke"]})
         end
 
-        describe "raising" do
+        describe 'raising' do
           before do
             @t = DataTable.from(%{
               | a | b |
@@ -515,7 +515,7 @@ module Cucumber
             expect( @t ).not_to eq nil
           end
 
-          it "should raise on missing rows" do
+          it 'should raise on missing rows' do
             t = DataTable.from(%{
               | a | b |
             })
@@ -523,7 +523,7 @@ module Cucumber
             expect { @t.dup.diff!(t, :missing_row => false) }.not_to raise_error
           end
 
-          it "should not raise on surplus rows when surplus is at the end" do
+          it 'should not raise on surplus rows when surplus is at the end' do
             t = DataTable.from(%{
               | a | b |
               | c | d |
@@ -533,7 +533,7 @@ module Cucumber
             expect { @t.dup.diff!(t, :surplus_row => false) }.not_to raise_error
           end
 
-          it "should not raise on surplus rows when surplus is interleaved" do
+          it 'should not raise on surplus rows when surplus is interleaved' do
             t1 = DataTable.from(%{
               | row_1 | row_2 |
               | four  | 4     |
@@ -551,7 +551,7 @@ module Cucumber
             expect { t1.dup.diff!(t2, :surplus_row => false) }.not_to raise_error
           end
 
-          it "should raise on missing columns" do
+          it 'should raise on missing columns' do
             t = DataTable.from(%{
               | a |
               | c |
@@ -560,7 +560,7 @@ module Cucumber
             expect { @t.dup.diff!(t, :missing_col => false) }.not_to raise_error
           end
 
-          it "should not raise on surplus columns" do
+          it 'should not raise on surplus columns' do
             t = DataTable.from(%{
               | a | b | x |
               | c | d | y |
@@ -569,7 +569,7 @@ module Cucumber
             expect { @t.dup.diff!(t, :surplus_col => true) }.to raise_error
           end
 
-          it "should not raise on misplaced columns" do
+          it 'should not raise on misplaced columns' do
             t = DataTable.from(%{
               | b | a |
               | d | c |
@@ -579,7 +579,7 @@ module Cucumber
           end
         end
 
-        it "can compare to an Array" do
+        it 'can compare to an Array' do
           t = DataTable.from(%{
             | b | a |
             | d | c |
@@ -590,8 +590,8 @@ module Cucumber
         end
       end
 
-      describe "#from" do
-        it "should allow Array of Hash" do
+      describe '#from' do
+        it 'should allow Array of Hash' do
           t1 = DataTable.from([{'name' => 'aslak', 'male' => 'true'}])
           expect( t1.to_s(:indent => 12, :color => false) ).to eq %{
             |     male |     name  |

--- a/spec/cucumber/project_initializer_spec.rb
+++ b/spec/cucumber/project_initializer_spec.rb
@@ -10,7 +10,7 @@ module Cucumber
       allow(command_line_config).to receive(:puts)
     end
 
-    context "no files created" do
+    context 'no files created' do
       around(:example) do |example|
 
         dir = Dir.mktmpdir
@@ -24,29 +24,29 @@ module Cucumber
         end
       end
 
-      it "should create features directory" do
+      it 'should create features directory' do
         expect(command_line_config).to receive(:puts).with %r(^\s+create\s+features$)
         command_line_config.run
       end
 
-      it "should create step_definitions directory" do
+      it 'should create step_definitions directory' do
         expect(command_line_config).to receive(:puts).with %r(^\s+create\s+features/step_definitions$)
         command_line_config.run
       end
 
-      it "should create support directory" do
+      it 'should create support directory' do
         expect(command_line_config).to receive(:puts).with %r(^\s+create\s+features/support$)
         command_line_config.run
       end
 
-      it "should create env.rb directory" do
+      it 'should create env.rb directory' do
         expect(command_line_config).to receive(:puts).with %r(^\s+create\s+features/support/env.rb$)
         command_line_config.run
       end
 
     end
 
-    context "files created" do
+    context 'files created' do
       around(:example) do |example|
         dir = Dir.mktmpdir
         FileUtils.mkdir_p "#{dir}/features"
@@ -63,22 +63,22 @@ module Cucumber
         end
       end
 
-      it "should not create features directory" do
+      it 'should not create features directory' do
         expect(command_line_config).to receive(:puts).with %r(^\s+exist\s+features$)
         command_line_config.run
       end
 
-      it "should not create step_definitions directory" do
+      it 'should not create step_definitions directory' do
         expect(command_line_config).to receive(:puts).with %r(^\s+exist\s+features/step_definitions$)
         command_line_config.run
       end
 
-      it "should not create support directory" do
+      it 'should not create support directory' do
         expect(command_line_config).to receive(:puts).with %r(^\s+exist\s+features/support$)
         command_line_config.run
       end
 
-      it "should not create env.rb directory" do
+      it 'should not create env.rb directory' do
         expect(command_line_config).to receive(:puts).with %r(^\s+exist\s+features/support/env.rb$)
         command_line_config.run
       end

--- a/spec/cucumber/rake/forked_spec.rb
+++ b/spec/cucumber/rake/forked_spec.rb
@@ -11,17 +11,17 @@ module Cucumber
       let(:cucumber_opts) { ['--cuke-option'] }
       let(:feature_files) { ['./some.feature'] }
 
-      context "when running with bundler" do
+      context 'when running with bundler' do
         let(:bundler) { true }
 
         subject { Task::ForkedCucumberRunner.new(
             libs, binary, cucumber_opts, bundler, feature_files) }
 
-        it "does use bundler if bundler is set to true" do
+        it 'does use bundler if bundler is set to true' do
           expect(subject.use_bundler).to be true
         end
 
-        it "uses bundle exec to find cucumber and libraries" do
+        it 'uses bundle exec to find cucumber and libraries' do
           expect(subject.cmd).to eq [Cucumber::RUBY_BINARY,
             '-S',
             'bundle',
@@ -31,22 +31,22 @@ module Cucumber
         end
       end
 
-      context "when running without bundler" do
+      context 'when running without bundler' do
         let(:bundler) { false }
 
         subject { Task::ForkedCucumberRunner.new(
             libs, binary, cucumber_opts, bundler, feature_files) }
 
-        it "does not use bundler if bundler is set to false" do
+        it 'does not use bundler if bundler is set to false' do
           expect(subject.use_bundler).to be false
         end
 
-        it "uses well known cucumber location and specified libraries" do
+        it 'uses well known cucumber location and specified libraries' do
           expect(subject.cmd).to eq [Cucumber::RUBY_BINARY,
-            "-I",
-            "\"lib\"",
+            '-I',
+            '"lib"',
             "\"#{Cucumber::BINARY }\"",
-            "--cuke-option"] + feature_files
+            '--cuke-option'] + feature_files
         end
       end
     end

--- a/spec/cucumber/rake/task_spec.rb
+++ b/spec/cucumber/rake/task_spec.rb
@@ -7,75 +7,75 @@ module Cucumber
   module Rake
     describe Task do
 
-      describe "#cucumber_opts" do
+      describe '#cucumber_opts' do
         before { subject.cucumber_opts = opts }
 
-        context "when set via array" do
+        context 'when set via array' do
           let(:opts) { %w[ foo bar ] }
           it { expect(subject.cucumber_opts).to be opts }
         end
 
-        context "when set via space-delimited string" do
-          let(:opts) { "foo bar" }
+        context 'when set via space-delimited string' do
+          let(:opts) { 'foo bar' }
           it { expect(subject.cucumber_opts).to eq %w[ foo bar ] }
         end
       end
 
-      describe "#cucumber_opts_with_profile" do
+      describe '#cucumber_opts_with_profile' do
         before do
           subject.cucumber_opts = opts
           subject.profile = profile
         end
 
-        context "with cucumber_opts" do
+        context 'with cucumber_opts' do
           let(:opts) { %w[ foo bar ] }
 
-          context "without profile" do
+          context 'without profile' do
             let(:profile) { nil }
 
-            it "should return just cucumber_opts" do
+            it 'should return just cucumber_opts' do
               expect(subject.cucumber_opts_with_profile).to be opts
             end
           end
 
-          context "with profile" do
-            let(:profile) { "fancy" }
+          context 'with profile' do
+            let(:profile) { 'fancy' }
 
-            it "should combine opts and profile into an array, prepending --profile option" do
+            it 'should combine opts and profile into an array, prepending --profile option' do
               expect(subject.cucumber_opts_with_profile).to eq %w[ foo bar --profile fancy ]
             end
           end
 
-          context "with multiple profiles" do
+          context 'with multiple profiles' do
             let(:profile) { %w[ fancy pants ] }
 
-            it "should combine opts and each profile into an array, prepending --profile option" do
+            it 'should combine opts and each profile into an array, prepending --profile option' do
               expect(subject.cucumber_opts_with_profile).to eq %w[ foo bar --profile fancy --profile pants ]
             end
           end
         end
 
-        context "without cucumber_opts" do
+        context 'without cucumber_opts' do
           let(:opts) { nil }
 
-          context "without profile" do
+          context 'without profile' do
             let(:profile) { nil }
 
             it { expect(subject.cucumber_opts_with_profile).to eq [] }
           end
 
-          context "with profile" do
-            let(:profile) { "fancy" }
+          context 'with profile' do
+            let(:profile) { 'fancy' }
 
-            it "should combine opts and profile into an array, prepending --profile option" do
+            it 'should combine opts and profile into an array, prepending --profile option' do
               expect(subject.cucumber_opts_with_profile).to eq %w[ --profile fancy ]
             end
           end
 
-          context "with multiple profiles" do
+          context 'with multiple profiles' do
             let(:profile) { %w[ fancy pants ] }
 
-            it "should combine opts and each profile into an array, prepending --profile option" do
+            it 'should combine opts and each profile into an array, prepending --profile option' do
               expect(subject.cucumber_opts_with_profile).to eq %w[ --profile fancy --profile pants ]
             end
           end

--- a/spec/cucumber/rb_support/rb_language_spec.rb
+++ b/spec/cucumber/rb_support/rb_language_spec.rb
@@ -15,7 +15,7 @@ module Cucumber
         Object.new.extend(RbSupport::RbDsl)
       end
 
-      describe "#load_code_file" do
+      describe '#load_code_file' do
         after do
           FileUtils.rm_rf('tmp.rb')
           FileUtils.rm_rf('docs.md')
@@ -27,16 +27,16 @@ module Cucumber
           end
         end
 
-        it "re-loads the file when called multiple times" do
+        it 're-loads the file when called multiple times' do
           a_file_called('tmp.rb') do
-            "$foo = 1"
+            '$foo = 1'
           end
 
           rb.load_code_file('tmp.rb')
           expect($foo).to eq 1
 
           a_file_called('tmp.rb') do
-            "$foo = 2"
+            '$foo = 2'
           end
 
           rb.load_code_file('tmp.rb')
@@ -44,23 +44,23 @@ module Cucumber
           expect($foo).to eq 2
         end
 
-        it "only loads ruby files" do
-          a_file_called("docs.md") do
-            "yo"
+        it 'only loads ruby files' do
+          a_file_called('docs.md') do
+            'yo'
           end
           rb.load_code_file('docs.md')
         end
       end
 
-      describe "Handling the World" do
-        it "raises an error if the world is nil" do
+      describe 'Handling the World' do
+        it 'raises an error if the world is nil' do
           dsl.World {}
 
           begin
             rb.begin_scenario(nil)
-            raise "Should fail"
+            raise 'Should fail'
           rescue RbSupport::NilWorld => e
-            expect(e.message).to eq "World procs should never return nil"
+            expect(e.message).to eq 'World procs should never return nil'
             expect(e.backtrace.length).to eq 1
             expect(e.backtrace[0]).to match(/spec\/cucumber\/rb_support\/rb_language_spec\.rb\:\d+\:in `World'/)
           end
@@ -75,7 +75,7 @@ module Cucumber
         class ClassOne
         end
 
-        it "implicitlys extend world with modules" do
+        it 'implicitlys extend world with modules' do
           dsl.World(ModuleOne, ModuleTwo)
           rb.begin_scenario(double('scenario').as_null_object)
           class << rb.current_world
@@ -87,7 +87,7 @@ module Cucumber
           expect(rb.current_world.class).to eq Object
         end
 
-        it "raises error when we try to register more than one World proc" do
+        it 'raises error when we try to register more than one World proc' do
           expected_error = %{You can only pass a proc to #World once, but it's happening
 in 2 places:
 
@@ -182,34 +182,34 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
         end
       end
 
-      describe "step argument transformations" do
-        describe "without capture groups" do
-          it "complains when registering with a with no transform block" do
+      describe 'step argument transformations' do
+        describe 'without capture groups' do
+          it 'complains when registering with a with no transform block' do
             expect(-> {
               dsl.Transform('^abc$')
             }).to raise_error(Cucumber::RbSupport::RbTransform::MissingProc)
           end
 
-          it "complains when registering with a zero-arg transform block" do
+          it 'complains when registering with a zero-arg transform block' do
             expect(-> {
               dsl.Transform('^abc$') {42}
             }).to raise_error(Cucumber::RbSupport::RbTransform::MissingProc)
           end
 
-          it "complains when registering with a splat-arg transform block" do
+          it 'complains when registering with a splat-arg transform block' do
             expect(-> {
               dsl.Transform('^abc$') {|*splat| 42 }
             }).to raise_error(Cucumber::RbSupport::RbTransform::MissingProc)
           end
 
-          it "complains when transforming with an arity mismatch" do
+          it 'complains when transforming with an arity mismatch' do
             expect(-> {
               dsl.Transform('^abc$') {|one, two| 42 }
               rb.execute_transforms(['abc'])
             }).to raise_error(Cucumber::ArityMismatchError)
           end
 
-          it "allows registering a regexp pattern that yields the step_arg matched" do
+          it 'allows registering a regexp pattern that yields the step_arg matched' do
             dsl.Transform(/^ab*c$/) {|arg| 42}
 
             expect(rb.execute_transforms(['ab'])).to eq ['ab']
@@ -218,7 +218,7 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
             expect(rb.execute_transforms(['abbc'])).to eq [42]
           end
 
-          it "transforms times" do
+          it 'transforms times' do
             require 'time'
             dsl.Transform(/^(\d\d-\d\d-\d\d\d\d)$/) do |arg|
               Time.parse(arg)
@@ -228,33 +228,33 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
           end
         end
 
-        describe "with capture groups" do
-          it "complains when registering with a with no transform block" do
+        describe 'with capture groups' do
+          it 'complains when registering with a with no transform block' do
             expect(-> {
               dsl.Transform('^a(.)c$')
             }).to raise_error(Cucumber::RbSupport::RbTransform::MissingProc)
           end
 
-          it "complains when registering with a zero-arg transform block" do
+          it 'complains when registering with a zero-arg transform block' do
             expect(-> {
               dsl.Transform('^a(.)c$') { 42 }
             }).to raise_error(Cucumber::RbSupport::RbTransform::MissingProc)
           end
 
-          it "complains when registering with a splat-arg transform block" do
+          it 'complains when registering with a splat-arg transform block' do
             expect(-> {
               dsl.Transform('^a(.)c$') {|*splat| 42 }
             }).to raise_error(Cucumber::RbSupport::RbTransform::MissingProc)
           end
 
-          it "complains when transforming with an arity mismatch" do
+          it 'complains when transforming with an arity mismatch' do
             expect(-> {
               dsl.Transform('^a(.)c$') {|one, two| 42 }
               rb.execute_transforms(['abc'])
             }).to raise_error(Cucumber::ArityMismatchError)
           end
 
-          it "allows registering a regexp pattern that yields capture groups" do
+          it 'allows registering a regexp pattern that yields capture groups' do
             dsl.Transform(/^shape: (.+), color: (.+)$/) do |shape, color|
               {shape.to_sym => color.to_sym}
             end
@@ -265,7 +265,7 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
           end
         end
 
-        it "allows registering a string pattern" do
+        it 'allows registering a string pattern' do
           dsl.Transform('^ab*c$') {|arg| 42}
 
           expect(rb.execute_transforms(['ab'])).to eq ['ab']
@@ -274,7 +274,7 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
           expect(rb.execute_transforms(['abbc'])).to eq [42]
         end
 
-        it "gives match priority to transforms defined last" do
+        it 'gives match priority to transforms defined last' do
           dsl.Transform(/^transform_me$/) {|arg| :foo }
           dsl.Transform(/^transform_me$/) {|arg| :bar }
           dsl.Transform(/^transform_me$/) {|arg| :baz }
@@ -282,7 +282,7 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
           expect(rb.execute_transforms(['transform_me'])).to eq [:baz]
         end
 
-        it "allows registering a transform which returns nil" do
+        it 'allows registering a transform which returns nil' do
           dsl.Transform('^ac$') {|arg| nil}
 
           expect(rb.execute_transforms(['ab'])).to eq ['ab']
@@ -290,8 +290,8 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
         end
       end
 
-      describe "hooks" do
-        it "finds before hooks" do
+      describe 'hooks' do
+        it 'finds before hooks' do
           fish = dsl.Before('@fish'){}
           meat = dsl.Before('@meat'){}
 
@@ -302,7 +302,7 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
           expect(rb.hooks_for(:before, scenario)).to eq [fish]
         end
 
-        it "finds around hooks" do
+        it 'finds around hooks' do
           a = dsl.Around do |scenario, block|
           end
 

--- a/spec/cucumber/rb_support/rb_step_definition_spec.rb
+++ b/spec/cucumber/rb_support/rb_step_definition_spec.rb
@@ -27,43 +27,43 @@ module Cucumber
         StepMatchSearch.new(rb.method(:step_matches), Configuration.default).call(text).first
       end
 
-      it "allows calling of other steps" do
+      it 'allows calling of other steps' do
         dsl.Given(/Outside/) do
-          step "Inside"
+          step 'Inside'
         end
         dsl.Given(/Inside/) do
           $inside = true
         end
 
-        run_step "Outside"
+        run_step 'Outside'
 
         expect($inside).to be true
       end
 
-      it "allows calling of other steps with inline arg" do
+      it 'allows calling of other steps with inline arg' do
         dsl.Given(/Outside/) do
           location = Core::Ast::Location.new(__FILE__, __LINE__)
-          step "Inside", table([['inside']])
+          step 'Inside', table([['inside']])
         end
         dsl.Given(/Inside/) do |t|
           $inside = t.raw[0][0]
         end
 
-        run_step "Outside"
+        run_step 'Outside'
 
         expect($inside).to eq 'inside'
       end
 
-      context "mapping to world methods" do
-        it "calls a method on the world when specified with a symbol" do
+      context 'mapping to world methods' do
+        it 'calls a method on the world when specified with a symbol' do
           expect(rb.current_world).to receive(:with_symbol)
 
           dsl.Given(/With symbol/, :with_symbol)
 
-          run_step "With symbol"
+          run_step 'With symbol'
         end
 
-        it "calls a method on a specified object" do
+        it 'calls a method on a specified object' do
           target = double('target')
 
           allow(rb.current_world).to receive(:target) { target }
@@ -72,10 +72,10 @@ module Cucumber
 
           expect(target).to receive(:with_symbol)
 
-          run_step "With symbol on block"
+          run_step 'With symbol on block'
         end
 
-        it "calls a method on a specified world attribute" do
+        it 'calls a method on a specified world attribute' do
           target = double('target')
 
           allow(rb.current_world).to receive(:target) { target }
@@ -84,26 +84,26 @@ module Cucumber
 
           expect(target).to receive(:with_symbol)
 
-          run_step "With symbol on symbol"
+          run_step 'With symbol on symbol'
         end
 
-        it "has the correct location" do
+        it 'has the correct location' do
           dsl.Given(/With symbol/, :with_symbol)
-          expect(step_match("With symbol").file_colon_line).to eq "spec/cucumber/rb_support/rb_step_definition_spec.rb:#{__LINE__-1}"
+          expect(step_match('With symbol').file_colon_line).to eq "spec/cucumber/rb_support/rb_step_definition_spec.rb:#{__LINE__-1}"
         end
       end
 
-      it "raises UndefinedDynamicStep when inside step is not defined" do
+      it 'raises UndefinedDynamicStep when inside step is not defined' do
         dsl.Given(/Outside/) do
           step 'Inside'
         end
 
         expect(-> {
-          run_step "Outside"
+          run_step 'Outside'
         }).to raise_error(Cucumber::UndefinedDynamicStep)
       end
 
-      it "raises UndefinedDynamicStep when an undefined step is parsed dynamically" do
+      it 'raises UndefinedDynamicStep when an undefined step is parsed dynamically' do
         dsl.Given(/Outside/) do
           steps %{
             Given Inside
@@ -111,11 +111,11 @@ module Cucumber
         end
 
         expect(-> {
-          run_step "Outside"
+          run_step 'Outside'
         }).to raise_error(Cucumber::UndefinedDynamicStep)
       end
 
-      it "raises UndefinedDynamicStep when an undefined step with doc string is parsed dynamically" do
+      it 'raises UndefinedDynamicStep when an undefined step with doc string is parsed dynamically' do
         dsl.Given(/Outside/) do
           steps %{
             Given Inside
@@ -126,11 +126,11 @@ module Cucumber
         end
 
         expect(-> {
-          run_step "Outside"
+          run_step 'Outside'
         }).to raise_error(Cucumber::UndefinedDynamicStep)
       end
 
-      it "raises UndefinedDynamicStep when an undefined step with data table is parsed dynamically" do
+      it 'raises UndefinedDynamicStep when an undefined step with data table is parsed dynamically' do
         dsl.Given(/Outside/) do
           steps %{
             Given Inside
@@ -140,35 +140,35 @@ module Cucumber
         end
 
         expect(-> {
-          run_step "Outside"
+          run_step 'Outside'
         }).to raise_error(Cucumber::UndefinedDynamicStep)
       end
 
-      it "allows forced pending" do
+      it 'allows forced pending' do
         dsl.Given(/Outside/) do
-          pending("Do me!")
+          pending('Do me!')
         end
 
         expect(-> {
-          run_step "Outside"
-        }).to raise_error(Cucumber::Pending, "Do me!")
+          run_step 'Outside'
+        }).to raise_error(Cucumber::Pending, 'Do me!')
       end
 
-      it "raises ArityMismatchError when the number of capture groups differs from the number of step arguments" do
+      it 'raises ArityMismatchError when the number of capture groups differs from the number of step arguments' do
         dsl.Given(/No group: \w+/) do |arg|
         end
 
         expect(-> {
-          run_step "No group: arg"
+          run_step 'No group: arg'
         }).to raise_error(Cucumber::ArityMismatchError)
       end
 
-      it "does not modify the step_match arg when arg is modified in a step" do
+      it 'does not modify the step_match arg when arg is modified in a step' do
         dsl.Given(/My car is (.*)/) do |colour|
-          colour << "xxx"
+          colour << 'xxx'
         end
 
-        step_name = "My car is white"
+        step_name = 'My car is white'
         step_args = step_match(step_name).args
 
         expect(-> {
@@ -176,24 +176,24 @@ module Cucumber
         }).not_to change{ step_args.first }
       end
 
-      it "allows puts" do
+      it 'allows puts' do
         expect(user_interface).to  receive(:puts).with('wasup')
         dsl.Given(/Loud/) do
           puts 'wasup'
         end
-        run_step "Loud"
+        run_step 'Loud'
       end
 
-      it "recognizes $arg style captures" do
-        arg_value = "wow!"
-        dsl.Given "capture this: $arg" do |arg|
+      it 'recognizes $arg style captures' do
+        arg_value = 'wow!'
+        dsl.Given 'capture this: $arg' do |arg|
           expect(arg).to eq arg_value
         end
-        run_step "capture this: wow!"
+        run_step 'capture this: wow!'
       end
 
-      it "has a JSON representation of the signature" do
-        expect(RbStepDefinition.new(rb, /I CAN HAZ (\d+) CUKES/i, lambda{}, {}).to_hash).to eq({ 'source' => "I CAN HAZ (\\d+) CUKES", 'flags' => 'i' })
+      it 'has a JSON representation of the signature' do
+        expect(RbStepDefinition.new(rb, /I CAN HAZ (\d+) CUKES/i, lambda{}, {}).to_hash).to eq({ 'source' => 'I CAN HAZ (\\d+) CUKES', 'flags' => 'i' })
       end
     end
   end

--- a/spec/cucumber/rb_support/rb_transform_spec.rb
+++ b/spec/cucumber/rb_support/rb_transform_spec.rb
@@ -9,37 +9,37 @@ module Cucumber
         RbTransform.new(nil, regexp, lambda { |a| })
       end
 
-      describe "#to_s" do
-        it "does not touch positive lookahead captures" do
-          expect(transform(/^xy(?=z)/).to_s).to eq "xy(?=z)"
+      describe '#to_s' do
+        it 'does not touch positive lookahead captures' do
+          expect(transform(/^xy(?=z)/).to_s).to eq 'xy(?=z)'
         end
 
-        it "does not touch negative lookahead captures" do
-          expect(transform(/^xy(?!z)/).to_s).to eq "xy(?!z)"
+        it 'does not touch negative lookahead captures' do
+          expect(transform(/^xy(?!z)/).to_s).to eq 'xy(?!z)'
         end
 
-        it "does not touch positive lookbehind captures" do
-          expect(transform(/^xy(?<=z)/).to_s).to eq "xy(?<=z)"
+        it 'does not touch positive lookbehind captures' do
+          expect(transform(/^xy(?<=z)/).to_s).to eq 'xy(?<=z)'
         end
 
-        it "does not touch negative lookbehind captures" do
-          expect(transform(/^xy(?<!z)/).to_s).to eq "xy(?<!z)"
+        it 'does not touch negative lookbehind captures' do
+          expect(transform(/^xy(?<!z)/).to_s).to eq 'xy(?<!z)'
         end
 
-        it "converts named captures" do
-          expect(transform(/^(?<str>xyz)/).to_s).to eq "(?:<str>xyz)"
+        it 'converts named captures' do
+          expect(transform(/^(?<str>xyz)/).to_s).to eq '(?:<str>xyz)'
         end
 
-        it "converts captures groups to non-capture groups" do
-          expect(transform(/(a|b)bc/).to_s).to eq "(?:a|b)bc"
+        it 'converts captures groups to non-capture groups' do
+          expect(transform(/(a|b)bc/).to_s).to eq '(?:a|b)bc'
         end
 
-        it "leaves non capture groups alone" do
-          expect(transform(/(?:a|b)bc/).to_s).to eq "(?:a|b)bc"
+        it 'leaves non capture groups alone' do
+          expect(transform(/(?:a|b)bc/).to_s).to eq '(?:a|b)bc'
         end
 
-        it "strips away anchors" do
-          expect(transform(/^xyz$/).to_s).to eq "xyz"
+        it 'strips away anchors' do
+          expect(transform(/^xyz$/).to_s).to eq 'xyz'
         end
       end
     end

--- a/spec/cucumber/rb_support/snippet_spec.rb
+++ b/spec/cucumber/rb_support/snippet_spec.rb
@@ -5,7 +5,7 @@ require 'cucumber/rb_support/snippet'
 module Cucumber
   module RbSupport
     describe Snippet do
-      let(:code_keyword) { "Given" }
+      let(:code_keyword) { 'Given' }
 
       before do
         @pattern = 'we have a missing step'
@@ -24,7 +24,7 @@ module Cucumber
         let(:snippet_class) { Snippet::Regexp }
         let(:snippet_text) { snippet.to_s }
 
-        it "wraps snippet patterns in parentheses" do
+        it 'wraps snippet patterns in parentheses' do
           @pattern = 'A "string" with 4 spaces'
 
           expect(snippet_text).to eq unindented(%{
@@ -34,7 +34,7 @@ module Cucumber
           })
         end
 
-        it "recognises numbers in name and make according regexp" do
+        it 'recognises numbers in name and make according regexp' do
           @pattern = 'Cloud 9 yeah'
 
           expect(snippet_text).to eq unindented(%{
@@ -44,7 +44,7 @@ module Cucumber
           })
         end
 
-        it "recognises a mix of ints, strings and why not a table too" do
+        it 'recognises a mix of ints, strings and why not a table too' do
           @pattern = 'I have 9 "awesome" cukes in 37 "boxes"'
           @multiline_argument = Core::Ast::DataTable.new([[]], Core::Ast::Location.new(''))
 
@@ -56,7 +56,7 @@ module Cucumber
           })
         end
 
-        it "recognises quotes in name and make according regexp" do
+        it 'recognises quotes in name and make according regexp' do
           @pattern = 'A "first" arg'
 
           expect(snippet_text).to eq unindented(%{
@@ -66,7 +66,7 @@ module Cucumber
           })
         end
 
-        it "recognises several quoted words in name and make according regexp and args" do
+        it 'recognises several quoted words in name and make according regexp and args' do
           @pattern = 'A "first" and "second" arg'
 
           expect(snippet_text).to eq unindented(%{
@@ -76,7 +76,7 @@ module Cucumber
           })
         end
 
-        it "does not use quote group when there are no quotes" do
+        it 'does not use quote group when there are no quotes' do
           @pattern = 'A first arg'
 
           expect(snippet_text).to eq unindented(%{
@@ -86,9 +86,9 @@ module Cucumber
           })
         end
 
-        it "is helpful with tables" do
+        it 'is helpful with tables' do
           @pattern = 'A "first" arg'
-          @multiline_argument = Core::Ast::DataTable.new([[]], Core::Ast::Location.new(""))
+          @multiline_argument = Core::Ast::DataTable.new([[]], Core::Ast::Location.new(''))
 
           expect(snippet_text).to eq unindented(%{
           Given(/^A "([^"]*)" arg$/) do |arg1, table|
@@ -98,9 +98,9 @@ module Cucumber
           })
         end
 
-        it "is helpful with doc string" do
+        it 'is helpful with doc string' do
           @pattern = 'A "first" arg'
-          @multiline_argument = MultilineArgument.from("", Core::Ast::Location.new(""))
+          @multiline_argument = MultilineArgument.from('', Core::Ast::Location.new(''))
 
           expect(snippet_text).to eq unindented(%{
           Given(/^A "([^"]*)" arg$/) do |arg1, string|
@@ -113,7 +113,7 @@ module Cucumber
       describe Snippet::Classic do
         let(:snippet_class) { Snippet::Classic }
 
-        it "renders snippet as unwrapped regular expression" do
+        it 'renders snippet as unwrapped regular expression' do
           expect(snippet.to_s).to eq unindented(%{
           Given /^we have a missing step$/ do
             pending # Write code here that turns the phrase above into concrete actions
@@ -125,7 +125,7 @@ module Cucumber
       describe Snippet::Percent do
         let(:snippet_class) { Snippet::Percent }
 
-        it "renders snippet as percent-style regular expression" do
+        it 'renders snippet as percent-style regular expression' do
           expect(snippet.to_s).to eq unindented(%{
           Given %r{^we have a missing step$} do
             pending # Write code here that turns the phrase above into concrete actions

--- a/spec/cucumber/running_test_case_spec.rb
+++ b/spec/cucumber/running_test_case_spec.rb
@@ -21,42 +21,42 @@ module Cucumber
       compile [gherkin_doc], receiver
     end
 
-    context "for a regular scenario" do
+    context 'for a regular scenario' do
       let(:gherkin_doc) do
         gherkin do
-          feature "feature name" do
-            scenario "scenario name" do
-              step "passing"
+          feature 'feature name' do
+            scenario 'scenario name' do
+              step 'passing'
             end
           end
         end
       end
 
-      it "sets the scenario name correctly" do
-        expect(wrapped_test_case.name).to eq "scenario name"
+      it 'sets the scenario name correctly' do
+        expect(wrapped_test_case.name).to eq 'scenario name'
       end
 
-      it "sets the feature name correctly" do
-        expect(wrapped_test_case.feature.name).to eq "feature name"
+      it 'sets the feature name correctly' do
+        expect(wrapped_test_case.feature.name).to eq 'feature name'
       end
 
-      it "exposes properties of the test_case" do
+      it 'exposes properties of the test_case' do
         expect(wrapped_test_case.location).to eq core_test_case.location
         expect(wrapped_test_case.source).to eq core_test_case.source
         expect(wrapped_test_case.keyword).to eq core_test_case.keyword
       end
 
-      it "exposes properties of the result" do
+      it 'exposes properties of the result' do
         expect(wrapped_test_case.status).to eq result.to_sym
       end
     end
 
-    context "for a failed scenario" do
+    context 'for a failed scenario' do
       let(:gherkin_doc) do
         gherkin do
-          feature "feature name" do
-            scenario "scenario name" do
-              step "failed"
+          feature 'feature name' do
+            scenario 'scenario name' do
+              step 'failed'
             end
           end
         end
@@ -68,21 +68,21 @@ module Cucumber
         self.wrapped_test_case = self.wrapped_test_case.with_result(Core::Test::Result::Failed.new(0, exception))
       end
 
-      it "is failed?" do
+      it 'is failed?' do
         expect(wrapped_test_case.failed?).to be_truthy
       end
 
-      it "exposes the exception" do
+      it 'exposes the exception' do
         expect(wrapped_test_case.exception).to eq exception
       end
     end
 
-    context "for a passing scenario" do
+    context 'for a passing scenario' do
       let(:gherkin_doc) do
         gherkin do
-          feature "feature name" do
-            scenario "scenario name" do
-              step "passing"
+          feature 'feature name' do
+            scenario 'scenario name' do
+              step 'passing'
             end
           end
         end
@@ -92,25 +92,25 @@ module Cucumber
         self.wrapped_test_case = self.wrapped_test_case.with_result(Core::Test::Result::Passed.new(0))
       end
 
-      it "is not failed?" do
+      it 'is not failed?' do
         expect(wrapped_test_case.failed?).to be_falsey
       end
 
-      it "#exception is nil" do
+      it '#exception is nil' do
         expect(wrapped_test_case.exception).to be_nil
       end
     end
 
-    context "for a scenario outline" do
+    context 'for a scenario outline' do
       let(:gherkin_doc) do
         gherkin do
-          feature "feature name" do
-            scenario_outline "scenario outline name" do
-              step "passing with <arg1> <arg2>"
+          feature 'feature name' do
+            scenario_outline 'scenario outline name' do
+              step 'passing with <arg1> <arg2>'
 
-              examples "examples name" do
-                row "arg1", "arg2"
-                row "a", "b"
+              examples 'examples name' do
+                row 'arg1', 'arg2'
+                row 'a', 'b'
               end
             end
           end
@@ -118,21 +118,21 @@ module Cucumber
       end
 
       it "sets the test case's name correctly" do
-        expect(wrapped_test_case.name).to eq "scenario outline name, examples name (#1)"
+        expect(wrapped_test_case.name).to eq 'scenario outline name, examples name (#1)'
       end
 
-      it "sets the feature name correctly" do
-        expect(wrapped_test_case.feature.name).to eq "feature name"
+      it 'sets the feature name correctly' do
+        expect(wrapped_test_case.feature.name).to eq 'feature name'
       end
 
-      it "exposes properties of the test_case" do
+      it 'exposes properties of the test_case' do
         expect(wrapped_test_case.location).to eq core_test_case.location
         expect(wrapped_test_case.source).to eq core_test_case.source
         expect(wrapped_test_case.keyword).to eq core_test_case.keyword
       end
 
-      it "exposes the examples table row cell values" do
-        expect(wrapped_test_case.cell_values).to eq ["a", "b"]
+      it 'exposes the examples table row cell values' do
+        expect(wrapped_test_case.cell_values).to eq ['a', 'b']
       end
 
     end

--- a/spec/cucumber/runtime/for_programming_languages_spec.rb
+++ b/spec/cucumber/runtime/for_programming_languages_spec.rb
@@ -8,7 +8,7 @@ module Cucumber
     subject               { Runtime::SupportCode.new(user_interface) }
     let(:runtime_facade)  { Runtime::ForProgrammingLanguages.new(subject, user_interface) }
 
-    describe "#doc_string" do
+    describe '#doc_string' do
 
       it 'defaults to a blank content-type' do
         str = runtime_facade.doc_string('DOC')
@@ -23,7 +23,7 @@ module Cucumber
 
     end
 
-    describe "#table" do
+    describe '#table' do
 
       it 'produces Ast::Table by #table' do
         expect(runtime_facade.table(%{

--- a/spec/cucumber/runtime_spec.rb
+++ b/spec/cucumber/runtime_spec.rb
@@ -6,10 +6,10 @@ module Cucumber
     subject { Runtime.new(options) }
     let(:options) { {} }
 
-    describe "#features_paths" do
+    describe '#features_paths' do
       let(:options) { {:paths => ['foo/bar/baz.feature', 'foo/bar/features/baz.feature', 'other_features'] } }
 
-      it "returns the value from configuration.paths" do
+      it 'returns the value from configuration.paths' do
         expect(subject.features_paths).to eq options[:paths]
       end
     end

--- a/spec/cucumber/step_argument_spec.rb
+++ b/spec/cucumber/step_argument_spec.rb
@@ -4,16 +4,16 @@ require 'cucumber/step_argument'
 
 module Cucumber
   describe StepArgument do
-    it "creates 2 arguments" do
-      arguments = StepArgument.arguments_from(/I (\w+) (\w+)/, "I like fish")
+    it 'creates 2 arguments' do
+      arguments = StepArgument.arguments_from(/I (\w+) (\w+)/, 'I like fish')
 
-      expect(arguments.map{|argument| [argument.val, argument.offset]}).to eq [["like", 2], ["fish", 7]]
+      expect(arguments.map{|argument| [argument.val, argument.offset]}).to eq [['like', 2], ['fish', 7]]
     end
 
-    it "creates 2 arguments when first group is optional" do
+    it 'creates 2 arguments when first group is optional' do
       arguments = StepArgument.arguments_from(/should( not)? be flashed '([^']*?)'$/, "I should be flashed 'Login failed.'")
 
-      expect(arguments.map{|argument| [argument.val, argument.offset]}).to eq [[nil, nil], ["Login failed.", 21]]
+      expect(arguments.map{|argument| [argument.val, argument.offset]}).to eq [[nil, nil], ['Login failed.', 21]]
     end
   end
 end

--- a/spec/cucumber/step_match_search_spec.rb
+++ b/spec/cucumber/step_match_search_spec.rb
@@ -22,21 +22,21 @@ module Cucumber
     end
 
     context 'caching' do
-      it "caches step match results" do
+      it 'caches step match results' do
         dsl.Given(/it (.*) in (.*)/) { |what, month| }
 
-        step_match = search.call("it snows in april").first
+        step_match = search.call('it snows in april').first
 
         expect(rb_language).not_to receive(:step_matches)
-        second_step_match = search.call("it snows in april").first
+        second_step_match = search.call('it snows in april').first
 
         expect(step_match).to equal(second_step_match)
       end
     end
 
-    describe "resolving step defintion matches" do
+    describe 'resolving step defintion matches' do
 
-      it "raises Ambiguous error with guess hint when multiple step definitions match" do
+      it 'raises Ambiguous error with guess hint when multiple step definitions match' do
         expected_error = %{Ambiguous match of "Three blind mice":
 
 spec/cucumber/step_match_search_spec.rb:\\d+:in `/Three (.*) mice/'
@@ -48,14 +48,14 @@ You can run again with --guess to make Cucumber be more smart about it
         dsl.Given(/Three blind (.*)/) {|animal|}
 
         expect(-> {
-          search.call("Three blind mice").first
+          search.call('Three blind mice').first
         }).to raise_error(Ambiguous, /#{expected_error}/)
       end
 
-      describe "when --guess is used" do
+      describe 'when --guess is used' do
         let(:options) { {:guess => true} }
 
-        it "does not show --guess hint" do
+        it 'does not show --guess hint' do
         expected_error = %{Ambiguous match of "Three cute mice":
 
 spec/cucumber/step_match_search_spec.rb:\\d+:in `/Three (.*) mice/'
@@ -66,48 +66,48 @@ spec/cucumber/step_match_search_spec.rb:\\d+:in `/Three cute (.*)/'
           dsl.Given(/Three cute (.*)/) {|animal|}
 
           expect(-> {
-            search.call("Three cute mice").first
+            search.call('Three cute mice').first
           }).to raise_error(Ambiguous, /#{expected_error}/)
         end
 
-        it "does not raise Ambiguous error when multiple step definitions match" do
+        it 'does not raise Ambiguous error when multiple step definitions match' do
           dsl.Given(/Three (.*) mice/) {|disability|}
           dsl.Given(/Three (.*)/) {|animal|}
 
           expect(-> {
-            search.call("Three blind mice").first
+            search.call('Three blind mice').first
           }).not_to raise_error
         end
 
-        it "does not raise NoMethodError when guessing from multiple step definitions with nil fields" do
+        it 'does not raise NoMethodError when guessing from multiple step definitions with nil fields' do
           dsl.Given(/Three (.*) mice( cannot find food)?/) {|disability, is_disastrous|}
           dsl.Given(/Three (.*)?/) {|animal|}
 
           expect(-> {
-            search.call("Three blind mice").first
+            search.call('Three blind mice').first
           }).not_to raise_error
         end
 
-        it "picks right step definition when an equal number of capture groups" do
+        it 'picks right step definition when an equal number of capture groups' do
           right = dsl.Given(/Three (.*) mice/) {|disability|}
           wrong = dsl.Given(/Three (.*)/) {|animal|}
 
-          expect(search.call("Three blind mice").first.step_definition).to eq right
+          expect(search.call('Three blind mice').first.step_definition).to eq right
         end
 
-        it "picks right step definition when an unequal number of capture groups" do
+        it 'picks right step definition when an unequal number of capture groups' do
           right = dsl.Given(/Three (.*) mice ran (.*)/) {|disability|}
           wrong = dsl.Given(/Three (.*)/) {|animal|}
 
-          expect(search.call("Three blind mice ran far").first.step_definition).to eq right
+          expect(search.call('Three blind mice ran far').first.step_definition).to eq right
         end
 
-        it "picks most specific step definition when an unequal number of capture groups" do
+        it 'picks most specific step definition when an unequal number of capture groups' do
           general       = dsl.Given(/Three (.*) mice ran (.*)/) {|disability|}
           specific      = dsl.Given(/Three blind mice ran far/) do; end
           more_specific = dsl.Given(/^Three blind mice ran far$/) do; end
 
-          expect(search.call("Three blind mice ran far").first.step_definition).to eq more_specific
+          expect(search.call('Three blind mice ran far').first.step_definition).to eq more_specific
         end
       end
 

--- a/spec/cucumber/step_match_spec.rb
+++ b/spec/cucumber/step_match_spec.rb
@@ -21,66 +21,66 @@ module Cucumber
       StepMatch.new(stepdef, name, stepdef.arguments_from(name))
     end
 
-    it "formats step names" do
-      m = step_match(/it (.*) in (.*)/, "it snows in april")
-      format = m.format_args("[%s]")
-      expect(format).to eq "it [snows] in [april]"
+    it 'formats step names' do
+      m = step_match(/it (.*) in (.*)/, 'it snows in april')
+      format = m.format_args('[%s]')
+      expect(format).to eq 'it [snows] in [april]'
     end
 
-    it "formats one group when we use Unicode" do
+    it 'formats one group when we use Unicode' do
       m = step_match(/I (#{WORD}+) ok/, "I æøåÆØÅæøåÆØÅæøåÆØÅæøåÆØÅ ok")
 
-      expect(m.format_args("<span>%s</span>")).to eq "I <span>æøåÆØÅæøåÆØÅæøåÆØÅæøåÆØÅ</span> ok"
+      expect(m.format_args('<span>%s</span>')).to eq "I <span>æøåÆØÅæøåÆØÅæøåÆØÅæøåÆØÅ</span> ok"
     end
 
-    it "formats several groups when we use Unicode" do
+    it 'formats several groups when we use Unicode' do
       m = step_match(/I (#{WORD}+) (#{WORD}+) (#{WORD}+) this (#{WORD}+)/, "I ate æøåÆØÅæøåÆØÅæøåÆØÅæøåÆØÅ egg this morning")
 
-      expect(m.format_args("<span>%s</span>")).to eq "I <span>ate</span> <span>æøåÆØÅæøåÆØÅæøåÆØÅæøåÆØÅ</span> <span>egg</span> this <span>morning</span>"
+      expect(m.format_args('<span>%s</span>')).to eq "I <span>ate</span> <span>æøåÆØÅæøåÆØÅæøåÆØÅæøåÆØÅ</span> <span>egg</span> this <span>morning</span>"
     end
 
-    it "deals with Unicode both inside and outside arguments" do
+    it 'deals with Unicode both inside and outside arguments' do
       expect("Jæ vø ålsker døtte løndet").to match(/Jæ (.+) ålsker (.+) løndet/)
 
       m = step_match(/Jæ (#{WORD}+) ålsker (#{WORD}+) løndet/, "Jæ vø ålsker døtte løndet")
 
-      expect(m.format_args("<span>%s</span>")).to eq "Jæ <span>vø</span> ålsker <span>døtte</span> løndet"
+      expect(m.format_args('<span>%s</span>')).to eq "Jæ <span>vø</span> ålsker <span>døtte</span> løndet"
     end
 
-    it "formats groups with format string" do
-      m = step_match(/I (#{WORD}+) (\d+) (#{WORD}+) this (#{WORD}+)/, "I ate 1 egg this morning")
+    it 'formats groups with format string' do
+      m = step_match(/I (#{WORD}+) (\d+) (#{WORD}+) this (#{WORD}+)/, 'I ate 1 egg this morning')
 
-      expect(m.format_args("<span>%s</span>")).to eq "I <span>ate</span> <span>1</span> <span>egg</span> this <span>morning</span>"
+      expect(m.format_args('<span>%s</span>')).to eq 'I <span>ate</span> <span>1</span> <span>egg</span> this <span>morning</span>'
     end
 
-    it "formats groups with format string when there are dupes" do
-      m = step_match(/I (#{WORD}+) (\d+) (#{WORD}+) this (#{WORD}+)/, "I bob 1 bo this bobs")
+    it 'formats groups with format string when there are dupes' do
+      m = step_match(/I (#{WORD}+) (\d+) (#{WORD}+) this (#{WORD}+)/, 'I bob 1 bo this bobs')
 
-      expect(m.format_args("<span>%s</span>")).to eq "I <span>bob</span> <span>1</span> <span>bo</span> this <span>bobs</span>"
+      expect(m.format_args('<span>%s</span>')).to eq 'I <span>bob</span> <span>1</span> <span>bo</span> this <span>bobs</span>'
     end
 
-    it "formats groups with block" do
-      m = step_match(/I (#{WORD}+) (\d+) (#{WORD}+) this (#{WORD}+)/, "I ate 1 egg this morning")
+    it 'formats groups with block' do
+      m = step_match(/I (#{WORD}+) (\d+) (#{WORD}+) this (#{WORD}+)/, 'I ate 1 egg this morning')
 
-      expect(m.format_args(&lambda{|m| "<span>#{m}</span>"})).to eq "I <span>ate</span> <span>1</span> <span>egg</span> this <span>morning</span>"
+      expect(m.format_args(&lambda{|m| "<span>#{m}</span>"})).to eq 'I <span>ate</span> <span>1</span> <span>egg</span> this <span>morning</span>'
     end
 
-    it "formats groups with proc object" do
-      m = step_match(/I (#{WORD}+) (\d+) (#{WORD}+) this (#{WORD}+)/, "I ate 1 egg this morning")
+    it 'formats groups with proc object' do
+      m = step_match(/I (#{WORD}+) (\d+) (#{WORD}+) this (#{WORD}+)/, 'I ate 1 egg this morning')
 
-      expect(m.format_args(lambda{|m| "<span>#{m}</span>"})).to eq "I <span>ate</span> <span>1</span> <span>egg</span> this <span>morning</span>"
+      expect(m.format_args(lambda{|m| "<span>#{m}</span>"})).to eq 'I <span>ate</span> <span>1</span> <span>egg</span> this <span>morning</span>'
     end
 
-    it "formats groups even when first group is optional and not matched" do
+    it 'formats groups even when first group is optional and not matched' do
       m = step_match(/should( not)? be flashed '([^']*?)'$/, "I should be flashed 'Login failed.'")
 
-      expect(m.format_args("<span>%s</span>")).to eq "I should be flashed '<span>Login failed.</span>'"
+      expect(m.format_args('<span>%s</span>')).to eq "I should be flashed '<span>Login failed.</span>'"
     end
 
-    it "formats embedded groups" do
-      m = step_match(/running( (\d+) times)? (\d+) meters/, "running 5 times 10 meters")
+    it 'formats embedded groups' do
+      m = step_match(/running( (\d+) times)? (\d+) meters/, 'running 5 times 10 meters')
 
-      expect(m.format_args("<span>%s</span>")).to eq "running<span> 5 times</span> <span>10</span> meters"
+      expect(m.format_args('<span>%s</span>')).to eq 'running<span> 5 times</span> <span>10</span> meters'
     end
   end
 end

--- a/spec/cucumber/world/pending_spec.rb
+++ b/spec/cucumber/world/pending_spec.rb
@@ -13,21 +13,21 @@ module Cucumber
 
     it 'raises a Pending if no block is supplied' do
       expect(-> {
-        @world.pending "TODO"
+        @world.pending 'TODO'
       }).to raise_error(Cucumber::Pending, /TODO/)
     end
 
     it 'raises a Pending if a supplied block fails as expected' do
       expect(-> {
-        @world.pending "TODO" do
-        raise "oops"
+        @world.pending 'TODO' do
+        raise 'oops'
         end
       }).to raise_error(Cucumber::Pending, /TODO/)
     end
 
     it 'raises a Pending if a supplied block fails as expected with a double' do
       expect do
-        @world.pending "TODO" do
+        @world.pending 'TODO' do
           m = double('thing')
           expect(m).to receive(:foo)
           RSpec::Mocks.verify
@@ -39,7 +39,7 @@ module Cucumber
 
     it 'raises a Pending if a supplied block starts working' do
       expect(-> {
-        @world.pending "TODO" do
+        @world.pending 'TODO' do
         # success!
         end
       }).to raise_error(Cucumber::Pending, /TODO/)


### PR DESCRIPTION
## Summary

Fixed the `Style/StringLiteral` [rubocop](https://github.com/bbatsov/rubocop) offending code.

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

This change fix part of #1021. It does not fix it completely, but only partially. Other PRs will follow on same issue.

## How Has This Been Tested?

No new tests have been added. But existing tests run green. Also [rubocop](https://github.com/bbatsov/rubocop) is happy with the `Style/StringLiterals` enabled.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Style changes to make [rubocop](https://github.com/bbatsov/rubocop) happy.

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

