### PR TITLE
Add Ruby 2.4.0 as allow_failures in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 
 matrix:
   include:
+    - rvm: 2.4.0
     - rvm: 2.3.1
     - rvm: 2.2
     - rvm: 2.1
@@ -16,6 +17,8 @@ matrix:
         - LC_ALL=en_US.UTF-8
         - LANG=en_US.UTF-8
         - LANGUAGE=en_US.UTF-8
+  allow_failures:
+    - rvm: 2.4.0
 
 # whitelist
 branches:


### PR DESCRIPTION
## Summary

<!--- Provide a general summary description of your changes -->
Add Ruby 2.4.0 as allow_failures in .travis.yml because of seeing tests failure situation on Ruby 2.4.0.
It is good to merge Ruby 2.4.0 features one by one seeing the result of Travis.
I might be better to merge this PR at first earlier than #1077.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
