### PR TITLE
Fix HTML injection in HTML formatter message output

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -401,7 +401,7 @@ module Cucumber
         #@builder.ol do
           @delayed_messages.each do |ann|
             @builder.li(:class => 'step message') do
-              @builder << ann
+              @builder << h(ann)
             end
           end
         #end

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -434,6 +434,23 @@ module Cucumber
           it { expect(@doc.css('pre').map { |pre| /^(Given|Then)/.match(pre.text)[1] }).to eq ['Then'] }
         end
 
+        describe 'with HTML in output from scenario' do
+          define_steps do
+            Given(/log/) { puts '<h1>Output</h1>' }
+          end
+
+          define_feature(<<-FEATURE)
+          Feature:
+            Scenario:
+              Given log
+            FEATURE
+
+          it 'should escape HTML tags in messages' do
+            expect(@doc.css('.step.message h1')).to be_empty
+            expect(@doc.css('.step.message')[0].text).to eq '<h1>Output</h1>'
+          end
+
+        end
         describe 'with a output from hooks' do
           describe 'in a scenario' do
             define_feature <<-FEATURE


### PR DESCRIPTION
## Summary

HTML formatter appends any scenario output to the HTML without escaping HTML tags in the messages. This means that any output from the steps gets injected into the report page.

## Details

This change adds HTML escaping of the message text with `ERB::Util.h`.

## Motivation and Context

In the simple case, HTML injection won't display the message as expected. When combined with for example capybara and CI environments this opens up the possibility of an XSS attack from the user input on the environment being tested.

Using manual escaping of the output itself would solve the HTML injection, but since the same output is used by multiple formatters it no longer prints the actual message in non-HTML formatters.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.