### PR TITLE
Fix incorrect DataTable#diff! report

### DIFF
--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -596,8 +596,8 @@ module Cucumber
         end
 
 
-        empty_col = cell_matrix.collect {SurplusCell.new(nil, self, -1)}
         unmatched_cols.each do
+          empty_col = cell_matrix.collect {SurplusCell.new(nil, self, -1)}
           cols << empty_col
         end
 

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -332,10 +332,42 @@ module Cucumber
           }
         end
 
-        it 'should allow diffing empty tables' do
-          t1 = DataTable.from([[]])
-          t2 = DataTable.from([[]])
-          expect{ t1.diff!(t2) }.not_to raise_error
+        context 'with empty tables' do
+          it 'should allow diffing empty tables' do
+            t1 = DataTable.from([[]])
+            t2 = DataTable.from([[]])
+            expect{ t1.diff!(t2) }.not_to raise_error
+          end
+
+          it 'should be able to diff when the right table is empty' do
+            t1 = DataTable.from(%{
+              |a|b|c|
+              |d|e|f|
+              |g|h|i|
+            })
+            t2 = DataTable.from([[]])
+            expect { t1.diff!(t2) }.to raise_error
+            expect( t1.to_s(:indent => 14, :color => false) ).to eq %{
+              | (-) a | (-) b | (-) c |
+              | (-) d | (-) e | (-) f |
+              | (-) g | (-) h | (-) i |
+            }
+          end
+
+          it 'should be able to diff when the left table is empty' do
+            t1 = DataTable.from([[]])
+            t2 = DataTable.from(%{
+              |a|b|c|
+              |d|e|f|
+              |g|h|i|
+            })
+            expect { t1.diff!(t2) }.to raise_error
+            expect( t1.to_s(:indent => 14, :color => false) ).to eq %{
+              | (+) a | (+) b | (+) c |
+              | (+) d | (+) e | (+) f |
+              | (+) g | (+) h | (+) i |
+            }
+          end
         end
 
         context 'in case of duplicate header values' do


### PR DESCRIPTION
## Summary

This fixes a bug in `#diff!` that was causing incorrect values to be displayed for the header row in the diff report.

## Details

If columns were missing in the first table, they would be filled in with instances of `SurplusCell`. However, the same instance of `SurplusCell` was being used for every missing column in the header column, so when the value was being set on one cell, it was being set on them all. This led to the last value "winning," and the diff report reporting an incorrect diff summary. For example:

```ruby
DataTable.from([[]]).diff! DataTable.from(%{
  |a|b|c|
  |d|e|f|
  |g|h|i|
})

            | (+) c | (+) c | (+) c |
            | (+) d | (+) e | (+) f |
            | (+) g | (+) h | (+) i |
```

The fix is simply to generate a new instance of SurplusCell for each cell.

## How Has This Been Tested?

Added two tests to expose the bug, and added the patch to fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
