### PR TITLE
Fix diffing empty DataTables

### DIFF
--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -589,7 +589,7 @@ module Cucumber
             matched_cols << unmatched_cols.delete_at(mapped_index)
           else
             mark_as_missing(cols[i])
-            empty_col = other_cell_matrix.collect {SurplusCell.new(nil, self, -1)}
+            empty_col = ensure_2d(other_cell_matrix).collect {SurplusCell.new(nil, self, -1)}
             empty_col.first.value = v
             matched_cols << empty_col
           end
@@ -601,7 +601,11 @@ module Cucumber
           cols << empty_col
         end
 
-        return cols.transpose, (matched_cols + unmatched_cols).transpose
+        return ensure_2d(cols.transpose), ensure_2d((matched_cols + unmatched_cols).transpose)
+      end
+
+      def ensure_2d(array) #:nodoc:
+        Array === array[0] ? array : [array]
       end
 
       def ensure_table(table_or_array) #:nodoc:

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -332,6 +332,12 @@ module Cucumber
           }
         end
 
+        it 'should allow diffing empty tables' do
+          t1 = DataTable.from([[]])
+          t2 = DataTable.from([[]])
+          expect{ t1.diff!(t2) }.not_to raise_error
+        end
+
         context 'in case of duplicate header values' do
           it 'raises no error for two identical tables' do
             t = DataTable.from(%{


### PR DESCRIPTION
## Summary
Fixes the following:
```ruby
DataTable.from([[]]).diff! [[]] #=> NoMethodError: undefined method `length' for nil:NilClass
```
See #1096 for much more details.

## Details
Added a private `#ensure_2d` method to DataTable, and used it internally in `#pad_and_match` to make sure we're always dealing with an array of arrays, which the code had previously been assuming.

## Motivation and Context
Fixes #1096

## How Has This Been Tested?
Added unit test to expose bug, then wrote patch to fix it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
