### PR TITLE
adding result in junit testcase report

### DIFF
--- a/features/docs/formatters/junit_formatter.feature
+++ b/features/docs/formatters/junit_formatter.feature
@@ -120,7 +120,7 @@ Feature: JUnit output formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Subdirectory - One passing scenario, one failing scenario" name="Failing" time="0.05">
+      <testcase classname="Subdirectory - One passing scenario, one failing scenario" name="Failing" time="0.05" status="failed">
         <failure message="failed Failing" type="failed" status="failed">
           <![CDATA[Scenario: Failing
 

--- a/features/docs/formatters/junit_formatter.feature
+++ b/features/docs/formatters/junit_formatter.feature
@@ -121,7 +121,7 @@ Feature: JUnit output formatter
         </system-err>
       </testcase>
       <testcase classname="Subdirectory - One passing scenario, one failing scenario" name="Failing" time="0.05" status="failed">
-        <failure message="failed Failing" type="failed" status="failed">
+        <failure message="failed Failing" type="failed">
           <![CDATA[Scenario: Failing
 
       Given this step fails

--- a/features/docs/formatters/junit_formatter.feature
+++ b/features/docs/formatters/junit_formatter.feature
@@ -70,7 +70,7 @@ Feature: JUnit output formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="1" errors="0" skipped="0" tests="2" time="0.05" name="One passing scenario, one failing scenario">
-      <testcase classname="One passing scenario, one failing scenario" name="Passing" time="0.05">
+      <testcase classname="One passing scenario, one failing scenario" name="Passing" time="0.05" status="passed">
         <system-out>
           <![CDATA[]]>
         </system-out>
@@ -78,7 +78,7 @@ Feature: JUnit output formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="One passing scenario, one failing scenario" name="Failing" time="0.05">
+      <testcase classname="One passing scenario, one failing scenario" name="Failing" time="0.05" status="failed">
         <failure message="failed Failing" type="failed">
           <![CDATA[Scenario: Failing
 
@@ -112,7 +112,7 @@ Feature: JUnit output formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="1" errors="0" skipped="0" tests="2" time="0.05" name="Subdirectory - One passing scenario, one failing scenario">
-      <testcase classname="Subdirectory - One passing scenario, one failing scenario" name="Passing" time="0.05">
+      <testcase classname="Subdirectory - One passing scenario, one failing scenario" name="Passing" time="0.05" status="passed">
         <system-out>
           <![CDATA[]]>
         </system-out>
@@ -121,7 +121,7 @@ Feature: JUnit output formatter
         </system-err>
       </testcase>
       <testcase classname="Subdirectory - One passing scenario, one failing scenario" name="Failing" time="0.05">
-        <failure message="failed Failing" type="failed">
+        <failure message="failed Failing" type="failed" status="failed">
           <![CDATA[Scenario: Failing
 
       Given this step fails
@@ -153,7 +153,7 @@ Feature: JUnit output formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="0" errors="0" skipped="2" tests="2" time="0.05" name="Pending step">
-      <testcase classname="Pending step" name="Pending" time="0.05">
+      <testcase classname="Pending step" name="Pending" time="0.05" status="pending">
         <skipped/>
         <system-out>
           <![CDATA[]]>
@@ -162,7 +162,7 @@ Feature: JUnit output formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Pending step" name="Undefined" time="0.05">
+      <testcase classname="Pending step" name="Undefined" time="0.05" status="undefined">
         <skipped/>
         <system-out>
           <![CDATA[]]>
@@ -185,7 +185,7 @@ Feature: JUnit output formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="2" errors="0" skipped="0" tests="2" time="0.05" name="Pending step">
-      <testcase classname="Pending step" name="Pending" time="0.05">
+      <testcase classname="Pending step" name="Pending" time="0.05" status="pending">
         <failure message="pending Pending" type="pending">
           <![CDATA[Scenario: Pending
 
@@ -204,7 +204,7 @@ Feature: JUnit output formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Pending step" name="Undefined" time="0.05">
+      <testcase classname="Pending step" name="Undefined" time="0.05" status="undefined">
         <failure message="undefined Undefined" type="undefined">
           <![CDATA[Scenario: Undefined
       
@@ -257,7 +257,7 @@ You *must* specify --out DIR for the junit formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="3" errors="0" skipped="0" tests="4" time="0.05" name="Scenario outlines">
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | passes |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | passes |)" time="0.05" status="passed">
         <system-out>
           <![CDATA[]]>
         </system-out>
@@ -265,7 +265,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | fails |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | fails |)" time="0.05" status="failed">
         <failure message="failed Using scenario outlines (outline example : | fails |)" type="failed">
           <![CDATA[Scenario Outline: Using scenario outlines
       
@@ -285,7 +285,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is pending |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is pending |)" time="0.05" status="pending">
         <failure message="pending Using scenario outlines (outline example : | is pending |)" type="pending">
           <![CDATA[Scenario Outline: Using scenario outlines
 
@@ -305,7 +305,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is undefined |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is undefined |)" time="0.05" status="undefined">
         <failure message="undefined Using scenario outlines (outline example : | is undefined |)" type="undefined">
           <![CDATA[Scenario Outline: Using scenario outlines
 
@@ -339,7 +339,7 @@ You *must* specify --out DIR for the junit formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="3" errors="0" skipped="0" tests="4" time="0.05" name="Scenario outlines">
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | passes |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | passes |)" time="0.05" status="passed">
         <system-out>
           <![CDATA[]]>
         </system-out>
@@ -347,7 +347,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | fails |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | fails |)" time="0.05" status="failed">
         <failure message="failed Using scenario outlines (outline example : | fails |)" type="failed">
           <![CDATA[Scenario Outline: Using scenario outlines
       
@@ -367,7 +367,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is pending |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is pending |)" time="0.05" status="pending">
         <failure message="pending Using scenario outlines (outline example : | is pending |)" type="pending">
           <![CDATA[Scenario Outline: Using scenario outlines
 
@@ -387,7 +387,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is undefined |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is undefined |)" time="0.05" status="undefined">
         <failure message="undefined Using scenario outlines (outline example : | is undefined |)" type="undefined">
           <![CDATA[Scenario Outline: Using scenario outlines
 
@@ -421,7 +421,7 @@ You *must* specify --out DIR for the junit formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="1" errors="0" skipped="0" tests="2" time="0.05" name="One passing scenario, one failing scenario">
-      <testcase classname="One passing scenario, one failing scenario" name="Passing" time="0.05">
+      <testcase classname="One passing scenario, one failing scenario" name="Passing" time="0.05" status="passed">
         <system-out>
           <![CDATA[]]>
         </system-out>
@@ -429,7 +429,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="One passing scenario, one failing scenario" name="Failing" time="0.05">
+      <testcase classname="One passing scenario, one failing scenario" name="Failing" time="0.05" status="failed">
         <failure message="failed Failing" type="failed">
           <![CDATA[Scenario: Failing
 

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -122,7 +122,7 @@ module Cucumber
         classname = @current_feature_data[:feature].name
         name = scenario_designation
 
-        @current_feature_data[:builder].testcase(:classname => classname, :name => name, :time => format('%.6f', duration)) do
+        @current_feature_data[:builder].testcase(:classname => classname, :name => name, :time => format('%.6f', duration), :status => result.to_sym) do
           if !result.passed? && result.ok?(@config.strict?)
             @current_feature_data[:builder].skipped
             @current_feature_data[:skipped] += 1


### PR DESCRIPTION
## Summary
Adding status in junit xml report for individual test cases. 

## Details
In junit xml report generator, individual testcase/scenario status is not shown.

## Motivation and Context
- I wanted to send html report of cucumber tests , for that I was creating a simple table like html in which individual testcases's status, time are shown in rows. Time was mentioned in xml report for each scenario/testcase, but status was not mentioned.
- I tried to write an XSLT file reading the xml file and added conditions like if std error is mentioned then scenario is passed else failed. 
- But finally I added this change in junit file and made my work easy.

## How Has This Been Tested?
- Ran the tests for failed and passed scenario each.
- Test setup: ruby 2.3, cucumber 2.4.0 
- Code doesn't effect any other areas


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
