### PR TITLE
error code 0 on successful `--retry`

### DIFF
--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -26,6 +26,8 @@ module Cucumber
     # @method on_event
     def_instance_delegator :event_bus, :on, :on_event
 
+    attr_writer :total_cases
+
     # @private
     def notify(message, *args)
       event_bus.send(message, *args)
@@ -65,6 +67,10 @@ module Cucumber
 
     def retry_attempts
       @options[:retry]
+    end
+
+    def total_cases
+      @total_cases ||= 0
     end
 
     def guess?

--- a/lib/cucumber/filters/retry.rb
+++ b/lib/cucumber/filters/retry.rb
@@ -8,6 +8,7 @@ module Cucumber
     class Retry < Core::Filter.new(:configuration)
 
       def test_case(test_case)
+        configuration.total_cases += 1
         configuration.on_event(:test_case_finished) do |event|
           next unless retry_required?(test_case, event)
 

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -231,9 +231,10 @@ module Cucumber
       elsif @configuration.retry_attempts > 0
         if summary_report.test_cases.total_passed == @configuration.total_cases
           Cucumber.logger.info "All retried test cases passed!\n" if summary_report.test_cases.total_failed > 0
-          return false
+          false
+        else
+          true
         end
-        true
       else
         summary_report.test_cases.total_failed > 0 || summary_report.test_steps.total_failed > 0 ||
           (@configuration.strict? && (summary_report.test_steps.total_undefined > 0 || summary_report.test_steps.total_pending > 0))

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -228,6 +228,8 @@ module Cucumber
     def failure?
       if @configuration.wip?
         summary_report.test_cases.total_passed > 0
+      elsif @configuration.retry_attempts > 0
+        summary_report.test_cases.total_passed != @configuration.total_cases
       else
         summary_report.test_cases.total_failed > 0 || summary_report.test_steps.total_failed > 0 ||
           (@configuration.strict? && (summary_report.test_steps.total_undefined > 0 || summary_report.test_steps.total_pending > 0))
@@ -246,6 +248,8 @@ module Cucumber
         filters << Cucumber::Core::Test::NameFilter.new(name_regexps)
         filters << Cucumber::Core::Test::LocationsFilter.new(filespecs.locations)
         filters << Filters::Randomizer.new(@configuration.seed) if @configuration.randomize?
+        filters << Filters::Quit.new
+        filters << Filters::Retry.new(@configuration)
         # TODO: can we just use Glue::RegistryAndMore's step definitions directly?
         step_match_search = StepMatchSearch.new(@support_code.registry.method(:step_matches), @configuration)
         filters << Filters::ActivateSteps.new(step_match_search, @configuration)

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -229,7 +229,11 @@ module Cucumber
       if @configuration.wip?
         summary_report.test_cases.total_passed > 0
       elsif @configuration.retry_attempts > 0
-        summary_report.test_cases.total_passed != @configuration.total_cases
+        unless summary_report.test_cases.total_passed != @configuration.total_cases
+          Cucumber.logger.info "All retried test cases passed!\n" if summary_report.test_cases.total_failed > 0
+          return false
+        end
+        true
       else
         summary_report.test_cases.total_failed > 0 || summary_report.test_steps.total_failed > 0 ||
           (@configuration.strict? && (summary_report.test_steps.total_undefined > 0 || summary_report.test_steps.total_pending > 0))

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -229,7 +229,7 @@ module Cucumber
       if @configuration.wip?
         summary_report.test_cases.total_passed > 0
       elsif @configuration.retry_attempts > 0
-        unless summary_report.test_cases.total_passed != @configuration.total_cases
+        if summary_report.test_cases.total_passed == @configuration.total_cases
           Cucumber.logger.info "All retried test cases passed!\n" if summary_report.test_cases.total_failed > 0
           return false
         end


### PR DESCRIPTION
## Summary

A basic working version of --retry based on work by @streetlogics, in the time I had available.

The logging could use some work and it would be nice to get feedback from the maintainers.

I figured I would put this here in case it helps someone else out and maybe it can go part-way towards a fix for #1044 :)

## Details

I cherry picked the commits https://github.com/cucumber/cucumber-ruby/compare/master...streetlogics:issue/retry-success-exit-code-0-1044 on top of master.
See https://github.com/cucumber/cucumber-ruby/issues/1044#issuecomment-278864246.

## Motivation and Context

I tried using @streetlogics branch but I got an ArgumentError when a feature is retried.
This seems to have been fixed by 31968ae09ae5ff8898cbc571ac9a932c98f0bbbd, that was not yet in the remote branch.

## How Has This Been Tested?

I tested quickly locally and can confirm the error code is now 0 if a step succeeds on subsequent retry.