### PR TITLE
Fix an json compile error for "bundle install" on Ruby 2.4.

### DIFF
--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cucumber-wire', '~> 0.0.1'
 
   s.add_development_dependency 'aruba', '~> 0.6.1'
-  s.add_development_dependency 'json', '~> 1.7'
+  s.add_development_dependency 'json', '~> 1.8.6'
   s.add_development_dependency 'nokogiri', '~> 1.5'
   s.add_development_dependency 'rake', '>= 0.9.2'
   s.add_development_dependency 'rspec', '>= 3.0'


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Fix an json compile error for "bundle install" on Ruby 2.4.
Installed json-1.8.3 does not have a compatibility for Ruby 2.4.

## Details

```
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]
```

```
$ bundle -v
Bundler version 1.13.7
```

On lastest master branch (commit hash: 8871da436987e2c46623a24909a925818be52314)

```
$ pushd ../cucumber-ruby-core
$ git checkout v2.0.0
$ popd
```

```
$ pushd ../cucumber-ruby-wire
$ git checkout v0.0.1
$ popd
```

```
$ bundle install --path vendor/bundle
...
current directory:
/home/jaruga/git/cucumber-ruby/vendor/bundle/ruby/2.4.0/gems/json-1.8.3/ext/json/ext/generator
/usr/local/ruby-2.4.0/bin/ruby -r ./siteconf20170109-6691-15ef87j.rb extconf.rb
creating Makefile

current directory:
/home/jaruga/git/cucumber-ruby/vendor/bundle/ruby/2.4.0/gems/json-1.8.3/ext/json/ext/generator 
make "DESTDIR=" clean

current directory:
/home/jaruga/git/cucumber-ruby/vendor/bundle/ruby/2.4.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR="
compiling generator.c
generator.c: In function ‘generate_json’:
generator.c:861:25: error: ‘rb_cFixnum’ undeclared (first use in this function)
     } else if (klass == rb_cFixnum) {
                         ^~~~~~~~~~
generator.c:861:25: note: each undeclared identifier is reported only once for each
function it appears in
generator.c:863:25: error: ‘rb_cBignum’ undeclared (first use in this function)
     } else if (klass == rb_cBignum) {
                         ^~~~~~~~~~
generator.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-self-assign’
cc1: warning: unrecognized command line option ‘-Wno-constant-logical-operand’
cc1: warning: unrecognized command line option ‘-Wno-parentheses-equality’
Makefile:241: recipe for target 'generator.o' failed
make: *** [generator.o] Error 1
...
```

## Motivation and Context

We may want to run cucumber on Ruby 2.4.

## How Has This Been Tested?

## Screenshots (if appropriate):

I ran below command, and done successfully.

```
$ bundle install --path vendor/bundle
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Later I want to add ruby 2.4.0 to .travis.yml.
But right now I got an error for `bundle exec rake cucumber`.
I will inform it as a issue later.
