### PR TITLE
Use tag expressions from the cucumber-tag_expressions gem.

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -3,18 +3,19 @@ cucumber_pro_opts = ENV['ENABLE_CUCUMBER_PRO'] ? "--format Cucumber::Pro --out /
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format progress features" : "--format pretty #{rerun}"
 std_opts = "--format progress features -r features --strict #{cucumber_pro_opts}"
-std_opts << " --tags ~@wip-jruby" if defined?(JRUBY_VERSION)
+std_opts << " --tags 'not @wip-jruby'" if defined?(JRUBY_VERSION)
 
-wip_opts = "--color -r features --tags @wip"
-wip_opts << ",@wip-jruby" if defined?(JRUBY_VERSION)
+wip_opts = "--color -r features"
+wip_opts << " --tags @wip" if !defined?(JRUBY_VERSION)
+wip_opts << " --tags '@wip or @wip-jruby'" if defined?(JRUBY_VERSION)
 %>
-default:     <%= std_opts %> --tags ~@jruby
-jruby:       <%= std_opts %> --tags ~@wire
-jruby_win:   <%= std_opts %> --tags ~@wire CUCUMBER_FORWARD_SLASH_PATHS=true
-windows_mri: <%= std_opts %> --tags ~@jruby --tags ~@wire --tags ~@needs-many-fonts CUCUMBER_FORWARD_SLASH_PATHS=true
-ruby_1_9:    <%= std_opts %> --tags ~@jruby
-ruby_2_0:    <%= std_opts %> --tags ~@jruby
-ruby_2_1:    <%= std_opts %> --tags ~@jruby
+default:     <%= std_opts %> --tags 'not @jruby'
+jruby:       <%= std_opts %> --tags 'not @wire'
+jruby_win:   <%= std_opts %> --tags 'not @wire' CUCUMBER_FORWARD_SLASH_PATHS=true
+windows_mri: <%= std_opts %> --tags 'not @jruby and not @wire and not @needs-many-fonts' CUCUMBER_FORWARD_SLASH_PATHS=true
+ruby_1_9:    <%= std_opts %> --tags 'not @jruby'
+ruby_2_0:    <%= std_opts %> --tags 'not @jruby'
+ruby_2_1:    <%= std_opts %> --tags 'not @jruby'
 wip:         --wip <%= wip_opts %> features <%= cucumber_pro_opts %>
 none:        --format pretty --format Cucumber::Pro --out /dev/null
-rerun:       <%= rerun_opts %> --format rerun --out rerun.txt --strict --tag ~@wip-new-core <%= cucumber_pro_opts %>
+rerun:       <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags 'not @wip-new-core' <%= cucumber_pro_opts %>

--- a/features/docs/cli/execute_with_tag_filter.feature
+++ b/features/docs/cli/execute_with_tag_filter.feature
@@ -26,7 +26,7 @@ Feature: Tag logic
       """
 
   Scenario: ANDing tags
-    When I run `cucumber -q -t @one -t @three features/test.feature`
+    When I run `cucumber -q -t '@one and @three' features/test.feature`
     Then it should pass with:
       """
       @feature
@@ -42,7 +42,7 @@ Feature: Tag logic
       """
 
   Scenario: ORing tags
-    When I run `cucumber -q -t @one,@three features/test.feature`
+    When I run `cucumber -q -t '@one or @three' features/test.feature`
     Then it should pass with:
       """
       @feature
@@ -66,7 +66,7 @@ Feature: Tag logic
       """
 
   Scenario: Negative tags
-    When I run `cucumber -q -t ~@three features/test.feature`
+    When I run `cucumber -q -t 'not @three' features/test.feature`
     Then it should pass with:
       """
       @feature
@@ -104,7 +104,7 @@ Feature: Tag logic
        """
 
   Scenario: Run with limited tag count using negative tag, blowing it via a tag that is not run
-     When I run `cucumber -q --no-source --tags ~@one:1 features/test.feature`
+     When I run `cucumber -q --no-source --tags 'not @one:1' features/test.feature`
      Then it fails before running features with:
        """
        @one occurred 2 times, but the limit was set to 1

--- a/features/docs/writing_support_code/tagged_hooks.feature
+++ b/features/docs/writing_support_code/tagged_hooks.feature
@@ -4,7 +4,7 @@ Feature: Tagged hooks
     Given the standard step definitions
     And a file named "features/support/hooks.rb" with:
       """
-      Before('~@no-boom') do 
+      Before('not @no-boom') do 
         raise 'boom'
       end
       """

--- a/features/lib/support/env.rb
+++ b/features/lib/support/env.rb
@@ -8,7 +8,7 @@ Before('@spawn') do
   Aruba.process = Aruba::SpawnProcess
 end
 
-Before('~@spawn') do
+Before('not @spawn') do
   Aruba::InProcess.main_class = Cucumber::Cli::Main
   Aruba.process = Aruba::InProcess
 end

