### PR TITLE
Step: Rename name to text

### DIFF
--- a/features/docs/api/listen_for_events.feature
+++ b/features/docs/api/listen_for_events.feature
@@ -21,7 +21,7 @@ Feature: Listen for events
         io = config.out_stream
         config.on_event :step_activated do |event|
           io.puts "Success!"
-          io.puts "Step name:       #{event.test_step.name}"
+          io.puts "Step name:       #{event.test_step.text}"
           io.puts "Source location: #{event.step_match.location}"
         end
       end

--- a/features/docs/api/listen_for_events.feature
+++ b/features/docs/api/listen_for_events.feature
@@ -21,7 +21,7 @@ Feature: Listen for events
         io = config.out_stream
         config.on_event :step_activated do |event|
           io.puts "Success!"
-          io.puts "Step name:       #{event.test_step.text}"
+          io.puts "Step text:       #{event.test_step}"
           io.puts "Source location: #{event.step_match.location}"
         end
       end

--- a/features/docs/events/test_step_finished_event.feature
+++ b/features/docs/events/test_step_finished_event.feature
@@ -24,7 +24,7 @@ Feature: Test Step Finished Event
       """
       AfterConfiguration do |config|
         config.on_event :test_step_finished do |event|
-          config.out_stream.puts "Test step: #{event.test_step.name}"
+          config.out_stream.puts "Test step: #{event.test_step}"
           config.out_stream.puts "The result is: #{event.result}"
         end
       end

--- a/lib/cucumber/filters/activate_steps.rb
+++ b/lib/cucumber/filters/activate_steps.rb
@@ -44,11 +44,10 @@ module Cucumber
 
           def result
             begin
-              return NoStepMatch.new(test_step.source.last, test_step.name) unless matches.any?
+              return NoStepMatch.new(test_step.source.last, test_step.text) unless matches.any?
             rescue Cucumber::Ambiguous => e
               return AmbiguousStepMatch.new(e)
             end
-
             configuration.notify :step_activated, test_step, match
             return SkippingStepMatch.new if configuration.dry_run?
             match
@@ -64,7 +63,7 @@ module Cucumber
           end
 
           def matches
-            step_match_search.call(test_step.name)
+            step_match_search.call(test_step.text)
           end
         end
       end

--- a/lib/cucumber/formatter/console.rb
+++ b/lib/cucumber/formatter/console.rb
@@ -135,7 +135,7 @@ module Cucumber
 
       def do_print_snippets(snippet_text_proc)
         snippets = @snippets_input.map do |data|
-          snippet_text_proc.call(data.actual_keyword, data.step.name, data.step.multiline_arg)
+          snippet_text_proc.call(data.actual_keyword, data.step.text, data.step.multiline_arg)
         end.uniq
 
         text = "\nYou can implement step definitions for undefined steps with these snippets:\n\n"

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -14,6 +14,7 @@ module Cucumber
       def initialize(config)
         @io = ensure_io(config.out_stream)
         @feature_hashes = []
+        @step_or_hook_hash = {}
         config.on_event :test_case_started, &method(:on_test_case_started)
         config.on_event :test_case_finished, &method(:on_test_case_finished)
         config.on_event :test_step_started, &method(:on_test_step_started)

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -102,7 +102,7 @@ module Cucumber
       end
 
       def first_step_after_background?(test_step)
-        test_step.source[1].name != @element_hash[:name]
+        test_step.source[1].to_s != @element_hash[:name]
       end
 
       def internal_hook?(test_step)
@@ -161,7 +161,7 @@ module Cucumber
       def create_step_hash(step_source)
         step_hash = {
           keyword: step_source.keyword,
-          name: step_source.name,
+          name: step_source.to_s,
           line: step_source.location.line
         }
         step_hash[:comments] = Formatter.create_comments_array(step_source.comments) unless step_source.comments.empty?
@@ -240,7 +240,7 @@ module Cucumber
             uri: feature.file,
             id: create_id(feature),
             keyword: feature.keyword,
-            name: feature.name,
+            name: feature.to_s,
             description: feature.description,
             line: feature.location.line
           }
@@ -259,7 +259,7 @@ module Cucumber
         def background(background)
           @background_hash = {
             keyword: background.keyword,
-            name: background.name,
+            name: background.to_s,
             description: background.description,
             line: background.location.line,
             type: 'background'
@@ -271,7 +271,7 @@ module Cucumber
           @test_case_hash = {
             id: create_id(scenario),
             keyword: scenario.keyword,
-            name: scenario.name,
+            name: scenario.to_s,
             description: scenario.description,
             line: scenario.location.line,
             type: 'scenario'
@@ -284,7 +284,7 @@ module Cucumber
           @test_case_hash = {
             id: create_id(scenario) + ';' + @example_id,
             keyword: scenario.keyword,
-            name: scenario.name,
+            name: scenario.to_s,
             description: scenario.description,
             line: @row.location.line,
             type: 'scenario'
@@ -317,7 +317,7 @@ module Cucumber
         private
 
         def create_id(element)
-          element.name.downcase.tr(' ', '-')
+          element.to_s.downcase.tr(' ', '-')
         end
 
         def create_tags_array(tags)

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -105,7 +105,7 @@ module Cucumber
         return output if result.ok?(@config.strict)
         if test_case.keyword == 'Scenario'
           output += @failing_step_source.keyword.to_s unless hook?(@failing_step_source)
-          output += "#{@failing_step_source.name}\n"
+          output += "#{@failing_step_source}\n"
         else
           output += "Example row: #{row_name}\n"
         end
@@ -113,7 +113,7 @@ module Cucumber
       end
 
       def hook?(step)
-        ['Before hook', 'After hook', 'AfterStep hook'].include? step.name
+        ['Before hook', 'After hook', 'AfterStep hook'].include? step.text
       end
 
       def build_testcase(result, scenario_designation, output)

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -920,7 +920,7 @@ module Cucumber
 
           [:step, :outline_step].each do |node_name|
             define_method(node_name) do |node|
-              record_width_of_step node
+              record_width_of node
             end
           end
 
@@ -934,16 +934,11 @@ module Cucumber
               [1, max - node.name.length - node.keyword.length].max
             else
               [1, max - node.text.length - node.keyword.length].max
-            end  
-            
+            end
           end
 
           def record_width_of(node)
             @widths << node.keyword.length + node.to_s.length + 1
-          end
-          
-          def record_width_of_step(node)
-            @widths << node.keyword.length + node.text.length + 1
           end
 
           private

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -920,7 +920,7 @@ module Cucumber
 
           [:step, :outline_step].each do |node_name|
             define_method(node_name) do |node|
-              record_width_of_step node
+              record_width_of node
             end
           end
 
@@ -930,20 +930,11 @@ module Cucumber
           def of(node)
             # The length of the instantiated steps in --expand mode are currently
             # not included in the calculation of max => make sure to return >= 1
-            if node.respond_to?(:name)
-              [1, max - node.name.length - node.keyword.length].max
-            else
-              [1, max - node.text.length - node.keyword.length].max
-            end  
-            
+            [1, max - node.to_s.length - node.keyword.length].max
           end
 
           def record_width_of(node)
-            @widths << node.keyword.length + node.name.length + 1
-          end
-          
-          def record_width_of_step(node)
-            @widths << node.keyword.length + node.text.length + 1
+            @widths << node.keyword.length + node.to_s.length + 1
           end
 
           private

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -930,11 +930,7 @@ module Cucumber
           def of(node)
             # The length of the instantiated steps in --expand mode are currently
             # not included in the calculation of max => make sure to return >= 1
-            if node.respond_to?(:name)
-              [1, max - node.name.length - node.keyword.length].max
-            else
-              [1, max - node.text.length - node.keyword.length].max
-            end
+            [1, max - node.to_s.length - node.keyword.length].max
           end
 
           def record_width_of(node)

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -920,7 +920,7 @@ module Cucumber
 
           [:step, :outline_step].each do |node_name|
             define_method(node_name) do |node|
-              record_width_of node
+              record_width_of_step node
             end
           end
 
@@ -930,11 +930,20 @@ module Cucumber
           def of(node)
             # The length of the instantiated steps in --expand mode are currently
             # not included in the calculation of max => make sure to return >= 1
-            [1, max - node.to_s.length - node.keyword.length].max
+            if node.respond_to?(:name)
+              [1, max - node.name.length - node.keyword.length].max
+            else
+              [1, max - node.text.length - node.keyword.length].max
+            end  
+            
           end
 
           def record_width_of(node)
-            @widths << node.keyword.length + node.to_s.length + 1
+            @widths << node.keyword.length + node.name.length + 1
+          end
+          
+          def record_width_of_step(node)
+            @widths << node.keyword.length + node.text.length + 1
           end
 
           private

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -939,7 +939,7 @@ module Cucumber
           end
 
           def record_width_of(node)
-            @widths << node.keyword.length + node.name.length + 1
+            @widths << node.keyword.length + node.to_s.length + 1
           end
           
           def record_width_of_step(node)

--- a/lib/cucumber/formatter/legacy_api/ast.rb
+++ b/lib/cucumber/formatter/legacy_api/ast.rb
@@ -103,7 +103,7 @@ module Cucumber
                                     :embeddings) do
           extend Forwardable
 
-          def_delegators :step, :keyword, :name, :multiline_arg, :location
+          def_delegators :step, :keyword, :text, :multiline_arg, :location
 
           def accept(formatter)
             formatter.before_step(self)

--- a/lib/cucumber/formatter/legacy_api/ast.rb
+++ b/lib/cucumber/formatter/legacy_api/ast.rb
@@ -155,6 +155,10 @@ module Cucumber
             self
           end
 
+          def to_s
+            step.text
+          end
+
           private
 
           def source_indent

--- a/lib/cucumber/formatter/legacy_api/ast.rb
+++ b/lib/cucumber/formatter/legacy_api/ast.rb
@@ -240,6 +240,10 @@ module Cucumber
             '| ' + cells.join(' | ') + ' |'
           end
 
+          def to_s
+            name
+          end
+
           def failed?
             status == :failed
           end

--- a/lib/cucumber/formatter/legacy_api/ast.rb
+++ b/lib/cucumber/formatter/legacy_api/ast.rb
@@ -156,7 +156,7 @@ module Cucumber
           end
 
           def to_s
-            step.text
+            text
           end
 
           private

--- a/lib/cucumber/hooks.rb
+++ b/lib/cucumber/hooks.rb
@@ -43,7 +43,7 @@ module Cucumber
         @location = location
       end
 
-      def name
+      def text
         'After hook'
       end
 
@@ -63,7 +63,7 @@ module Cucumber
         @location = location
       end
 
-      def name
+      def text
         'Before hook'
       end
 
@@ -83,7 +83,7 @@ module Cucumber
         @location = location
       end
 
-      def name
+      def text
         'AfterStep hook'
       end
 

--- a/spec/cucumber/filters/activate_steps_spec.rb
+++ b/spec/cucumber/filters/activate_steps_spec.rb
@@ -27,7 +27,7 @@ describe Cucumber::Filters::ActivateSteps do
 
     it 'activates each step' do
       expect(step_match).to receive(:activate) do |test_step|
-        expect(test_step.name).to eq 'a passing step'
+        expect(test_step.text).to eq 'a passing step'
       end
       compile [doc], receiver, [filter]
     end
@@ -35,7 +35,7 @@ describe Cucumber::Filters::ActivateSteps do
     it 'notifies with a StepActivated event' do
       expect(configuration).to receive(:notify) do |message, test_step, step_match|
         expect(message).to eq :step_activated
-        expect(test_step.name).to eq 'a passing step'
+        expect(test_step.text).to eq 'a passing step'
         expect(step_match).to eq step_match
       end
       compile [doc], receiver, [filter]
@@ -60,7 +60,7 @@ describe Cucumber::Filters::ActivateSteps do
 
     it 'activates each step' do
       expect(step_match).to receive(:activate) do |test_step|
-        expect(test_step.name).to eq 'a passing step'
+        expect(test_step.text).to eq 'a passing step'
       end
       compile [doc], receiver, [filter]
     end
@@ -115,7 +115,7 @@ describe Cucumber::Filters::ActivateSteps do
     it 'notifies with a StepActivated event' do
       expect(configuration).to receive(:notify) do |message, test_step, step_match|
         expect(message).to eq :step_activated
-        expect(test_step.name).to eq 'a passing step'
+        expect(test_step.text).to eq 'a passing step'
         expect(step_match).to eq step_match
       end
       compile [doc], receiver, [filter]

--- a/spec/cucumber/formatter/json_spec.rb
+++ b/spec/cucumber/formatter/json_spec.rb
@@ -43,7 +43,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec.feature:4"},
                       "result": {"status": "undefined"}}]}]}]})
@@ -79,7 +79,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:62"},
                       "result": {"status": "passed",
@@ -116,7 +116,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:99"},
                       "result": {"status": "failed",
@@ -154,7 +154,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:137"},
                       "result": {"status": "pending",
@@ -196,7 +196,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 8,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:179"},
                       "result": {"status": "passed",
@@ -250,7 +250,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 6,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:227"},
                       "result": {"status": "passed",
@@ -269,7 +269,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 15,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:227"},
                       "result": {"status": "passed",
@@ -343,7 +343,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Then ",
-                      "text": "the monkey eats bananas",
+                      "name": "the monkey eats bananas",
                       "line": 11,
                       "comments": [{"value": "#step comment1",
                                     "line": 10}],
@@ -359,7 +359,7 @@ module Cucumber
                    "type": "background",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 6,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:307"},
                       "result": {"status": "passed",
@@ -378,7 +378,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Then ",
-                      "text": "the monkey eats bananas",
+                      "name": "the monkey eats bananas",
                       "line": 22,
                       "comments": [{"value": "#step comment2",
                                     "line": 15}],
@@ -420,7 +420,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 4,
                       "doc_string": {"value": "the doc string",
                                      "content_type": "",
@@ -460,7 +460,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 4,
                       "output": ["from step"],
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:443"},
@@ -499,7 +499,7 @@ module Cucumber
                    "type": "background",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec.feature:4"},
                       "result": {"status": "undefined"}}]},
@@ -511,7 +511,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Then ",
-                      "text": "the monkey eats bananas",
+                      "name": "the monkey eats bananas",
                       "line": 7,
                       "match": {"location": "spec.feature:7"},
                       "result": {"status": "undefined"}}]},
@@ -522,7 +522,7 @@ module Cucumber
                    "type": "background",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec.feature:4"},
                       "result": {"status": "undefined"}}]},
@@ -534,7 +534,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Then ",
-                      "text": "the monkey eats more bananas",
+                      "name": "the monkey eats more bananas",
                       "line": 10,
                       "match": {"location": "spec.feature:10"},
                       "result": {"status": "undefined"}}]}]}]})
@@ -571,7 +571,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 4,
                       "embeddings": [{"mime_type": "mime-type",
                                       "data": "YWJj"}],
@@ -616,7 +616,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 4,
                       "embeddings": [{"mime_type": "image/png",
                                       "data": "Zm9v"}],
@@ -669,7 +669,7 @@ module Cucumber
                                  "duration": 1}}],
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:645"},
                       "result": {"status": "passed",
@@ -721,7 +721,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "text": "there are bananas",
+                      "name": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:704"},
                       "result": {"status": "passed",
@@ -765,7 +765,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                      [{"keyword": "Given ",
-                       "text": "there are bananas",
+                       "name": "there are bananas",
                        "line": 4,
                        "rows":
                          [{"cells": ["aa", "bb"]},

--- a/spec/cucumber/formatter/json_spec.rb
+++ b/spec/cucumber/formatter/json_spec.rb
@@ -43,7 +43,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec.feature:4"},
                       "result": {"status": "undefined"}}]}]}]})
@@ -79,7 +79,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:62"},
                       "result": {"status": "passed",
@@ -116,7 +116,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:99"},
                       "result": {"status": "failed",
@@ -154,7 +154,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:137"},
                       "result": {"status": "pending",
@@ -196,7 +196,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 8,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:179"},
                       "result": {"status": "passed",
@@ -250,7 +250,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 6,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:227"},
                       "result": {"status": "passed",
@@ -269,7 +269,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 15,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:227"},
                       "result": {"status": "passed",
@@ -343,7 +343,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Then ",
-                      "name": "the monkey eats bananas",
+                      "text": "the monkey eats bananas",
                       "line": 11,
                       "comments": [{"value": "#step comment1",
                                     "line": 10}],
@@ -359,7 +359,7 @@ module Cucumber
                    "type": "background",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 6,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:307"},
                       "result": {"status": "passed",
@@ -378,7 +378,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Then ",
-                      "name": "the monkey eats bananas",
+                      "text": "the monkey eats bananas",
                       "line": 22,
                       "comments": [{"value": "#step comment2",
                                     "line": 15}],
@@ -420,7 +420,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 4,
                       "doc_string": {"value": "the doc string",
                                      "content_type": "",
@@ -460,7 +460,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 4,
                       "output": ["from step"],
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:443"},
@@ -499,7 +499,7 @@ module Cucumber
                    "type": "background",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec.feature:4"},
                       "result": {"status": "undefined"}}]},
@@ -511,7 +511,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Then ",
-                      "name": "the monkey eats bananas",
+                      "text": "the monkey eats bananas",
                       "line": 7,
                       "match": {"location": "spec.feature:7"},
                       "result": {"status": "undefined"}}]},
@@ -522,7 +522,7 @@ module Cucumber
                    "type": "background",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec.feature:4"},
                       "result": {"status": "undefined"}}]},
@@ -534,7 +534,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Then ",
-                      "name": "the monkey eats more bananas",
+                      "text": "the monkey eats more bananas",
                       "line": 10,
                       "match": {"location": "spec.feature:10"},
                       "result": {"status": "undefined"}}]}]}]})
@@ -571,7 +571,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 4,
                       "embeddings": [{"mime_type": "mime-type",
                                       "data": "YWJj"}],
@@ -616,7 +616,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 4,
                       "embeddings": [{"mime_type": "image/png",
                                       "data": "Zm9v"}],
@@ -669,7 +669,7 @@ module Cucumber
                                  "duration": 1}}],
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:645"},
                       "result": {"status": "passed",
@@ -721,7 +721,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                     [{"keyword": "Given ",
-                      "name": "there are bananas",
+                      "text": "there are bananas",
                       "line": 4,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:704"},
                       "result": {"status": "passed",
@@ -765,7 +765,7 @@ module Cucumber
                    "type": "scenario",
                    "steps":
                      [{"keyword": "Given ",
-                       "name": "there are bananas",
+                       "text": "there are bananas",
                        "line": 4,
                        "rows":
                          [{"cells": ["aa", "bb"]},

--- a/spec/cucumber/formatter/junit_spec.rb
+++ b/spec/cucumber/formatter/junit_spec.rb
@@ -43,7 +43,7 @@ module Cucumber
             "
           class Junit
             def before_step(step)
-              return unless step.name.match('a passing ctrl scenario')
+              return unless step.text.match('a passing ctrl scenario')
               Interceptor::Pipe.unwrap! :stdout
               @fake_io = $stdout = StringIO.new
               $stdout.sync = true
@@ -51,7 +51,7 @@ module Cucumber
             end
 
             def after_step(step)
-              return unless step.name.match('a passing ctrl scenario')
+              return unless step.text.match('a passing ctrl scenario')
               @interceptedout.write("boo\b\cx\e\a\f boo ")
               $stdout = STDOUT
               @fake_io.close

--- a/spec/cucumber/hooks_spec.rb
+++ b/spec/cucumber/hooks_spec.rb
@@ -2,8 +2,8 @@
 require 'cucumber/hooks'
 module Cucumber::Hooks
   shared_examples_for 'a source node' do
-    it 'responds to name' do
-      expect( subject.name ).to be_a(String)
+    it 'responds to text' do
+      expect( subject.text ).to be_a(String)
     end
 
     it 'responds to location' do

--- a/spec/support/standard_step_actions.rb
+++ b/spec/support/standard_step_actions.rb
@@ -3,7 +3,7 @@
 class StandardStepActions < Cucumber::Core::Filter.new
   def test_case(test_case)
     test_steps = test_case.test_steps.map do |step|
-      case step.name
+      case step.text
       when /fail/
         step.with_action { raise Failure }
       when /pass/


### PR DESCRIPTION
This PR is a follow-up to (the now-merged) https://github.com/cucumber/cucumber-ruby-core/pull/137 

It

- [x] renames `Step`'s "name" to "text"
- [x] calculates widths of lines using the brand-new `to_s` implementation from Core