### PR TITLE
use absolute path to avoid chdir issues

### DIFF
--- a/lib/cucumber/formatter/io.rb
+++ b/lib/cucumber/formatter/io.rb
@@ -26,7 +26,7 @@ module Cucumber
         raise "You *must* specify --out DIR for the #{name} formatter" unless String === path
         raise "I can't write #{name} reports to a file - it has to be a directory" if File.file?(path)
         FileUtils.mkdir_p(path) unless File.directory?(path)
-        path
+        File.absolute_path path
       end
     end
   end

--- a/spec/cucumber/formatter/junit_spec.rb
+++ b/spec/cucumber/formatter/junit_spec.rb
@@ -117,8 +117,8 @@ module Cucumber
                   Given a passing scenario
             }, File.join('features', 'some', 'path', 'spec.feature')
 
-            it 'writes the filename including the subdirectory' do
-              expect(@formatter.written_files.keys.first).to eq File.join('', 'TEST-features-some-path-spec.xml')
+            it 'writes the filename with absolute path' do
+              expect(@formatter.written_files.keys.first).to eq File.absolute_path('TEST-features-some-path-spec.xml')
             end
           end
 


### PR DESCRIPTION
I hit an issue that sometimes after failure the junit reports cannot be 
generated due to:
```
No such file or directory @ rb_sysopen - junit-report/TEST-features-admin-build.xml (Errno::ENOENT)
```

I initially asked about this in:
https://groups.google.com/forum/#!topic/cukes/EZ9mOm7iiKs