--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -3,7 +3,6 @@ require 'logger'
 require 'cucumber/cli/options'
 require 'cucumber/cli/rerun_file'
 require 'cucumber/constantize'
-require 'cucumber/core/gherkin/tag_expression'
 require 'cucumber'
 
 module Cucumber
@@ -28,8 +27,6 @@ module Cucumber
         @options.parse!(args)
         arrange_formats
         raise("You can't use both --strict and --wip") if strict? && wip?
-        # todo: remove
-        @options[:tag_expression] = Cucumber::Core::Gherkin::TagExpression.new(@options[:tag_expressions])
         set_environment_variables
       end
 
@@ -85,13 +82,8 @@ module Cucumber
         logger
       end
 
-      # todo: remove
-      def tag_expression
-        Cucumber::Core::Gherkin::TagExpression.new(@options[:tag_expressions])
-      end
-
       def tag_limits
-        tag_expression.limits.to_hash
+        @options[:tag_limits]
       end
 
       def tag_expressions

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -54,6 +54,7 @@ module Cucumber
                                   '-l', '--lines', '--port',
                                   '-I', '--snippet-type']
       ORDER_TYPES = %w{defined random}
+      TAG_LIMIT_MATCHER = /(?<tag_name>\@\w+):(?<limit>\d+)/x
 
       def self.parse(args, out_stream, error_stream, options = {})
         new(out_stream, error_stream, options).parse!(args)
@@ -101,7 +102,7 @@ module Cucumber
           opts.on('-f FORMAT', '--format FORMAT', *format_msg, *FORMAT_HELP) {|v| add_option :formats, [v, @out_stream] }
           opts.on('--init', *init_msg) {|v| initialize_project }
           opts.on('-o', '--out [FILE|DIR]', *out_msg) {|v| set_out_stream v }
