### PR TITLE
Spec: Events.registry exercised

### DIFF
--- a/spec/cucumber/events_spec.rb
+++ b/spec/cucumber/events_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cucumber
+  describe Events do
+    it 'builds a registry without failing' do
+      expect { described_class.registry }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a unit test which calls the method `Events.registry`, in order to exercise the code. See #1124 

---

Eh, also: work to get rid of all the Ruby warnings, to prepare to enable `--warnings` in `.rspec`.