### PR TITLE
move --retry to latest relase

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,7 +7,6 @@
 ### New Features
 
 * Use the event bus in Cucumber-Ruby-Core ([#973](https://github.com/cucumber/cucumber-ruby/pull/973) @mattwynne)
-* Add --retry option to retry failed tests as part of the same run ([#920](https://github.com/cucumber/cucumber-ruby/pull/920) @DanaScheider)
 * Add a summary formatter ([#999](https://github.com/cucumber/cucumber-ruby/pull/999) @mattwynne)
 * Namespaced World modules ([#1007](https://github.com/cucumber/cucumber-ruby/pull/1007) @nodo)
 
@@ -41,6 +40,7 @@
 ### New Features
 
 * Update to Gherkin v4.0 (@brasmusson)
+* Add --retry option to retry failed tests as part of the same run ([#920](https://github.com/cucumber/cucumber-ruby/pull/920) @DanaScheider)
 
 ### Bugfixes
 


### PR DESCRIPTION
i just installed 2.4.0 and the `--retry` option is available there. the history still lists it as "in git" while it's part of the commits 2.3.0..2.4.0