### PR TITLE
Fix some rubocop offenses 1021 001

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1121,12 +1121,6 @@ Style/TrivialAccessors:
 
 # Offense count: 1
 # Cop supports --auto-correct.
-Style/UnlessElse:
-  Exclude:
-    - 'lib/cucumber/formatter/legacy_api/adapter.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
 Style/UnneededInterpolation:
   Exclude:
     - 'lib/cucumber/rb_support/rb_world.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1085,14 +1085,6 @@ Style/SymbolProc:
 Style/TrailingBlankLines:
   Enabled: false
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline, SupportedStyles.
-# SupportedStyles: comma, consistent_comma, no_comma
-Style/TrailingCommaInArguments:
-  Exclude:
-    - 'lib/cucumber/events.rb'
-
 # Offense count: 43
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline, SupportedStyles.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -158,13 +158,14 @@ Style/Alias:
   Exclude:
     - 'lib/cucumber/formatter/ansicolor.rb'
 
-# Offense count: 1192
+# Offense count: 1197
 # Cop supports --auto-correct.
 Style/AlignArray:
   Exclude:
     - 'lib/cucumber/cli/options.rb'
     - 'lib/cucumber/rake/task.rb'
     - 'spec/cucumber/formatter/legacy_api/adapter_spec.rb'
+    - 'spec/cucumber/multiline_argument/data_table_spec.rb'
     - 'spec/cucumber/rake/forked_spec.rb'
 
 # Offense count: 20
@@ -1146,10 +1147,4 @@ Style/VariableName:
 Style/WhileUntilDo:
   Exclude:
     - 'lib/autotest/cucumber_mixin.rb'
-
-# Offense count: 24
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles, MinSize, WordRegex.
-# SupportedStyles: percent, brackets
-Style/WordArray:
-  Enabled: false
+    

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1121,6 +1121,7 @@ Style/TrivialAccessors:
 
 # Offense count: 1
 # Cop supports --auto-correct.
+# Reviewed: when the offense is fixed there is one spec failing (./spec/cucumber/rb_support/rb_world_spec.rb:37)
 Style/UnneededInterpolation:
   Exclude:
     - 'lib/cucumber/rb_support/rb_world.rb'
@@ -1128,5 +1129,6 @@ Style/UnneededInterpolation:
 # Offense count: 15
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 # SupportedStyles: snake_case, camelCase
+# Reviewed: these offenses look false as the variables are in cyrillic
 Style/VariableName:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1110,15 +1110,6 @@ Style/TrailingCommaInLiteral:
 Style/TrailingWhitespace:
   Enabled: false
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: ExactNameMatch, AllowPredicates, AllowDSLWriters, IgnoreClassMethods, Whitelist.
-# Whitelist: to_ary, to_a, to_c, to_enum, to_h, to_hash, to_i, to_int, to_io, to_open, to_path, to_proc, to_r, to_regexp, to_str, to_s, to_sym
-Style/TrivialAccessors:
-  Exclude:
-    - 'lib/cucumber/formatter/legacy_api/ast.rb'
-    - 'lib/cucumber/multiline_argument/data_table.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Reviewed: when the offense is fixed there is one spec failing (./spec/cucumber/rb_support/rb_world_spec.rb:37)

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1153,9 +1153,3 @@ Style/WhileUntilDo:
 # SupportedStyles: percent, brackets
 Style/WordArray:
   Enabled: false
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/ZeroLengthPredicate:
-  Exclude:
-    - 'lib/cucumber/step_match_search.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1141,10 +1141,3 @@ Style/UnneededInterpolation:
 # SupportedStyles: snake_case, camelCase
 Style/VariableName:
   Enabled: false
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/WhileUntilDo:
-  Exclude:
-    - 'lib/autotest/cucumber_mixin.rb'
-    

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1125,7 +1125,7 @@ Style/UnlessElse:
   Exclude:
     - 'lib/cucumber/formatter/legacy_api/adapter.rb'
 
-# Offense count: 7
+# Offense count: 1
 # Cop supports --auto-correct.
 Style/UnneededInterpolation:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1129,12 +1129,7 @@ Style/UnlessElse:
 # Cop supports --auto-correct.
 Style/UnneededInterpolation:
   Exclude:
