### PR TITLE
Fix rubocop offenses 1021 003

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -752,13 +752,6 @@ Style/OpMethod:
 Style/ParallelAssignment:
   Enabled: false
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AllowSafeAssignment.
-Style/ParenthesesAroundCondition:
-  Exclude:
-    - 'lib/cucumber/multiline_argument/data_table.rb'
-
 # Offense count: 225
 # Cop supports --auto-correct.
 # Configuration parameters: PreferredDelimiters.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1077,18 +1077,6 @@ Style/SymbolProc:
 Style/TrailingBlankLines:
   Enabled: false
 
-# Offense count: 43
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline, SupportedStyles.
-# SupportedStyles: comma, consistent_comma, no_comma
-Style/TrailingCommaInLiteral:
-  Exclude:
-    - 'lib/cucumber/cli/options.rb'
-    - 'lib/cucumber/term/ansicolor.rb'
-    - 'spec/cucumber/file_specs_spec.rb'
-    - 'spec/cucumber/filters/tag_limits/verifier_spec.rb'
-    - 'spec/cucumber/formatter/legacy_api/adapter_spec.rb'
-
 # Offense count: 18
 # Cop supports --auto-correct.
 # Reviewed: in pretty_spec.rb, progress_spec.rb offences look false,

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -986,13 +986,6 @@ Style/SpaceBeforeComma:
   Exclude:
     - 'lib/cucumber/term/ansicolor.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment.
-Style/SpaceBeforeFirstArg:
-  Exclude:
-    - 'spec/cucumber/rb_support/rb_step_definition_spec.rb'
-
 # Offense count: 255
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -316,7 +316,7 @@ TEXT
           'cucumber examples/i18n/en/features',
           'cucumber @rerun.txt (See --format rerun)',
           'cucumber examples/i18n/it/features/somma.feature:6:98:113',
-          'cucumber -s -i http://rubyurl.com/eeCl', '', '',
+          'cucumber -s -i http://rubyurl.com/eeCl', '', ''
         ].join("\n")
       end
 

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -585,7 +585,7 @@ module Cucumber
 
         header_values.each_with_index do |v, i|
           mapped_index = unmatched_cols.index{|unmapped_col| unmapped_col.first == v}
-          if (mapped_index)
+          if mapped_index
             matched_cols << unmatched_cols.delete_at(mapped_index)
           else
             mark_as_missing(cols[i])

--- a/lib/cucumber/term/ansicolor.rb
+++ b/lib/cucumber/term/ansicolor.rb
@@ -33,7 +33,7 @@ module Cucumber
         [ :on_blue      ,  44 ],
         [ :on_magenta   ,  45 ],
         [ :on_cyan      ,  46 ],
-        [ :on_white     ,  47 ],
+        [ :on_white     ,  47 ]
       ]
 
       ATTRIBUTE_NAMES = ATTRIBUTES.transpose.first

--- a/spec/cucumber/file_specs_spec.rb
+++ b/spec/cucumber/file_specs_spec.rb
@@ -15,7 +15,7 @@ module Cucumber
         Cucumber::Core::Ast::Location.new('features/foo.feature', 3),
         Cucumber::Core::Ast::Location.new('features/bar.feature', 4),
         Cucumber::Core::Ast::Location.new('features/bar.feature', 5),
-        Cucumber::Core::Ast::Location.new('features/bar.feature', 6),
+        Cucumber::Core::Ast::Location.new('features/bar.feature', 6)
       ]
     end
 
@@ -23,7 +23,7 @@ module Cucumber
       expect(files.length).to eq 2
       expect(files).to eq [
         'features/foo.feature',
-        'features/bar.feature',
+        'features/bar.feature'
       ]
     end
 
@@ -42,7 +42,7 @@ module Cucumber
       it 'returns a wildcard location for that file' do
         expect(locations).to eq [
           Cucumber::Core::Ast::Location.new('features/foo.feature'),
-          Cucumber::Core::Ast::Location.new('features/bar.feature', 34),
+          Cucumber::Core::Ast::Location.new('features/bar.feature', 34)
         ]
       end
     end
@@ -53,7 +53,7 @@ module Cucumber
       it 'returns locations in the order specified' do
         expect(locations).to eq [
           Cucumber::Core::Ast::Location.new('features/foo.feature', 10),
-          Cucumber::Core::Ast::Location.new('features/foo.feature', 1),
+          Cucumber::Core::Ast::Location.new('features/foo.feature', 1)
         ]
       end
     end

--- a/spec/cucumber/filters/tag_limits/verifier_spec.rb
+++ b/spec/cucumber/filters/tag_limits/verifier_spec.rb
@@ -16,7 +16,7 @@ describe Cucumber::Filters::TagLimits::Verifier do
       let(:locations) do
         [
           double(:location, to_s: 'path/to/some.feature:3'),
-          double(:location, to_s: 'path/to/some/other.feature:8'),
+          double(:location, to_s: 'path/to/some/other.feature:8')
         ]
       end
 

--- a/spec/cucumber/formatter/legacy_api/adapter_spec.rb
+++ b/spec/cucumber/formatter/legacy_api/adapter_spec.rb
@@ -106,7 +106,7 @@ module Cucumber
                   step 'passing'
                 end
               end
-            end,
+            end
           ]
           runner = Core::Test::Runner.new(events)
           compile gherkin_docs, runner, default_filters
