### PR TITLE
Avoid showing "@ rb_sysopen" noise for Ruby 2.4.

### DIFF
--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -30,8 +30,14 @@ module Cucumber
   class FileNotFoundException < FileException
   end
 
-  class FeatureFolderNotFoundException < FileException
-    include FixRuby21Bug9285 if Cucumber::RUBY_2_1 || Cucumber::RUBY_2_2 || Cucumber::RUBY_2_3
+  class FeatureFolderNotFoundException < Exception
+    def initialize(path)
+      @path = path
+    end
+
+    def message
+      "No such file or directory - #{@path}"
+    end
   end
 
   require 'cucumber/core'
@@ -141,8 +147,8 @@ module Cucumber
           set_encoding
         rescue Errno::EACCES => e
           raise FileNotFoundException.new(e, File.expand_path(path))
-        rescue Errno::ENOENT => e
-          raise FeatureFolderNotFoundException.new(e, path)
+        rescue Errno::ENOENT
+          raise FeatureFolderNotFoundException.new(path)
         end
       end
 


### PR DESCRIPTION
## Summary

This fixes #1071.

## Details

This issue happens for only Ruby 2.4.0.

## Motivation and Context

Want to pass tests.

## How Has This Been Tested?

```
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]

$ bundle exec rake spec
...
568 examples, 0 failures

$ bundle exec rake cucumber
...
207 scenarios (17 failed, 190 passed)
1217 steps (17 failed, 1200 passed)
```

There are still failed tests. But they will be fixed by https://github.com/cucumber/cucumber-ruby/pull/1079 .
The `rb_sysopen` message was disappeared.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
