### PR TITLE
Do not delay the the loading of step definitions

### DIFF
--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -64,11 +64,9 @@ module Cucumber
 
     require 'cucumber/wire/plugin'
     def run!
-      install_wire_plugin
-      load_support_files
-      fire_after_configuration_hook
-      formatters
       load_step_definitions
+      install_wire_plugin
+      fire_after_configuration_hook
       self.visitor = report
 
       receiver = Test::Runner.new(@configuration.event_bus)
@@ -266,13 +264,8 @@ module Cucumber
       end
     end
 
-    def load_support_files
-      files = @configuration.support_to_load
-      @support_code.load_files!(files)
-    end
-
     def load_step_definitions
-      files = @configuration.step_defs_to_load
+      files = @configuration.support_to_load + @configuration.step_defs_to_load
       @support_code.load_files!(files)
     end
 


### PR DESCRIPTION
When the events are queued in the event queue (https://github.com/cucumber/cucumber-ruby-core/pull/136) and passed to new handlers when they register, there is no need to delay the loading
of the step definitions until the formatter have been created.

This reverts change of cc7eb89 in runtime.rb (from #977).
