### PR TITLE
Add Ruby 2.4.0 to Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 
 matrix:
   include:
+    - rvm: 2.4.0
     - rvm: 2.3.1
     - rvm: 2.2
     - rvm: 2.1


### PR DESCRIPTION
Add Ruby 2.4.0 to Travis CI.
