### PR TITLE
Start the event bus after all listeners are registered

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -122,7 +122,7 @@ Metrics/MethodLength:
 # Offense count: 19
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 1976
+  Max: 1977
 
 # Offense count: 7
 # Configuration parameters: CountKeywordArgs.

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -58,14 +58,13 @@ module Cucumber
 
     require 'cucumber/wire/plugin'
     def run!
-      install_wire_plugin
-      load_support_files
-      fire_after_configuration_hook
-      formatters
       load_step_definitions
+      install_wire_plugin
+      fire_after_configuration_hook
       self.visitor = report
 
       receiver = Test::Runner.new(@configuration.event_bus)
+      @configuration.event_bus.start
       compile features, receiver, filters
       @configuration.notify :test_run_finished
     end
@@ -248,13 +247,8 @@ module Cucumber
       end
     end
 
-    def load_support_files
-      files = @configuration.support_to_load
-      @support_code.load_files!(files)
-    end
-
     def load_step_definitions
-      files = @configuration.step_defs_to_load
+      files = @configuration.support_to_load + @configuration.step_defs_to_load
       @support_code.load_files!(files)
     end
 

--- a/spec/cucumber/filters/retry_spec.rb
+++ b/spec/cucumber/filters/retry_spec.rb
@@ -19,6 +19,8 @@ describe Cucumber::Filters::Retry do
   let(:fail) { Cucumber::Events::AfterTestCase.new(test_case, double('result', :failed? => true, :ok? => false)) }
   let(:pass) { Cucumber::Events::AfterTestCase.new(test_case, double('result', :failed? => false, :ok? => true)) }
 
+  before(:each) { configuration.event_bus.start }
+
   it { is_expected.to respond_to(:test_case) }
   it { is_expected.to respond_to(:with_receiver) }
   it { is_expected.to respond_to(:done) }

--- a/spec/cucumber/formatter/fail_fast_spec.rb
+++ b/spec/cucumber/formatter/fail_fast_spec.rb
@@ -15,6 +15,7 @@ module Cucumber::Formatter
 
     let(:configuration) { Cucumber::Configuration.new }
     before { FailFast.new(configuration) }
+    before(:each) { configuration.event_bus.start }
 
     context 'failing scenario' do 
       before(:each) do 

--- a/spec/cucumber/formatter/legacy_api/adapter_spec.rb
+++ b/spec/cucumber/formatter/legacy_api/adapter_spec.rb
@@ -19,6 +19,7 @@ module Cucumber
       let(:runtime)   { Runtime.new }
       let(:events)    { runtime.configuration.event_bus }
       let(:step_match_search) { SimpleStepDefinitionSearch.new }
+      before(:each) { runtime.configuration.event_bus.start }
 
       Failure = Class.new(StandardError)
 

--- a/spec/cucumber/formatter/rerun_spec.rb
+++ b/spec/cucumber/formatter/rerun_spec.rb
@@ -14,6 +14,7 @@ module Cucumber
 
       let(:config) { Cucumber::Configuration.new(out_stream: io) }
       let(:io) { StringIO.new }
+      before(:each) { config.event_bus.start }
 
       # after_test_case
       context 'when 2 scenarios fail in the same file' do

--- a/spec/cucumber/formatter/spec_helper.rb
+++ b/spec/cucumber/formatter/spec_helper.rb
@@ -19,6 +19,7 @@ module Cucumber
       include Core
 
       def run_defined_feature
+        event_bus.start
         define_steps
         actual_runtime.visitor = report
 


### PR DESCRIPTION
## Summary

To make sure that all listeners will receive all events broadcasted through the event bus, start the event bus only after all listeners have had a change so register themselves with the event bus.

One case where this is important is so that the usage formatter get to know all step definitions that are registered, even though the step definitions are registered before the formatters have been created.

## Details

Revert changes in file loading from #977, so that the support and step definition files again are loaded at the same time (before the formatters has been created).

Call `EventBus#start` after all formatters and other event bus listeners have been created and had a change to register themselves with the event bus.

Requires https://github.com/cucumber/cucumber-ruby-core/pull/117.

## Motivation and Context

Fixes https://github.com/cucumber/cucumber-ruby/issues/1041.

## How Has This Been Tested?

The current `usage_formatter.feature` verifies that the step definitions loaded before the usage/stepdefs formatter has registered itself with the event bus are reported by the usage/stepdefs formatter.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I've added tests for my code (the current features verify the correctness of the change).