-    - 'lib/cucumber/formatter/html.rb'
-    - 'lib/cucumber/formatter/junit.rb'
-    - 'lib/cucumber/formatter/legacy_api/ast.rb'
-    - 'lib/cucumber/formatter/pretty.rb'
     - 'lib/cucumber/rb_support/rb_world.rb'
-    - 'spec/cucumber/cli/options_spec.rb'
 
 # Offense count: 15
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/features/lib/step_definitions/language_steps.rb
+++ b/features/lib/step_definitions/language_steps.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 Then(/^cucumber lists all the supported languages$/) do
-  sample_languages = ['Arabic', "български", 'Pirate', 'English', "日本語"]
+  sample_languages = %w(Arabic български Pirate English 日本語)
   sample_languages.each do |language|
     expect(all_output.force_encoding('utf-8')).to include(language)
   end

--- a/features/lib/support/normalise_output.rb
+++ b/features/lib/support/normalise_output.rb
@@ -24,7 +24,7 @@ module NormaliseArubaOutput
       elements = feature.fetch('elements') { [] }
       elements.each do |scenario|
         scenario['steps'].each do |step|
-          ['steps', 'before', 'after'].each do |type|
+          %w(steps before after).each do |type|
             if scenario[type]
               scenario[type].each do |step_or_hook|
                 normalise_json_step_or_hook(step_or_hook)

--- a/lib/autotest/cucumber_mixin.rb
+++ b/lib/autotest/cucumber_mixin.rb
@@ -79,7 +79,7 @@ module Autotest::CucumberMixin
       line = []
       begin
         open("| #{cmd}", 'r') do |f|
-          until f.eof? do
+          until f.eof?
             c = f.getc or break
             if RUBY_VERSION >= '1.9' then
               print c

--- a/lib/cucumber/events.rb
+++ b/lib/cucumber/events.rb
@@ -30,7 +30,7 @@ module Cucumber
         TestStepStarting,
         StepDefinitionRegistered,
         StepActivated,
-        TestRunFinished,
+        TestRunFinished
       )
     end
   end

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -587,7 +587,7 @@ module Cucumber
       end
 
       def format_exception(exception)
-        (["#{exception.message}"] + exception.backtrace).join("\n")
+        ([exception.message.to_s] + exception.backtrace).join("\n")
       end
 
       def backtrace_line(line)

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -104,7 +104,7 @@ module Cucumber
         output = "#{test_case.keyword}: #{scenario}\n\n"
         return output if result.ok?(@config.strict?)
         if test_case.keyword == 'Scenario'
-          output += "#{@failing_step_source.keyword}" unless hook?(@failing_step_source)
+          output += @failing_step_source.keyword.to_s unless hook?(@failing_step_source)
           output += "#{@failing_step_source.name}\n"
         else
           output += "Example row: #{row_name}\n"

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -388,11 +388,11 @@ module Cucumber
                   @previous_outline_child.after unless same_scenario_outline_as_previous_test_case?(source)
                 end
               end
-              unless from_scenario_outline_to_hidden_backgroud(@child, child)
+              if from_scenario_outline_to_hidden_backgroud(@child, child)
+                @previous_outline_child = @child
+              else
                 @child.after
                 @previous_outline_child = nil
-              else
-                @previous_outline_child = @child
               end
             end
             child.before unless to_scenario_outline(child) and same_scenario_outline_as_previous_test_case?(source)

--- a/lib/cucumber/formatter/legacy_api/ast.rb
+++ b/lib/cucumber/formatter/legacy_api/ast.rb
@@ -278,7 +278,7 @@ module Cucumber
         end
 
         Scenario = Struct.new(:status, :name, :location) do
-          def backtrace_line(step_name = "#{name}", line = self.location.line)
+          def backtrace_line(step_name = name.to_s, line = self.location.line)
             "#{location.on_line(line)}:in `#{step_name}'"
           end
 
@@ -292,7 +292,7 @@ module Cucumber
         end
 
         ScenarioOutline = Struct.new(:status, :name, :location) do
-          def backtrace_line(step_name = "#{name}", line = self.location.line)
+          def backtrace_line(step_name = name.to_s, line = self.location.line)
             "#{location.on_line(line)}:in `#{step_name}'"
           end
 

