### PR TITLE
Add supported platforms to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@ Where to get more info:
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for info on contributing to Cucumber.
 
-## Code of Conduct
+## Supported platforms
+
+* Ruby 2.4
+* Ruby 2.3
+* Ruby 2.2
+* Ruby 2.1
+* JRuby 9.1
+
+## Code of Conduct
 
 Everyone interacting in this codebase and issue tracker is expected to follow the Cucumber [code of conduct](https://github.com/cucumber/cucumber/blob/master/CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Add supported platforms to README.
This clarify `cucumber-ruby` and other `cucumber` ruby projects' policy used with `cucumber-ruby`.
 
## Details

Here is updated README.md
https://github.com/junaruga/cucumber-ruby/blob/feature/readme-supported_platforms/README.md

I also replaced a wield character code on the left of "Code of Conduct" in `README.md` to white space.

## Motivation and Context

This PR is from below `cucumber-ruby-wire` PR not to get lost supported platforms.

https://github.com/cucumber/cucumber-ruby-wire/commit/77d1f70b7c2576aeda15dd9dc06773c897290625#commitcomment-21260194

## How Has This Been Tested?

No test. as it updates document.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
