### PR TITLE
Add a `GherkinSourceRead` event

### DIFF
--- a/features/docs/events/gherkin_source_read_event.feature
+++ b/features/docs/events/gherkin_source_read_event.feature
@@ -1,0 +1,42 @@
+Feature: Gherkin Source Read Event
+
+  This event is fired when Cucumber reads a Gherkin document.
+
+  See [the API documentation](http://www.rubydoc.info/github/cucumber/cucumber-ruby/Cucumber/Events/GherkinSourceRead)
+  for more information about the data available on this event.
+
+  Scenario: Read two documents
+    Given a file named "features/one.feature" with:
+      """
+      Feature: One
+        This is the first feature
+
+      """
+    And a file named "features/two.feature" with:
+      """
+      Feature: Two
+        This is the other feature
+
+      """
+    And a file named "features/support/events.rb" with:
+      """
+      AfterConfiguration do |config|
+        config.on_event :gherkin_source_read do |event|
+          config.out_stream.puts "path: #{event.path}"
+          config.out_stream.puts "body:\n#{event.body}"
+        end
+      end
+      """
+    When I run `cucumber --dry-run`
+    Then it should pass with:
+      """
+      path: features/one.feature
+      body:
+      Feature: One
+        This is the first feature
+      path: features/two.feature
+      body:
+      Feature: Two
+        This is the other feature
+      """
+

--- a/lib/cucumber/events.rb
+++ b/lib/cucumber/events.rb
@@ -30,7 +30,8 @@ module Cucumber
         TestStepStarting,
         StepDefinitionRegistered,
         StepActivated,
-        TestRunFinished
+        TestRunFinished,
+        GherkinSourceRead
       )
     end
   end

--- a/lib/cucumber/events/gherkin_source_read.rb
+++ b/lib/cucumber/events/gherkin_source_read.rb
@@ -1,0 +1,17 @@
+require 'cucumber/core/events'
+
+module Cucumber
+  module Events
+
+    # Fired after we've read in the contents of a feature file
+    class GherkinSourceRead < Core::Event.new(:path, :body)
+
+      # The path to the file
+      attr_reader :path
+
+      # The raw Gherkin source
+      attr_reader :body
+    end
+
+  end
+end

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -121,6 +121,7 @@ module Cucumber
     def features
       @features ||= feature_files.map do |path|
         source = NormalisedEncodingFile.read(path)
+        @configuration.notify :gherkin_source_read, path, source
         Cucumber::Core::Gherkin::Document.new(path, source)
       end
     end


### PR DESCRIPTION
## Summary

Adds a new event that fires when a Gherkin document is read in.

## Details

## Motivation and Context

This event will allow formatters to create their own Gherkin AST, should they need it. This would also potentially allow us to simplify the core `Test::Case` value objects to no longer contain references to the AST.

It's also needed to support the standard [event protocol](https://github.com/cucumber/cucumber/tree/master/event-protocol)

## How Has This Been Tested?

See `features/docs/events/gherkin_source_read_event.feature`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
