### PR TITLE
Fixes rubocop violation Style/FormatString

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -555,18 +555,6 @@ Style/FirstParameterIndentation:
   Exclude:
     - 'spec/cucumber/rake/forked_spec.rb'
 
-# Offense count: 9
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: format, sprintf, percent
-Style/FormatString:
-  Exclude:
-    - 'lib/cucumber/formatter/duration.rb'
-    - 'lib/cucumber/formatter/junit.rb'
-    - 'lib/cucumber/formatter/usage.rb'
-    - 'lib/cucumber/rake/task.rb'
-    - 'lib/cucumber/rb_support/rb_world.rb'
-    - 'lib/cucumber/rb_support/snippet.rb'
-
 # Offense count: 13
 # Configuration parameters: AllowedVariables.
 Style/GlobalVars:

--- a/lib/cucumber/formatter/duration.rb
+++ b/lib/cucumber/formatter/duration.rb
@@ -7,7 +7,7 @@ module Cucumber
       # <tt>time</tt> format.
       def format_duration(seconds)
         m, s = seconds.divmod(60)
-        "#{m}m#{'%.3f' % s}s"
+        "#{m}m#{format('%.3f', s)}s"
       end
     end
   end

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -92,7 +92,7 @@ module Cucumber
           :errors => feature_data[:errors],
           :skipped => feature_data[:skipped],
           :tests => feature_data[:tests],
-          :time => '%.6f' % feature_data[:time],
+          :time => format('%.6f', feature_data[:time]),
           :name => feature_data[:feature].name ) do
           @testsuite << feature_data[:builder].target!
         end
@@ -122,7 +122,7 @@ module Cucumber
         classname = @current_feature_data[:feature].name
         name = scenario_designation
 
-        @current_feature_data[:builder].testcase(:classname => classname, :name => name, :time => '%.6f' % duration) do
+        @current_feature_data[:builder].testcase(:classname => classname, :name => name, :time => format('%.6f', duration)) do
           if !result.passed? && result.ok?(@config.strict?)
             @current_feature_data[:builder].skipped
             @current_feature_data[:skipped] += 1

--- a/lib/cucumber/formatter/usage.rb
+++ b/lib/cucumber/formatter/usage.rb
@@ -79,7 +79,7 @@ module Cucumber
       end
 
       def print_step_definition(stepdef_key)
-        @io.print format_string(sprintf('%.7f', stepdef_key.mean_duration), :skipped) + ' ' unless config.dry_run?
+        @io.print format_string(format('%.7f', stepdef_key.mean_duration), :skipped) + ' ' unless config.dry_run?
         @io.print format_string(stepdef_key.regexp_source, stepdef_key.status)
         if config.source?
           indent = max_length - stepdef_key.regexp_source.unpack('U*').length
@@ -92,7 +92,7 @@ module Cucumber
       def print_steps(stepdef_key)
         @stepdef_to_match[stepdef_key].each do |step|
           @io.print '  '
-          @io.print format_string(sprintf('%.7f', step[:duration]), :skipped) + ' ' unless config.dry_run?
+          @io.print format_string(format('%.7f', step[:duration]), :skipped) + ' ' unless config.dry_run?
           @io.print format_step(step[:keyword], step[:step_match], step[:status], nil)
           if config.source?
             indent = max_length - (step[:keyword].unpack('U*').length + step[:step_match].format_args.unpack('U*').length)

--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -62,11 +62,11 @@ module Cucumber
         end
 
         def load_path(libs)
-          ['"%s"' % @libs.join(File::PATH_SEPARATOR)]
+          [format('"%s"', @libs.join(File::PATH_SEPARATOR))]
         end
 
         def quoted_binary(cucumber_bin)
-          ['"%s"' % cucumber_bin]
+          [format('"%s"', cucumber_bin)]
         end
 
         def use_bundler

--- a/lib/cucumber/rb_support/rb_world.rb
+++ b/lib/cucumber/rb_support/rb_world.rb
@@ -125,7 +125,7 @@ module Cucumber
           modules += included_modules
         end
         modules << stringify_namespaced_modules
-        sprintf('#<%s:0x%x>', modules.join('+'), self.object_id)
+        format('#<%s:0x%x>', modules.join('+'), self.object_id)
       end
 
       # see {#inspect}

--- a/lib/cucumber/rb_support/snippet.rb
+++ b/lib/cucumber/rb_support/snippet.rb
@@ -38,7 +38,7 @@ module Cucumber
         end
 
         def self.cli_option_string(type)
-          '%-7s: %-28s e.g. %s' % [type, description, example]
+          format('%-7s: %-28s e.g. %s', type, description, example)
         end
 
         private


### PR DESCRIPTION
## Summary

<!--- Provide a general summary description of your changes -->
It fixes the rubocop violation `Style/FormatString`. The suggestion from rubocop is to use `Kernel#format` instead of the cryptic `String#%`. Also, it favours the `Kernel#format` over the `Kernal#sprintf` although the former is alias of the latter, just to make sure that we are using one method consistently throughout the code base.

## Details

1. I have replaced all the `Kernel#sprintf` calls with `Kernel#format` calls. 
2. I have also replaced all the `String#%` calls with `Kernel#format` calls.

## Motivation and Context

This change is required to comply with rubocop suggestion to be using `Kernel#format` vs `Kernel#sprintf` and `String#%`.

Refs #1021 

## How Has This Been Tested?

With `bundle exec rake` everything is green.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Style changes

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

