### PR TITLE
Add ruby-head as a allow failures in .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 
 matrix:
   include:
+    - rvm: ruby-head
     - rvm: 2.4.0
     - rvm: 2.3.1
     - rvm: 2.2
@@ -18,7 +19,9 @@ matrix:
         - LANG=en_US.UTF-8
         - LANGUAGE=en_US.UTF-8
   allow_failures:
+    - rvm: ruby-head
     - rvm: 2.4.0
+  fast_finish: true
 
 # whitelist
 branches:


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Change Ruby 2.4.0 from allow failures to required.

## Details

I changed Ruby 2.4.0 from allow failures to required.
Because this looks better than current "allow_failures".

We can skip Ruby 2.4's coverage until `coveralls` supports `simplecov` (>= 0.13.0) as a dependency package for Ruby 2.4 compatibility.
https://rubygems.org/gems/coveralls

I added "ruby-head" as a "allow_failures".
I think this is useful, because we can prepare `cucumber` for next Ruby version 2.5 in advance before it will be released.

Adding "ruby-head" as a "allow_failures" is actually practiced by `rspec` and  `rails`.
And this is the secret that they could support Ruby 2.4.0 quickly.
So, I want to add it to `cucumber` too.

https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/rails/rails/blob/master/.travis.yml

`fast_finish` option in `.travis.yml` is also useful.
https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/

## Motivation and Context

It  looks better than current "allow_failures".


## How Has This Been Tested?

We can see if my code is correct on Travis CI.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