--- a/lib/cucumber/formatter/legacy_api/ast.rb
+++ b/lib/cucumber/formatter/legacy_api/ast.rb
@@ -377,9 +377,7 @@ module Cucumber
             @feature = feature
           end
 
-          def feature
-            @feature
-          end
+          attr_reader :feature
         end
 
       end

--- a/lib/cucumber/formatter/pretty.rb
+++ b/lib/cucumber/formatter/pretty.rb
@@ -235,7 +235,7 @@ module Cucumber
           @io.print(format_string(line_comment, :comment))
         end
         @io.puts
-        names[1..-1].each {|s| @io.puts "#{s}"}
+        names[1..-1].each {|s| @io.puts s.to_s}
         @io.flush
       end
 

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -453,9 +453,7 @@ module Cucumber
         cells_rows[0][col]
       end
 
-      def cell_matrix #:nodoc:
-        @cell_matrix
-      end
+      attr_reader :cell_matrix
 
       def col_width(col) #:nodoc:
         columns[col].__send__(:width)

--- a/lib/cucumber/step_match_search.rb
+++ b/lib/cucumber/step_match_search.rb
@@ -34,7 +34,7 @@ module Cucumber
       private
 
       def best_matches(_step_name, step_matches) #:nodoc:
-        no_groups      = step_matches.select {|step_match| step_match.args.length == 0}
+        no_groups      = step_matches.select {|step_match| step_match.args.empty?}
         max_arg_length = step_matches.map {|step_match| step_match.args.length }.max
         top_groups     = step_matches.select {|step_match| step_match.args.length == max_arg_length }
 

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -89,7 +89,7 @@ module Cucumber
             it 'displays the language table' do
               after_parsing '--i18n foo' do
                 ::Gherkin::DIALECTS.keys.map do |key|
-                  expect(@output_stream.string).to include("#{key}");
+                  expect(@output_stream.string).to include(key.to_s);
                 end
               end
             end

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -403,7 +403,7 @@ module Cucumber
               And another undefined step
             FEATURE
 
-          it { expect(@doc.css('pre').map { |pre| /^(Given|And)/.match(pre.text)[1] }).to eq ['Given', 'Given'] }
+          it { expect(@doc.css('pre').map { |pre| /^(Given|And)/.match(pre.text)[1] }).to eq %w(Given Given) }
         end
 
         describe 'with an undefined When step then an undefined And step' do
@@ -415,7 +415,7 @@ module Cucumber
               And another undefined step
             FEATURE
 
-          it { expect(@doc.css('pre').map { |pre| /^(Given|When|And)/.match(pre.text)[1] }).to eq ['Given', 'When', 'When'] }
+          it { expect(@doc.css('pre').map { |pre| /^(Given|When|And)/.match(pre.text)[1] }).to eq %w(Given When When) }
         end
 
         describe 'with an passing Then step and an undefined And step' do
@@ -514,7 +514,7 @@ module Cucumber
               Given(/^this step passes$/) {}
             end
 
-          it { expect(@doc.css('pre').map { |pre| /^(Given|Then|When)/.match(pre.text)[1] }).to eq ['Given', 'Given'] }
+          it { expect(@doc.css('pre').map { |pre| /^(Given|Then|When)/.match(pre.text)[1] }).to eq %w(Given Given) }
         end
 
         describe 'with a scenario outline and a before hook that fails' do

--- a/spec/cucumber/formatter/json_spec.rb
+++ b/spec/cucumber/formatter/json_spec.rb
@@ -812,7 +812,7 @@ module Cucumber
         json.each do |feature|
           elements = feature.fetch('elements') { [] }
           elements.each do |scenario|
-            ['steps', 'before', 'after', 'around'].each do |type|
+            %w(steps before after around).each do |type|
               if scenario[type]
                 scenario[type].each do |step_or_hook|
                   normalise_json_step_or_hook(step_or_hook)

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -408,12 +408,12 @@ module Cucumber
 
         it 'should inspect missing and surplus cells' do
           t1 = DataTable.from([
-            ['name',  'male', 'lastname', 'swedish'],
-            ['aslak', 'true', 'hellesøy', 'false']
+            %w(name  male lastname swedish),
+            %w(aslak true hellesøy false)
           ])
           t2 = DataTable.from([
-            ['name',  'male', 'lastname', 'swedish'],
-            ['aslak', true,   'hellesøy', false]
+            %w(name    male   lastname   swedish),
+             ['aslak', true, 'hellesøy', false]
           ])
           expect { t1.diff!(t2) }.to raise_error
 