-          opts.on('-t TAG_EXPRESSION', '--tags TAG_EXPRESSION', *tags_msg) {|v| add_option :tag_expressions, v }
+          opts.on('-t TAG_EXPRESSION', '--tags TAG_EXPRESSION', *tags_msg) {|v| add_tag v }
           opts.on('-n NAME', '--name NAME', *name_msg) {|v| add_option :name_regexps, /#{v}/ }
           opts.on('-e', '--exclude PATTERN', *exclude_msg) {|v| add_option :excludes, Regexp.new(v) }
           opts.on(PROFILE_SHORT_FLAG, "#{PROFILE_LONG_FLAG} PROFILE", *profile_short_flag_msg) {|v| add_profile v }
@@ -253,17 +254,20 @@ TEXT
         [
           'Only execute the features or scenarios with tags matching TAG_EXPRESSION.',
           'Scenarios inherit tags declared on the Feature level. The simplest',
-          'TAG_EXPRESSION is simply a tag. Example: --tags @dev. When a tag in a tag',
-          'expression starts with a ~, this represents boolean NOT. Example: --tags ~@dev.',
-          'A tag expression can have several tags separated by a comma, which represents',
-          'logical OR. Example: --tags @dev,@wip. The --tags option can be specified',
-          'several times, and this represents logical AND. Example: --tags @foo,~@bar --tags @zap.',
-          'This represents the boolean expression (@foo || !@bar) && @zap.',
+          'TAG_EXPRESSION is simply a tag. Example: --tags @dev. To represent',
+          "boolean NOT preceed the tag with 'not '. Example: --tags 'not @dev'.",
+          'A tag expression can have several tags separated by an or which represents',
+          "logical OR. Example: --tags '@dev or @wip'. The --tags option can be specified",
+          'A tag expression can have several tags separated by an and which represents',
+          "logical AND. Example: --tags '@dev and @wip'. The --tags option can be specified",
+          'several times, and this also represents logical AND.',
+          "Example: --tags '@foo or not @bar' --tags @zap. This represents the boolean",
+          'expression (@foo || !@bar) && @zap.',
           "\n",
           'Beware that if you want to use several negative tags to exclude several tags',
-          'you have to use logical AND: --tags ~@fixme --tags ~@buggy.',
+          "you have to use logical AND: --tags 'not @fixme and not @buggy'.",
           "\n",
-          'Positive tags can be given a threshold to limit the number of occurrences.',
+          'Tags can be given a threshold to limit the number of occurrences.',
           'Example: --tags @qa:3 will fail if there are more than 3 occurrences of the @qa tag.',
           'This can be practical if you are practicing Kanban or CONWIP.'
         ]
@@ -341,6 +345,26 @@ TEXT
 
       def add_option(option, value)
         @options[option] << value
+      end
+
+      def add_tag(value)
+        warn("Deprecated: Found tags option '#{value}'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.") if value.include?('~')
+        warn("Deprecated: Found tags option '#{value}'. Support for '@tag1,@tag2' will be removed from the next release of Cucumber. Please use '@tag or @tag2' instead.") if value.include?(',')
+        @options[:tag_expressions] << value.gsub(/(@\w+)(:\d+)?/, '\1')
+        add_tag_limits(value)
+      end
+
+      def add_tag_limits(value)
+        value.split(/[, ]/).map { |part| TAG_LIMIT_MATCHER.match(part) }.compact.each do |matchdata|
+          add_tag_limit(@options[:tag_limits], matchdata[:tag_name], matchdata[:limit].to_i)
+        end
+      end
+
+      def add_tag_limit(tag_limits, tag_name, limit)
+        if tag_limits[tag_name] && tag_limits[tag_name] != limit
+          raise "Inconsistent tag limits for #{tag_name}: #{tag_limits[tag_name]} and #{limit}"
+        end
+        tag_limits[tag_name] = limit
       end
 
       def set_color(color)
@@ -433,6 +457,7 @@ TEXT
         @options[:excludes] += other_options[:excludes]
         @options[:name_regexps] += other_options[:name_regexps]
         @options[:tag_expressions] += other_options[:tag_expressions]
+        merge_tag_limits(@options[:tag_limits], other_options[:tag_limits])
         @options[:env_vars] = other_options[:env_vars].merge(@options[:env_vars])
         if @options[:paths].empty?
           @options[:paths] = other_options[:paths]
@@ -456,6 +481,10 @@ TEXT
         end
 
         self
+      end
+
+      def merge_tag_limits(option_limits, other_limits)
+        other_limits.each { |key, value| add_tag_limit(option_limits, key, value) }
       end
 
       def indicate_invalid_language_and_exit(lang)
@@ -512,6 +541,7 @@ TEXT
           :formats      => [],
           :excludes     => [],
           :tag_expressions  => [],
+          :tag_limits   => {},
           :name_regexps => [],
           :env_vars     => {},
           :diff_enabled => true,

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -4,7 +4,6 @@ require 'cucumber/cli/rerun_file'
 require 'cucumber/events'
 require 'cucumber/core/event_bus'
 require 'forwardable'
-require 'cucumber/core/gherkin/tag_expression'
 require 'cucumber'
 
 module Cucumber
@@ -130,13 +129,8 @@ module Cucumber
       with_default_features_path(dirs)
     end
 
-    # todo: remove
-    def tag_expression
-      Cucumber::Core::Gherkin::TagExpression.new(@options[:tag_expressions])
-    end
-
     def tag_limits
-      tag_expression.limits.to_hash
+      @options[:tag_limits]
     end
 
     def tag_expressions

--- a/lib/cucumber/rb_support/rb_hook.rb
+++ b/lib/cucumber/rb_support/rb_hook.rb
@@ -10,10 +10,24 @@ module Cucumber
         @tag_expressions = tag_expressions
         @proc = proc
         @location = Cucumber::Core::Ast::Location.from_source_location(*@proc.source_location)
+        warn_for_old_style_tag_expressions(tag_expressions)
       end
 
       def invoke(pseudo_method, arguments, &block)
         @rb_language.current_world.cucumber_instance_exec(false, pseudo_method, *[arguments, block].flatten.compact, &@proc)
+      end
+
+      private
+
+      def warn_for_old_style_tag_expressions(tag_expressions)
+        tag_expressions.each do |tag_expression|
+          if tag_expression.include?('~') && tag_expression != '~@no-clobber' # ~@no-clobber is used in aruba
+            warn("Deprecated: Found tagged hook with '#{tag_expression}'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.") 
+          end
+          if tag_expression.include?(',')
+            warn("Deprecated: Found tagged hook with '#{tag_expression}'. Support for '@tag1,@tag2' will be removed from the next release of Cucumber. Please use '@tag or @tag2' instead.")
+          end
+        end
       end
     end
   end

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -354,19 +354,17 @@ END_OF_MESSAGE
       expect(config.paths).not_to include('RAILS_ENV=selenium')
     end
 
-    describe '#tag_expression' do
-      include RSpec::WorkInProgress
-
+    describe '#tag_expressions' do
       it 'returns an empty expression when no tags are specified' do
         config.parse!([])
 
-        expect(config.tag_expression).to be_empty
+        expect(config.tag_expressions).to be_empty
       end
 
       it 'returns an expression when tags are specified' do
         config.parse!(['--tags','@foo'])
 
-        expect(config.tag_expression).not_to be_empty
+        expect(config.tag_expressions).not_to be_empty
       end
     end
 


### PR DESCRIPTION
## Summary

Support [standard library tag expressions](https://github.com/cucumber/cucumber/tree/master/tag-expressions) from the cucumber-tag_expressions gem.

## Details

The tag limits from the `--tags` options are stripped of and handled separately, so that the stored tag expressions can be passed the tag expressions library directly.

Old style tag expressions are deprecated but still handled correctly.

Requires https://github.com/cucumber/cucumber-ruby-core/pull/116

Closes https://github.com/cucumber/cucumber-ruby/issues/1003

## How Has This Been Tested?

Features and spec are updated accordingly.

## Types of changes

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] I've added tests for my code
- [X] I've updated the help test (`-h` option)
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
