### PR TITLE
Test that tags are available in the before_test_case event

### DIFF
--- a/features/docs/events/test_case_starting_event.feature
+++ b/features/docs/events/test_case_starting_event.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Test Case Starting Event
 
   This event is fired just before each scenario or scenario outline example row
@@ -9,8 +10,10 @@ Feature: Test Case Starting Event
     Given the standard step definitions
     And a file named "features/test.feature" with:
       """
+      @feature
       Feature: A feature
 
+        @scenario
         Scenario: A passing scenario
           Given this is a step
       """
@@ -21,6 +24,7 @@ Feature: Test Case Starting Event
         stdout = config.out_stream # make sure all the `puts` calls can write to the same output
         config.on_event :test_case_starting do |event|
           stdout.puts "before"
+          stdout.puts event.test_case.tags.map(&:name)
         end
         config.on_event :test_case_finished do |event|
           stdout.puts "after"
@@ -37,8 +41,12 @@ Feature: Test Case Starting Event
     Then it should pass with:
       """
       before
+      @feature
+      @scenario
+      @feature
       Feature: A feature
       
+        @scenario
         Scenario: A passing scenario
           Given this is a step
       after


### PR DESCRIPTION
This PR verifies that both feature- and scenario-level tags are available inside test_case_starting event hooks

## Summary

See cucumber/cucumber-ruby-core#115 for context.

## Details

Since the required functionality already works in the new events API, this PR only changes a feature to make sure the functionality is tested.

## Motivation and Context

There was a concern that feature-level tags were not available in before_tag hooks in the old formatter API. This PR verifies that this is fixed in the new events API

## How Has This Been Tested?

Made an addition to one of the feature files.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