@@ -426,13 +426,13 @@ module Cucumber
 
         it 'should allow column mapping of target before diffing' do
           t1 = DataTable.from([
-            ['name',  'male'],
-            ['aslak', 'true']
+            %w(name  male),
+            %w(aslak true)
           ])
           t1.map_column!('male') { |m| m == 'true' }
           t2 = DataTable.from([
-            ['name',  'male'],
-            ['aslak', true]
+            %w(name    male),
+             ['aslak', true]
           ])
           t1.diff!(t2)
           expect( t1.to_s(:indent => 12, :color => false) ).to eq %{
@@ -443,15 +443,15 @@ module Cucumber
 
         it 'should allow column mapping of argument before diffing' do
           t1 = DataTable.from([
-            ['name',  'male'],
-            ['aslak', true]
+            %w(name    male),
+             ['aslak', true]
           ])
           t1.map_column!('male') {
             'true'
           }
           t2 = DataTable.from([
-            ['name',  'male'],
-            ['aslak', 'true']
+            %w(name  male),
+            %w(aslak true)
           ])
           t2.diff!(t1)
           expect( t1.to_s(:indent => 12, :color => false) ).to eq %{
@@ -462,14 +462,14 @@ module Cucumber
 
         it 'should allow header mapping before diffing' do
           t1 = DataTable.from([
-            ['Name',  'Male'],
-            ['aslak', 'true']
+            %w(Name  Male),
+            %w(aslak true)
           ])
           t1.map_headers!('Name' => 'name', 'Male' => 'male')
           t1.map_column!('male') { |m| m == 'true' }
           t2 = DataTable.from([
-            ['name',  'male'],
-            ['aslak', true]
+            %w(name    male),
+             ['aslak', true]
           ])
           t1.diff!(t2)
           expect( t1.to_s(:indent => 12, :color => false) ).to eq %{
@@ -480,12 +480,12 @@ module Cucumber
 
         it 'should detect seemingly identical tables as different' do
           t1 = DataTable.from([
-            ['X',  'Y'],
-            ['2', '1']
+            %w(X Y),
+            %w(2 1)
           ])
           t2 = DataTable.from([
-            ['X',  'Y'],
-            [2, 1]
+            %w(X  Y),
+              [2, 1]
           ])
           expect { t1.diff!(t2) }.to raise_error
           expect( t1.to_s(:indent => 12, :color => false) ).to eq %{
@@ -497,8 +497,8 @@ module Cucumber
 
         it 'should not allow mappings that match more than 1 column' do
           t1 = DataTable.from([
-            ['Cuke',  'Duke'],
-            ['Foo', 'Bar']
+            %w(Cuke Duke),
+            %w(Foo  Bar)
           ])
           expect do
             t1.map_headers!(/uk/ => 'u')

--- a/spec/cucumber/running_test_case_spec.rb
+++ b/spec/cucumber/running_test_case_spec.rb
@@ -132,7 +132,7 @@ module Cucumber
       end
 
       it 'exposes the examples table row cell values' do
-        expect(wrapped_test_case.cell_values).to eq ['a', 'b']
+        expect(wrapped_test_case.cell_values).to eq %w(a b)
       end
 
     end


### PR DESCRIPTION
## Summary
Several fixes has been made for some of the RuboCop offenses reported.

## Details
The following style violations has been fixed whether completely or partially:
- Style/TrailingCommaInArguments
- Style/TrivialAccessors
- Style/UnlessElse
- Style/UnneededInterpolation
- Style/UnneededInterpolation
- Style/WhileUntilDo
- Style/WordArray
- Style/ZeroLengthPredicate

There are RoboCop's offenses reviewed but not fixed due to irrelevance like `Style/VariableName` for the Cyrillic variable names.

## Motivation and Context
There is bunch of exceptions for the code styling tool of RoboCop to be fixed.
Here is the main issue: #1021 

## How Has This Been Tested?
Although only styling is being changed, there is setup of [Travis ](https://travis-ci.org/bv/cucumber-ruby/builds/210334869) to run the proper set of tests. All the tests are green (except for the allowed to fail profiles)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
