### PR TITLE
Relax filter for "/usr/local/ruby-X.Y.Z/bin/bundle".

### DIFF
--- a/lib/cucumber/formatter/backtrace_filter.rb
+++ b/lib/cucumber/formatter/backtrace_filter.rb
@@ -14,7 +14,7 @@ module Cucumber
       test/unit
       .gem/ruby
       lib/ruby/
-      rbenv/.*/bin/bundle
+      bin/bundle
     )
 
     if ::Cucumber::JRUBY


### PR DESCRIPTION
## Summary

This fixes tests with /usr/local/ruby-X.Y.Z/bin/bundle.
The solution is mentioned by https://github.com/cucumber/cucumber-ruby/pull/1069#issuecomment-278132114
Can you check this PR before #1077 ?

## Details

## Motivation and Context

Want to pass tests.

## How Has This Been Tested?

There is still an error. but it is another reason.

```
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]

$ bundle -v
Bundler version 1.14.3

$ bundle exec rake spec
...
568 examples, 0 failures

$ bundle exec rake cucumber
...
(::) failed steps (::)

expected "No such file or directory @ rb_sysopen - features. You can use `cucumber --init` to get started.\n" to include "No such file or directory - features. You can use `cucumber --init` to get started."
Diff:
@@ -1,2 +1,2 @@
-No such file or directory - features. You can use `cucumber --init` to get started.
+No such file or directory @ rb_sysopen - features. You can use `cucumber --init` to get started.
 (RSpec::Expectations::ExpectationNotMetError)
features/docs/getting_started.feature:10:in `Then it should fail with:'

Failing Scenarios:
cucumber features/docs/getting_started.feature:7 # Scenario: Run Cucumber in an empty directory

207 scenarios (1 failed, 206 passed)
1217 steps (1 failed, 1216 passed)
```

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
