### PR TITLE
Fixes rubocop violation Lint/StringConversionInInterpolation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -85,15 +85,6 @@ Lint/ShadowingOuterLocalVariable:
     - 'lib/cucumber/multiline_argument/data_table.rb'
     - 'spec/cucumber/step_match_spec.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Lint/StringConversionInInterpolation:
-  Exclude:
-    - 'lib/cucumber/formatter/html.rb'
-    - 'lib/cucumber/rb_support/rb_language.rb'
-    - 'lib/cucumber/rb_support/rb_step_definition.rb'
-    - 'lib/cucumber/rb_support/snippet.rb'
-
 # Offense count: 69
 # Cop supports --auto-correct.
 # Configuration parameters: AllowUnusedKeywordArguments.

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -619,7 +619,7 @@ module Cucumber
       def print_status_counts
         counts = [:failed, :skipped, :undefined, :pending, :passed].map do |status|
           elements = yield status
-          elements.any? ? "#{elements.length} #{status.to_s}" : nil
+          elements.any? ? "#{elements.length} #{status}" : nil
         end.compact
         return " (#{counts.join(', ')})" if counts.any?
       end

--- a/lib/cucumber/rb_support/rb_language.rb
+++ b/lib/cucumber/rb_support/rb_language.rb
@@ -221,7 +221,7 @@ module Cucumber
 
     def self.backtrace_line(proc, name)
       location = Cucumber::Core::Ast::Location.from_source_location(*proc.source_location)
-      "#{location.to_s}:in `#{name}'"
+      "#{location}:in `#{name}'"
     end
   end
 end

--- a/lib/cucumber/rb_support/rb_step_definition.rb
+++ b/lib/cucumber/rb_support/rb_step_definition.rb
@@ -108,7 +108,7 @@ module Cucumber
       end
 
       def backtrace_line
-        "#{location.to_s}:in `#{regexp_source}'"
+        "#{location}:in `#{regexp_source}'"
       end
 
       def file_colon_line

--- a/lib/cucumber/rb_support/snippet.rb
+++ b/lib/cucumber/rb_support/snippet.rb
@@ -154,7 +154,7 @@ module Cucumber
           end
 
           def append_comment_to(string)
-            string << "  # table is a #{Cucumber::MultilineArgument::DataTable.to_s}\n"
+            string << "  # table is a #{Cucumber::MultilineArgument::DataTable}\n"
           end
         end
 


### PR DESCRIPTION
## Summary

Fixes rubocop violation Lint/StringConversionInInterpolation

## Details

All the `*.to_s` calls inside interpolations have been fixed: Removed `.to_s`.

## Motivation and Context

This change is required to satisfy the ruboxop requirement related to Lint/StringConversionInInterpolation

Refs #1021 

## How Has This Been Tested?

No new tests. Existing tests are green (with `bundle exec rake`). Rubocop is happy.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Changes in interpolations to avoid using `.to_s` in string interpolations

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
