### PR TITLE
Travis: jruby-9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - rvm: 2.3.4
     - rvm: 2.2
     - rvm: 2.1
-    - rvm: jruby-9.1.10.0
+    - rvm: jruby-9.1.12.0
       env:
         # Travis by default also have "-Dcext.enabled=false" set in
         # JRUBY_OPTS, but JRuby 9 does not support C extensions at all


### PR DESCRIPTION

## Summary

This PR updates the CI matrix to use latest JRuby.


## Details

See [JRuby's blog post](http://jruby.org/2017/06/15/jruby-9-1-12-0.html
).
