### PR TITLE
Run rubygems update before installing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ matrix:
     - rvm: 2.2
     - rvm: 2.1
     - rvm: jruby-9.1.2.0
-      env: 
+      env:
         # Travis by default also have "-Dcext.enabled=false" set in
         # JRUBY_OPTS, but JRuby 9 does not support C extensions at all
-        # so it issues warning that will mess up the sterr checks. 
+        # so it issues warning that will mess up the sterr checks.
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false"
-        # Somehow a "ASCII-8BIT to UTF-8 conversion error" appears for 
+        # Somehow a "ASCII-8BIT to UTF-8 conversion error" appears for
         # JRuby 9
         - LC_ALL=en_US.UTF-8
         - LANG=en_US.UTF-8
@@ -24,6 +24,7 @@ branches:
     - v1.3.x-bugfix
 
 before_install:
+  - gem update --system
   - gem update bundler
 
 notifications:


### PR DESCRIPTION
Travis build is failing due to this bug: https://github.com/sickill/rainbow/issues/49.

Running `gem update --system` before running `bundle install` fixes the problem (see https://github.com/sickill/rainbow/issues/49#issuecomment-274714272 and https://github.com/bundler/bundler/issues/5357#issuecomment-274742137)