@@ -147,7 +147,7 @@ module Cucumber
                   :after_steps,
                 :after_feature_element,
               :after_feature,
-            :after_features,
+            :after_features
           ]
         end
 
@@ -170,7 +170,7 @@ module Cucumber
                     :scenario_name,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -207,7 +207,7 @@ module Cucumber
                     :scenario_name,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -238,7 +238,7 @@ module Cucumber
                     :after_steps,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -276,7 +276,7 @@ module Cucumber
               :after_steps,
               :after_feature_element,
               :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -322,7 +322,7 @@ module Cucumber
                     :after_steps,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -357,7 +357,7 @@ module Cucumber
                   :scenario_name,
                 :after_feature_element,
               :after_feature,
-            :after_features,
+            :after_features
           ]
         end
 
@@ -416,7 +416,7 @@ module Cucumber
                     :after_steps,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -498,7 +498,7 @@ module Cucumber
                     :after_examples_array,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -580,7 +580,7 @@ module Cucumber
                     :after_steps,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -685,7 +685,7 @@ module Cucumber
                     :after_examples_array,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -758,7 +758,7 @@ module Cucumber
                     :after_examples_array,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -846,7 +846,7 @@ module Cucumber
                     :after_examples_array,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -896,7 +896,7 @@ module Cucumber
                     :after_steps,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -940,7 +940,7 @@ module Cucumber
               :after_steps,
               :after_feature_element,
               :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -994,7 +994,7 @@ module Cucumber
                     :after_examples_array,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -1063,7 +1063,7 @@ module Cucumber
                     :after_examples_array,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
           ]
         end
 
@@ -1132,7 +1132,7 @@ module Cucumber
                     :after_steps,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
             ]
         end
 
@@ -1192,7 +1192,7 @@ module Cucumber
                     :after_examples_array,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
             ]
         end
 
@@ -1267,7 +1267,7 @@ module Cucumber
                     :after_examples_array,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
             ]
         end
 
@@ -1359,7 +1359,7 @@ module Cucumber
                     :after_examples_array,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
             ]
         end
 
@@ -1413,7 +1413,7 @@ module Cucumber
                     :after_examples_array,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
             ]
         end
 
@@ -1473,7 +1473,7 @@ module Cucumber
                     :after_steps,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
             ]
         end
 
@@ -1534,7 +1534,7 @@ module Cucumber
                       :after_examples_array,
                     :after_feature_element,
                   :after_feature,
-                :after_features,
+                :after_features
               ]
           end
         end
@@ -1581,7 +1581,7 @@ module Cucumber
                       :after_steps,
                     :after_feature_element,
                   :after_feature,
-                :after_features,
+                :after_features
                 ])
           end
         end
@@ -1628,7 +1628,7 @@ module Cucumber
                       :after_steps,
                     :after_feature_element,
                   :after_feature,
-                :after_features,
+                :after_features
                 ])
           end
 
@@ -1679,7 +1679,7 @@ module Cucumber
                       :after_steps,
                     :after_feature_element,
                   :after_feature,
-                :after_features,
+                :after_features
                 ])
           end
 
@@ -1741,7 +1741,7 @@ module Cucumber
                       :after_examples_array,
                     :after_feature_element,
                   :after_feature,
-                :after_features,
+                :after_features
               ])
           end
         end
@@ -1791,7 +1791,7 @@ module Cucumber
                       :after_steps,
                     :after_feature_element,
                   :after_feature,
-                :after_features,
+                :after_features
                 ])
           end
         end
@@ -1839,7 +1839,7 @@ module Cucumber
                     :exception,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
             ])
           end
 
@@ -1900,7 +1900,7 @@ module Cucumber
                     :after_examples_array,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
             ])
           end
         end
@@ -1948,7 +1948,7 @@ module Cucumber
                     :exception,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
             ])
           end
         end
@@ -1980,7 +1980,7 @@ module Cucumber
                     :exception,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
             ])
           end
         end
@@ -2020,7 +2020,7 @@ module Cucumber
                     :exception,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
             ])
           end
         end
@@ -2068,7 +2068,7 @@ module Cucumber
                     :after_steps,
                   :after_feature_element,
                 :after_feature,
-              :after_features,
+              :after_features
             ])
           end
         end

--- a/spec/cucumber/rb_support/rb_step_definition_spec.rb
+++ b/spec/cucumber/rb_support/rb_step_definition_spec.rb
@@ -176,7 +176,7 @@ module Cucumber
       end
 
       it 'allows puts' do
-        expect(user_interface).to  receive(:puts).with('wasup')
+        expect(user_interface).to receive(:puts).with('wasup')
         dsl.Given(/Loud/) do
           puts 'wasup'
         end


### PR DESCRIPTION
## Summary
Several fixes have been made for some of the RuboCop offenses reported.

## Details
There are rubocop offenses, which has been fixed:
Style/TrailingCommaInLiteral
Style/SpaceBeforeFirstArg
Style/ParenthesesAroundCondition

## Motivation and Context
There is bunch of exceptions for the code styling tool of RoboCop to be fixed.
Here is the main issue: #1021 

## How Has This Been Tested?
`bundle exec rake` produces no test failures
There build configuration on Travis passes green: https://travis-ci.org/bv/cucumber-ruby-bv/builds/218226436

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)