### PR TITLE
Fixes rubocop violation Performance/StringReplacement

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -153,13 +153,12 @@ Performance/RedundantMatch:
     - 'lib/cucumber/deprecate.rb'
     - 'spec/cucumber/formatter/junit_spec.rb'
 
-# Offense count: 5
+# Offense count: 8
 # Cop supports --auto-correct.
-Performance/StringReplacement:
-  Exclude:
-    - 'features/lib/support/feature_factory.rb'
-    - 'lib/cucumber/configuration.rb'
-    - 'lib/cucumber/formatter/json.rb'
+# Configuration parameters: EnforcedStyle, SupportedStyles, IndentationWidth.
+# SupportedStyles: outdent, indent
+Style/AccessModifierIndentation:
+  Enabled: false
 
 # Offense count: 6
 Style/AccessorMethodName:

--- a/features/lib/support/feature_factory.rb
+++ b/features/lib/support/feature_factory.rb
@@ -55,7 +55,7 @@ Feature: #{name}
   end
 
   def filename(name)
-    "features/#{name.downcase.gsub(' ', '_')}.feature"
+    "features/#{name.downcase.tr(' ', '_')}.feature"
   end
 
   def features

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -153,7 +153,7 @@ module Cucumber
 
     def feature_files
       potential_feature_files = with_default_features_path(paths).map do |path|
-        path = path.gsub(/\\/, '/') # In case we're on windows. Globs don't work with backslashes.
+        path = path.tr('\\', '/') # In case we're on windows. Globs don't work with backslashes.
         path = path.chomp('/')
 
         # TODO: Move to using feature loading strategies stored in
@@ -179,7 +179,7 @@ module Cucumber
 
     def all_files_to_load
       files = require_dirs.map do |path|
-        path = path.gsub(/\\/, '/') # In case we're on windows. Globs don't work with backslashes.
+        path = path.tr('\\', '/') # In case we're on windows. Globs don't work with backslashes.
         path = path.gsub(/\/$/, '') # Strip trailing slash.
         File.directory?(path) ? Dir["#{path}/**/*"] : path
       end.flatten.uniq

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -218,7 +218,7 @@ module Cucumber
 
       def encode64(data)
         # strip newlines from the encoded data
-        Base64.encode64(data).gsub(/\n/, '')
+        Base64.encode64(data).delete("\n")
       end
 
       class Builder
@@ -316,7 +316,7 @@ module Cucumber
         private
 
         def create_id(element)
-          element.name.downcase.gsub(/ /, '-')
+          element.name.downcase.tr(' ', '-')
         end
 
         def create_tags_array(tags)


### PR DESCRIPTION
## Summary

<!--- Provide a general summary description of your changes -->

Fixes rubocop violation Performance/StringReplacement
## Details

Changes to stop using `.gsub()` to do character replacements, but use `,tr()` instead. Also, when
`.gsub()` was used to delete a character, we are now using `.delete()`.
## Motivation and Context

This change makes sure our code is compliant with the ruboxop `Performance/StringReplacemenet` rule

Refs #1021 
## How Has This Been Tested?

I have run all the tests with `bundle exec rake` and everything is green. Rubocop is happy too.
## Screenshots (if appropriate):

N/A
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvements
## Checklist:
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
