### PR TITLE
Windows 10 (WINDOWS_MODERN) supports ANSI coloring

### DIFF
--- a/lib/cucumber/formatter/ansicolor.rb
+++ b/lib/cucumber/formatter/ansicolor.rb
@@ -2,7 +2,7 @@
 require 'cucumber/platform'
 require 'cucumber/term/ansicolor'
 
-if Cucumber::WINDOWS_MRI
+if Cucumber::WINDOWS_MRI && !Cucumber::WINDOWS_MODERN
   unless ENV['ANSICON']
     STDERR.puts %{*** WARNING: You must use ANSICON 1.31 or higher (https://github.com/adoxa/ansicon/) to get coloured output on Windows}
     Cucumber::Term::ANSIColor.coloring = false


### PR DESCRIPTION
Allow Cucumber on Windows 10 to support ANSI coloring into its output without ANSICON

## Summary
Cucumber relies on ANSICON to produce colored output in Windows. Windows 10, however, natively supports it. For Windows 10 Creators Update I made a change so that ANSICON is not required

## Details
As of Windows 10 Microsoft does support ANSI colors in the Command prompt. Even more colors have been added in the Creators Update (256):
https://blogs.msdn.microsoft.com/commandline/2017/04/11/windows-10-creators-update-whats-new-in-bashwsl-windows-console/

I have introduced Cucumber::WINDOWS_MODERN flag in Cucumber core which is set on Creators Update (10.0.15063). If this flag is set, do not prompt for ANSICON but use colors.

## Motivation and Context
Cucumber is unnecessary requiring ANSICON for Windows 10, where ANSI colored output is supported. Fix that by outputting colors on Windows versions that support them

## How Has This Been Tested?
I have tested it on Windows 10 Anniversary and Creators Updates

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
