### PR TITLE
Remove programming language abstraction

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -67,7 +67,7 @@ Lint/RescueException:
     - 'lib/cucumber/cli/main.rb'
     - 'lib/cucumber/cli/profile_loader.rb'
     - 'lib/cucumber/configuration.rb'
-    - 'lib/cucumber/core_ext/instance_exec.rb'
+    - 'lib/cucumber/glue/invoke_in_world.rb'
     - 'lib/cucumber/formatter/ansicolor.rb'
     - 'lib/cucumber/glue/proto_world.rb'
 
@@ -799,7 +799,7 @@ Style/RaiseArgs:
 Style/RedundantBegin:
   Exclude:
     - 'features/lib/support/fake_wire_server.rb'
-    - 'lib/cucumber/core_ext/instance_exec.rb'
+    - 'lib/cucumber/glue/invoke_in_world.rb'
     - 'lib/cucumber/formatter/ansicolor.rb'
     - 'lib/cucumber/formatter/unicode.rb'
     - 'lib/cucumber/multiline_argument/data_table.rb'
@@ -953,7 +953,7 @@ Style/SpaceAroundOperators:
     - 'examples/i18n/Rakefile'
     - 'examples/i18n/pt/lib/calculadora.rb'
     - 'lib/cucumber/cli/options.rb'
-    - 'lib/cucumber/core_ext/instance_exec.rb'
+    - 'lib/cucumber/glue/invoke_in_world.rb'
     - 'lib/cucumber/formatter/ansicolor.rb'
     - 'lib/cucumber/formatter/console.rb'
     - 'lib/cucumber/formatter/html.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,7 @@ Lint/AssignmentInCondition:
   Exclude:
     - 'features/lib/step_definitions/wire_steps.rb'
     - 'features/lib/support/fake_wire_server.rb'
-    - 'lib/cucumber/rb_support/rb_transform.rb'
+    - 'lib/cucumber/glue/transform.rb'
     - 'lib/cucumber/runtime/support_code.rb'
     - 'spec/cucumber/formatter/spec_helper.rb'
 
@@ -52,8 +52,8 @@ Lint/HandleExceptions:
 # Offense count: 2
 Lint/IneffectiveAccessModifier:
   Exclude:
-    - 'lib/cucumber/rb_support/rb_language.rb'
-    - 'lib/cucumber/rb_support/snippet.rb'
+    - 'lib/cucumber/glue/registry_and_more.rb'
+    - 'lib/cucumber/glue/snippet.rb'
 
 # Offense count: 1
 Lint/Loop:
@@ -69,7 +69,7 @@ Lint/RescueException:
     - 'lib/cucumber/configuration.rb'
     - 'lib/cucumber/core_ext/instance_exec.rb'
     - 'lib/cucumber/formatter/ansicolor.rb'
-    - 'lib/cucumber/rb_support/rb_world.rb'
+    - 'lib/cucumber/glue/proto_world.rb'
 
 # Offense count: 6
 Lint/ShadowingOuterLocalVariable:
@@ -197,7 +197,7 @@ Style/AsciiComments:
     - 'lib/cucumber/filters/randomizer.rb'
     - 'lib/cucumber/formatter/html.rb'
     - 'lib/cucumber/formatter/legacy_api/adapter.rb'
-    - 'lib/cucumber/rb_support/rb_step_definition.rb'
+    - 'lib/cucumber/glue/step_definition.rb'
     - 'lib/cucumber/running_test_case.rb'
     - 'lib/cucumber/runtime.rb'
     - 'spec/cucumber/formatter/legacy_api/adapter_spec.rb'
@@ -265,7 +265,7 @@ Style/BracesAroundHashParameters:
     - 'spec/cucumber/formatter/junit_spec.rb'
     - 'spec/cucumber/formatter/pretty_spec.rb'
     - 'spec/cucumber/multiline_argument/data_table_spec.rb'
-    - 'spec/cucumber/rb_support/rb_step_definition_spec.rb'
+    - 'spec/cucumber/glue/step_definition_spec.rb'
 
 # Offense count: 12
 Style/CaseEquality:
@@ -385,7 +385,7 @@ Style/DoubleNegation:
 Style/EachWithObject:
   Exclude:
     - 'lib/cucumber/formatter/steps.rb'
-    - 'lib/cucumber/rb_support/rb_language.rb'
+    - 'lib/cucumber/glue/registry_and_more.rb'
 
 # Offense count: 12
 # Cop supports --auto-correct.
@@ -416,7 +416,7 @@ Style/EmptyLinesAroundAccessModifier:
     - 'lib/cucumber/formatter/interceptor.rb'
     - 'lib/cucumber/formatter/legacy_api/adapter.rb'
     - 'lib/cucumber/multiline_argument/data_table.rb'
-    - 'lib/cucumber/rb_support/rb_transform.rb'
+    - 'lib/cucumber/glue/transform.rb'
     - 'lib/cucumber/runtime/step_hooks.rb'
     - 'lib/cucumber/step_match.rb'
 
@@ -453,9 +453,9 @@ Style/EmptyLiteral:
   Exclude:
     - 'lib/cucumber/errors.rb'
     - 'lib/cucumber/formatter/html.rb'
-    - 'lib/cucumber/rb_support/rb_language.rb'
-    - 'lib/cucumber/rb_support/snippet.rb'
-    - 'spec/cucumber/rb_support/rb_language_spec.rb'
+    - 'lib/cucumber/glue/registry_and_more.rb'
+    - 'lib/cucumber/glue/snippet.rb'
+    - 'spec/cucumber/glue/registry_and_more_spec.rb'
 
 # Offense count: 11
 # Cop supports --auto-correct.
@@ -468,7 +468,7 @@ Style/ExtraSpacing:
     - 'spec/cucumber/formatter/junit_spec.rb'
     - 'spec/cucumber/formatter/legacy_api/adapter_spec.rb'
     - 'spec/cucumber/multiline_argument/data_table_spec.rb'
-    - 'spec/cucumber/rb_support/rb_step_definition_spec.rb'
+    - 'spec/cucumber/glue/step_definition_spec.rb'
 
 # Offense count: 1
 # Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts.
@@ -490,8 +490,8 @@ Style/GlobalVars:
   Exclude:
     - 'lib/autotest/cucumber_mixin.rb'
     - 'spec/cucumber/cli/options_spec.rb'
-    - 'spec/cucumber/rb_support/rb_language_spec.rb'
-    - 'spec/cucumber/rb_support/rb_step_definition_spec.rb'
+    - 'spec/cucumber/glue/registry_and_more_spec.rb'
+    - 'spec/cucumber/glue/step_definition_spec.rb'
 
 # Offense count: 10
 # Configuration parameters: MinBodyLength.
@@ -502,7 +502,7 @@ Style/GuardClause:
     - 'lib/cucumber/formatter/junit.rb'
     - 'lib/cucumber/formatter/legacy_api/adapter.rb'
     - 'lib/cucumber/formatter/pretty.rb'
-    - 'lib/cucumber/rb_support/rb_world.rb'
+    - 'lib/cucumber/glue/proto_world.rb'
 
 # Offense count: 182
 # Cop supports --auto-correct.
@@ -567,7 +567,7 @@ Style/IndentationWidth:
     - 'lib/cucumber/formatter/legacy_api/adapter.rb'
     - 'lib/cucumber/gherkin/formatter/ansi_escapes.rb'
     - 'lib/cucumber/gherkin/formatter/escaping.rb'
-    - 'lib/cucumber/rb_support/rb_transform.rb'
+    - 'lib/cucumber/glue/transform.rb'
     - 'spec/cucumber/cli/configuration_spec.rb'
     - 'spec/cucumber/multiline_argument/data_table_spec.rb'
     - 'spec/cucumber/step_match_search_spec.rb'
@@ -582,13 +582,13 @@ Style/Lambda:
     - 'features/lib/support/fake_wire_server.rb'
     - 'lib/cucumber/formatter/html.rb'
     - 'lib/cucumber/multiline_argument/data_table.rb'
-    - 'lib/cucumber/rb_support/rb_step_definition.rb'
+    - 'lib/cucumber/glue/step_definition.rb'
     - 'lib/cucumber/step_match.rb'
     - 'spec/cucumber/formatter/html_spec.rb'
     - 'spec/cucumber/formatter/junit_spec.rb'
     - 'spec/cucumber/multiline_argument/data_table_spec.rb'
-    - 'spec/cucumber/rb_support/rb_language_spec.rb'
-    - 'spec/cucumber/rb_support/rb_step_definition_spec.rb'
+    - 'spec/cucumber/glue/registry_and_more_spec.rb'
+    - 'spec/cucumber/glue/step_definition_spec.rb'
     - 'spec/cucumber/rb_support/rb_transform_spec.rb'
     - 'spec/cucumber/step_match_search_spec.rb'
     - 'spec/cucumber/step_match_spec.rb'
@@ -695,7 +695,7 @@ Style/MutableConstant:
     - 'lib/cucumber/formatter/progress.rb'
     - 'lib/cucumber/formatter/unicode.rb'
     - 'lib/cucumber/gherkin/formatter/ansi_escapes.rb'
-    - 'lib/cucumber/rb_support/snippet.rb'
+    - 'lib/cucumber/glue/snippet.rb'
     - 'lib/cucumber/term/ansicolor.rb'
     - 'spec/cucumber/step_match_spec.rb'
 
@@ -744,7 +744,7 @@ Style/NumericLiterals:
 Style/OpMethod:
   Exclude:
     - 'lib/cucumber/multiline_argument/data_table.rb'
-    - 'lib/cucumber/rb_support/rb_step_definition.rb'
+    - 'lib/cucumber/glue/step_definition.rb'
     - 'lib/cucumber/step_definition_light.rb'
 
 # Offense count: 25
@@ -803,7 +803,7 @@ Style/RedundantBegin:
     - 'lib/cucumber/formatter/ansicolor.rb'
     - 'lib/cucumber/formatter/unicode.rb'
     - 'lib/cucumber/multiline_argument/data_table.rb'
-    - 'lib/cucumber/rb_support/rb_step_definition.rb'
+    - 'lib/cucumber/glue/step_definition.rb'
     - 'lib/cucumber/runtime.rb'
     - 'lib/cucumber/runtime/user_interface.rb'
 
@@ -843,8 +843,8 @@ Style/RedundantSelf:
     - 'lib/cucumber/formatter/legacy_api/ast.rb'
     - 'lib/cucumber/multiline_argument/data_table.rb'
     - 'lib/cucumber/multiline_argument/doc_string.rb'
-    - 'lib/cucumber/rb_support/rb_step_definition.rb'
-    - 'lib/cucumber/rb_support/rb_world.rb'
+    - 'lib/cucumber/glue/step_definition.rb'
+    - 'lib/cucumber/glue/proto_world.rb'
     - 'spec/cucumber/running_test_case_spec.rb'
 
 # Offense count: 18
@@ -862,7 +862,7 @@ Style/RegexpLiteral:
     - 'lib/cucumber/runtime.rb'
     - 'spec/cucumber/formatter/html_spec.rb'
     - 'spec/cucumber/project_initializer_spec.rb'
-    - 'spec/cucumber/rb_support/rb_language_spec.rb'
+    - 'spec/cucumber/glue/registry_and_more_spec.rb'
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -941,7 +941,7 @@ Style/SpaceAroundKeyword:
     - 'lib/cucumber/formatter/legacy_api/results.rb'
     - 'lib/cucumber/multiline_argument/data_table.rb'
     - 'lib/cucumber/rake/task.rb'
-    - 'lib/cucumber/rb_support/rb_language.rb'
+    - 'lib/cucumber/glue/registry_and_more.rb'
     - 'lib/cucumber/runtime/user_interface.rb'
     - 'spec/cucumber/cli/profile_loader_spec.rb'
 
@@ -960,11 +960,11 @@ Style/SpaceAroundOperators:
     - 'lib/cucumber/formatter/interceptor.rb'
     - 'lib/cucumber/formatter/json.rb'
     - 'lib/cucumber/formatter/pretty.rb'
-    - 'lib/cucumber/rb_support/snippet.rb'
+    - 'lib/cucumber/glue/snippet.rb'
     - 'lib/cucumber/step_definition_light.rb'
     - 'spec/cucumber/cli/configuration_spec.rb'
     - 'spec/cucumber/multiline_argument/data_table_spec.rb'
-    - 'spec/cucumber/rb_support/rb_step_definition_spec.rb'
+    - 'spec/cucumber/glue/step_definition_spec.rb'
 
 # Offense count: 88
 # Cop supports --auto-correct.
@@ -1077,7 +1077,7 @@ Style/TrailingWhitespace:
 # Reviewed: when the offense is fixed there is one spec failing (./spec/cucumber/rb_support/rb_world_spec.rb:37)
 Style/UnneededInterpolation:
   Exclude:
-    - 'lib/cucumber/rb_support/rb_world.rb'
+    - 'lib/cucumber/glue/proto_world.rb'
 
 # Offense count: 15
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'cucumber/cli/profile_loader'
 require 'cucumber/formatter/ansicolor'
-require 'cucumber/rb_support/rb_language'
+require 'cucumber/glue/registry_and_more'
 require 'cucumber/project_initializer'
 
 module Cucumber
@@ -306,7 +306,7 @@ TEXT
       def snippet_type_msg
         [
           'Use different snippet type (Default: regexp). Available types:',
-          Cucumber::RbSupport::RbLanguage.cli_snippet_type_options
+          Cucumber::Glue::RegistryAndMore.cli_snippet_type_options
         ].flatten
       end
 

--- a/lib/cucumber/core_ext/instance_exec.rb
+++ b/lib/cucumber/core_ext/instance_exec.rb
@@ -8,49 +8,9 @@ module Cucumber
   end
 end
 
+# TODO: Move most of this stuff out to an InstanceExecutor class.
 class Object #:nodoc:
-  # TODO: Move most of this stuff out to an InstanceExecutor class.
-  def cucumber_instance_exec(check_arity, pseudo_method, *args, &block)
-    cucumber_run_with_backtrace_filtering(pseudo_method) do
-      if check_arity && !cucumber_compatible_arity?(args, block)
-        instance_exec do
-          ari = block.arity
-          ari = ari < 0 ? (ari.abs-1).to_s+'+' : ari
-          s1 = ari == 1 ? '' : 's'
-          s2 = args.length == 1 ? '' : 's'
-          raise Cucumber::ArityMismatchError.new(
-            "Your block takes #{ari} argument#{s1}, but the Regexp matched #{args.length} argument#{s2}."
-          )
-        end
-      else
-        instance_exec(*args, &block)
-      end
-    end
-  end
-
-  private
-
-  def cucumber_compatible_arity?(args, block)
-    return true if block.arity == args.length
-    if block.arity < 0
-      return true if args.length >= (block.arity.abs - 1)
-    end
-    false
-  end
-
-  def cucumber_run_with_backtrace_filtering(pseudo_method)
-    begin
-      yield
-    rescue Exception => e
-      instance_exec_invocation_line = "#{__FILE__}:#{__LINE__ - 2}:in `cucumber_run_with_backtrace_filtering'"
-      replace_instance_exec_invocation_line!((e.backtrace || []), instance_exec_invocation_line, pseudo_method)
-      raise e
-    end
-  end
-
-  INSTANCE_EXEC_OFFSET = -3
-
-  def replace_instance_exec_invocation_line!(backtrace, instance_exec_invocation_line, pseudo_method)
+  def self.replace_instance_exec_invocation_line!(backtrace, instance_exec_invocation_line, pseudo_method)
     return if Cucumber.use_full_backtrace
 
     instance_exec_pos = backtrace.index(instance_exec_invocation_line)
@@ -65,4 +25,42 @@ class Object #:nodoc:
       backtrace.compact!
     end
   end
+
+  def cucumber_instance_exec_in(world, check_arity, pseudo_method, *args, &block)
+    Object.cucumber_run_with_backtrace_filtering(pseudo_method) do
+      if check_arity && !Object.cucumber_compatible_arity?(args, block)
+        world.instance_exec do
+          ari = block.arity
+          ari = ari < 0 ? (ari.abs-1).to_s+'+' : ari
+          s1 = ari == 1 ? '' : 's'
+          s2 = args.length == 1 ? '' : 's'
+          raise Cucumber::ArityMismatchError.new(
+            "Your block takes #{ari} argument#{s1}, but the Regexp matched #{args.length} argument#{s2}."
+          )
+        end
+      else
+        world.instance_exec(*args, &block)
+      end
+    end
+  end
+
+  def self.cucumber_compatible_arity?(args, block)
+    return true if block.arity == args.length
+    if block.arity < 0
+      return true if args.length >= (block.arity.abs - 1)
+    end
+    false
+  end
+
+  def self.cucumber_run_with_backtrace_filtering(pseudo_method)
+    begin
+      yield
+    rescue Exception => e
+      instance_exec_invocation_line = "#{__FILE__}:#{__LINE__ - 2}:in `cucumber_run_with_backtrace_filtering'"
+      Object.replace_instance_exec_invocation_line!((e.backtrace || []), instance_exec_invocation_line, pseudo_method)
+      raise e
+    end
+  end
+
+  INSTANCE_EXEC_OFFSET = -3
 end

--- a/lib/cucumber/core_ext/instance_exec.rb
+++ b/lib/cucumber/core_ext/instance_exec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'cucumber/platform'
+require 'cucumber/glue/invoke_in_world'
 
 module Cucumber
   # Raised if the number of a StepDefinition's Regexp match groups
@@ -8,59 +8,10 @@ module Cucumber
   end
 end
 
-# TODO: Move most of this stuff out to an InstanceExecutor class.
 class Object #:nodoc:
-  def self.replace_instance_exec_invocation_line!(backtrace, instance_exec_invocation_line, pseudo_method)
-    return if Cucumber.use_full_backtrace
 
-    instance_exec_pos = backtrace.index(instance_exec_invocation_line)
-    if instance_exec_pos
-      replacement_line = instance_exec_pos + INSTANCE_EXEC_OFFSET
-      backtrace[replacement_line].gsub!(/`.*'/, "`#{pseudo_method}'") if pseudo_method
-
-      depth = backtrace.count { |line| line == instance_exec_invocation_line }
-      end_pos = depth > 1 ? instance_exec_pos : -1
-
-      backtrace[replacement_line+1..end_pos] = nil
-      backtrace.compact!
-    end
-  end
-
+  # TODO: inline
   def cucumber_instance_exec_in(world, check_arity, pseudo_method, *args, &block)
-    Object.cucumber_run_with_backtrace_filtering(pseudo_method) do
-      if check_arity && !Object.cucumber_compatible_arity?(args, block)
-        world.instance_exec do
-          ari = block.arity
-          ari = ari < 0 ? (ari.abs-1).to_s+'+' : ari
-          s1 = ari == 1 ? '' : 's'
-          s2 = args.length == 1 ? '' : 's'
-          raise Cucumber::ArityMismatchError.new(
-            "Your block takes #{ari} argument#{s1}, but the Regexp matched #{args.length} argument#{s2}."
-          )
-        end
-      else
-        world.instance_exec(*args, &block)
-      end
-    end
+    Cucumber::Glue::InvokeInWorld.cucumber_instance_exec_in(world, check_arity, pseudo_method, *args, &block)
   end
-
-  def self.cucumber_compatible_arity?(args, block)
-    return true if block.arity == args.length
-    if block.arity < 0
-      return true if args.length >= (block.arity.abs - 1)
-    end
-    false
-  end
-
-  def self.cucumber_run_with_backtrace_filtering(pseudo_method)
-    begin
-      yield
-    rescue Exception => e
-      instance_exec_invocation_line = "#{__FILE__}:#{__LINE__ - 2}:in `cucumber_run_with_backtrace_filtering'"
-      Object.replace_instance_exec_invocation_line!((e.backtrace || []), instance_exec_invocation_line, pseudo_method)
-      raise e
-    end
-  end
-
-  INSTANCE_EXEC_OFFSET = -3
 end

--- a/lib/cucumber/glue/dsl.rb
+++ b/lib/cucumber/glue/dsl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Cucumber
   module Glue
-    # This module provides the methods the DSL you can use to define 
+    # This module provides the methods the DSL you can use to define
     # steps, hooks, transforms etc.
     module Dsl
       class << self

--- a/lib/cucumber/glue/dsl.rb
+++ b/lib/cucumber/glue/dsl.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 module Cucumber
-  module RbSupport
-    # This module defines the methods you can use to define pure Ruby
-    # Step Definitions and Hooks. This module is mixed into the toplevel
-    # object.
-    module RbDsl
+  module Glue
+    # This module provides the methods the DSL you can use to define 
+    # steps, hooks, transforms etc.
+    module Dsl
       class << self
         attr_writer :rb_language
 
@@ -54,19 +53,19 @@ module Cucumber
       #    World(my_module: MyModule)
       #
       def World(*world_modules, **namespaced_world_modules, &proc)
-        RbDsl.build_rb_world_factory(world_modules, namespaced_world_modules, proc)
+        Dsl.build_rb_world_factory(world_modules, namespaced_world_modules, proc)
       end
 
       # Registers a proc that will run before each Scenario. You can register as many
       # as you want (typically from ruby scripts under <tt>support/hooks.rb</tt>).
       def Before(*tag_expressions, &proc)
-        RbDsl.register_rb_hook('before', tag_expressions, proc)
+        Dsl.register_rb_hook('before', tag_expressions, proc)
       end
 
       # Registers a proc that will run after each Scenario. You can register as many
       # as you want (typically from ruby scripts under <tt>support/hooks.rb</tt>).
       def After(*tag_expressions, &proc)
-        RbDsl.register_rb_hook('after', tag_expressions, proc)
+        Dsl.register_rb_hook('after', tag_expressions, proc)
       end
 
       # Registers a proc that will be wrapped around each scenario. The proc
@@ -75,13 +74,13 @@ module Cucumber
       # blocks in 1.8), on which it should call the .call method. You can register
       # as many  as you want (typically from ruby scripts under <tt>support/hooks.rb</tt>).
       def Around(*tag_expressions, &proc)
-        RbDsl.register_rb_hook('around', tag_expressions, proc)
+        Dsl.register_rb_hook('around', tag_expressions, proc)
       end
 
       # Registers a proc that will run after each Step. You can register as
       # as you want (typically from ruby scripts under <tt>support/hooks.rb</tt>).
       def AfterStep(*tag_expressions, &proc)
-        RbDsl.register_rb_hook('after_step', tag_expressions, proc)
+        Dsl.register_rb_hook('after_step', tag_expressions, proc)
       end
 
       # Registers a proc that will be called with a step definition argument if it
@@ -90,14 +89,13 @@ module Cucumber
       # provided proc. The return value of the proc is consequently yielded to the
       # step definition.
       def Transform(regexp, &proc)
-        RbDsl.register_rb_transform(regexp, proc)
+        Dsl.register_rb_transform(regexp, proc)
       end
 
       # Registers a proc that will run after Cucumber is configured. You can register as
       # as you want (typically from ruby scripts under <tt>support/hooks.rb</tt>).
-      # TODO: Deprecate this
       def AfterConfiguration(&proc)
-        RbDsl.register_rb_hook('after_configuration', [], proc)
+        Dsl.register_rb_hook('after_configuration', [], proc)
       end
 
       # Registers a new Ruby StepDefinition. This method is aliased
@@ -117,10 +115,11 @@ module Cucumber
       # the context of the <tt>World</tt> object.
       def register_rb_step_definition(regexp, symbol = nil, options = {}, &proc)
         proc_or_sym = symbol || proc
-        RbDsl.register_rb_step_definition(regexp, proc_or_sym, options)
+        Dsl.register_rb_step_definition(regexp, proc_or_sym, options)
       end
     end
   end
 end
 
-extend(Cucumber::RbSupport::RbDsl)
+# TODO: can we avoid adding methods to the global namespace (Kernel)
+extend(Cucumber::Glue::Dsl)

--- a/lib/cucumber/glue/hook.rb
+++ b/lib/cucumber/glue/hook.rb
@@ -14,7 +14,7 @@ module Cucumber
       end
 
       def invoke(pseudo_method, arguments, &block)
-        @registry.current_world.cucumber_instance_exec(false, pseudo_method, *[arguments, block].flatten.compact, &@proc)
+        cucumber_instance_exec_in(@registry.current_world, false, pseudo_method, *[arguments, block].flatten.compact, &@proc)
       end
 
       private

--- a/lib/cucumber/glue/hook.rb
+++ b/lib/cucumber/glue/hook.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 module Cucumber
-  module RbSupport
-    # Wrapper for Before, After and AfterStep hooks
-    class RbHook
+  module Glue
+    # TODO: Kill pointless wrapper for Before, After and AfterStep hooks with fire
+    class Hook
       attr_reader :tag_expressions, :location
 
       def initialize(rb_language, tag_expressions, proc)

--- a/lib/cucumber/glue/hook.rb
+++ b/lib/cucumber/glue/hook.rb
@@ -5,8 +5,8 @@ module Cucumber
     class Hook
       attr_reader :tag_expressions, :location
 
-      def initialize(rb_language, tag_expressions, proc)
-        @rb_language = rb_language
+      def initialize(registry, tag_expressions, proc)
+        @registry = registry
         @tag_expressions = tag_expressions
         @proc = proc
         @location = Cucumber::Core::Ast::Location.from_source_location(*@proc.source_location)
@@ -14,7 +14,7 @@ module Cucumber
       end
 
       def invoke(pseudo_method, arguments, &block)
-        @rb_language.current_world.cucumber_instance_exec(false, pseudo_method, *[arguments, block].flatten.compact, &@proc)
+        @registry.current_world.cucumber_instance_exec(false, pseudo_method, *[arguments, block].flatten.compact, &@proc)
       end
 
       private

--- a/lib/cucumber/glue/invoke_in_world.rb
+++ b/lib/cucumber/glue/invoke_in_world.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+require 'cucumber/platform'
+module Cucumber
+  module Glue
+    class InvokeInWorld
+      def self.replace_instance_exec_invocation_line!(backtrace, instance_exec_invocation_line, pseudo_method)
+        return if Cucumber.use_full_backtrace
+
+        instance_exec_pos = backtrace.index(instance_exec_invocation_line)
+        if instance_exec_pos
+          replacement_line = instance_exec_pos + INSTANCE_EXEC_OFFSET
+          backtrace[replacement_line].gsub!(/`.*'/, "`#{pseudo_method}'") if pseudo_method
+
+          depth = backtrace.count { |line| line == instance_exec_invocation_line }
+          end_pos = depth > 1 ? instance_exec_pos : -1
+
+          backtrace[replacement_line+1..end_pos] = nil
+          backtrace.compact!
+        end
+      end
+
+      def self.cucumber_instance_exec_in(world, check_arity, pseudo_method, *args, &block)
+        cucumber_run_with_backtrace_filtering(pseudo_method) do
+          if check_arity && !cucumber_compatible_arity?(args, block)
+            world.instance_exec do
+              ari = block.arity
+              ari = ari < 0 ? (ari.abs-1).to_s+'+' : ari
+              s1 = ari == 1 ? '' : 's'
+              s2 = args.length == 1 ? '' : 's'
+              raise Cucumber::ArityMismatchError.new(
+                "Your block takes #{ari} argument#{s1}, but the Regexp matched #{args.length} argument#{s2}."
+              )
+            end
+          else
+            world.instance_exec(*args, &block)
+          end
+        end
+      end
+
+      def self.cucumber_compatible_arity?(args, block)
+        return true if block.arity == args.length
+        if block.arity < 0
+          return true if args.length >= (block.arity.abs - 1)
+        end
+        false
+      end
+
+      def self.cucumber_run_with_backtrace_filtering(pseudo_method)
+        begin
+          yield
+        rescue Exception => e
+          instance_exec_invocation_line = "#{__FILE__}:#{__LINE__ - 2}:in `cucumber_run_with_backtrace_filtering'"
+          replace_instance_exec_invocation_line!((e.backtrace || []), instance_exec_invocation_line, pseudo_method)
+          raise e
+        end
+      end
+
+      INSTANCE_EXEC_OFFSET = -3
+    end
+  end
+end

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'cucumber/gherkin/formatter/ansi_escapes'
+require 'cucumber/core/ast/data_table'
 
 module Cucumber
   module Glue
@@ -69,8 +70,26 @@ module Cucumber
       #     | Aslak | aslak@aslak.com |
       #   })
       # @param [String] text_or_table The Gherkin string that represents the table
-      def table(text_or_table, file=nil, line_offset=0)
-        @__cucumber_runtime.table(text_or_table, file, line_offset)
+      # Returns a Cucumber::MultilineArgument::DataTable for +text_or_table+, which can either
+      # be a String:
+      #
+      #   table(%{
+      #     | account | description | amount |
+      #     | INT-100 | Taxi        | 114    |
+      #     | CUC-101 | Peeler      | 22     |
+      #   })
+      #
+      # or a 2D Array:
+      #
+      #   table([
+      #     %w{ account description amount },
+      #     %w{ INT-100 Taxi        114    },
+      #     %w{ CUC-101 Peeler      22     }
+      #   ])
+      #
+      def table(text_or_table, file=nil, line=0)
+        location = !file ? Core::Ast::Location.of_caller : Core::Ast::Location.new(file, line)
+        MultilineArgument::DataTable.from(text_or_table, location)
       end
 
       # Print a message to the output.

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -2,20 +2,20 @@
 require 'cucumber/gherkin/formatter/ansi_escapes'
 
 module Cucumber
-  module RbSupport
+  module Glue
     # Defines the basic DSL methods availlable in all Cucumber step definitions.
     #
     # You can, and probably should, extend this DSL with your own methods that
-    # make sense in your domain. For more on that, see {Cucumber::RbSupport::RbDsl#World}
-    module RbWorld
+    # make sense in your domain. For more on that, see {Cucumber::Glue::Dsl#World}
+    module ProtoWorld
 
       # @private
       AnsiEscapes = Cucumber::Gherkin::Formatter::AnsiEscapes
 
       # Call a Transform with a string from another Transform definition
       def Transform(arg)
-        rb = @__cucumber_runtime.support_code.ruby
-        rb.execute_transforms([arg]).first
+        registry = @__cucumber_runtime.support_code.registry
+        registry.execute_transforms([arg]).first
       end
 
       # @private
@@ -169,3 +169,4 @@ module Cucumber
     end
   end
 end
+

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -4,28 +4,15 @@ require 'cucumber/core/ast/data_table'
 
 module Cucumber
   module Glue
-    # Defines the basic DSL methods availlable in all Cucumber step definitions.
+    # Defines the basic API methods availlable in all Cucumber step definitions.
     #
-    # You can, and probably should, extend this DSL with your own methods that
+    # You can, and probably should, extend this API with your own methods that
     # make sense in your domain. For more on that, see {Cucumber::Glue::Dsl#World}
     module ProtoWorld
 
-      # @private
-      AnsiEscapes = Cucumber::Gherkin::Formatter::AnsiEscapes
-
       # Call a Transform with a string from another Transform definition
       def Transform(arg)
-        registry = @__cucumber_runtime.support_code.registry
-        registry.execute_transforms([arg]).first
-      end
-
-      # @private
-      attr_writer :__cucumber_runtime, :__natural_language
-
-      # Extend the World with user-defined modules
-      def add_modules!(world_modules, namespaced_world_modules)
-        add_world_modules!(world_modules)
-        add_namespaced_modules!(namespaced_world_modules)
+        super
       end
 
       # Run a single Gherkin step
@@ -44,8 +31,7 @@ module Cucumber
       # @param [String] name The name of the step
       # @param [String,Cucumber::Ast::DocString,Cucumber::Ast::Table] multiline_argument
       def step(name, raw_multiline_arg=nil)
-        location = Core::Ast::Location.of_caller
-        @__cucumber_runtime.invoke_dynamic_step(name, MultilineArgument.from(raw_multiline_arg, location))
+        super
       end
 
       # Run a snippet of Gherkin
@@ -56,8 +42,7 @@ module Cucumber
       #   }
       # @param [String] steps_text The Gherkin snippet to run
       def steps(steps_text)
-        location = Core::Ast::Location.of_caller
-        @__cucumber_runtime.invoke_dynamic_steps(steps_text, @__natural_language, location)
+        super
       end
 
       # Parse Gherkin into a {Cucumber::Ast::Table} object.
@@ -100,22 +85,17 @@ module Cucumber
       #
       #   If you'd prefer to see the message immediately, call {Kernel.puts} instead.
       def puts(*messages)
-        # Even though they won't be output until later, converting the messages to
-        # strings right away will protect them from modifications to their original
-        # objects in the mean time
-        messages.collect! { |message| "#{message}" }
-
-        @__cucumber_runtime.puts(*messages)
+        super
       end
 
       # Pause the tests and ask the operator for input
       def ask(question, timeout_seconds=60)
-        @__cucumber_runtime.ask(question, timeout_seconds)
+        super
       end
 
       # Embed an image in the output
       def embed(file, mime_type, label='Screenshot')
-        @__cucumber_runtime.embed(file, mime_type, label)
+        super
       end
 
       # Mark the matched step as pending.
@@ -139,12 +119,7 @@ module Cucumber
 
       # Prints the list of modules that are included in the World
       def inspect
-        modules = [self.class]
-        (class << self; self; end).instance_eval do
-          modules += included_modules
-        end
-        modules << stringify_namespaced_modules
-        format('#<%s:0x%x>', modules.join('+'), self.object_id)
+        super
       end
 
       # see {#inspect}
@@ -152,39 +127,104 @@ module Cucumber
         inspect
       end
 
-      private
+      # Dynamially generate the API module, closuring the dependencies
+      def self.for(runtime, language) # rubocop:disable Metrics/MethodLength
+        Module.new do
+          def self.extended(object)
+            # wrap the dynamically generated module so that we can document the methods
+            # for yardoc, which doesn't like define_method.
+            object.extend(ProtoWorld)
+          end
 
-      # @private
-      def add_world_modules!(modules)
-        modules.each do |world_module|
-          extend(world_module)
-        end
-      end
+          define_method(:Transform) do |arg|
+            registry = runtime.support_code.registry
+            registry.execute_transforms([arg]).first
+          end
 
-      # @private
-      def add_namespaced_modules!(modules)
-        @__namespaced_modules = modules
-        modules.each do |namespace, world_modules|
-          world_modules.each do |world_module|
-            variable_name = "@__#{namespace}_world"
+          # TODO: pass these in when building the module, instead of mutating them later
+          # Extend the World with user-defined modules
+          def add_modules!(world_modules, namespaced_world_modules)
+            add_world_modules!(world_modules)
+            add_namespaced_modules!(namespaced_world_modules)
+          end
 
-            inner_world = if self.class.respond_to?(namespace)
-                            instance_variable_get(variable_name)
-                          else
-                            Object.new
-                          end
-            instance_variable_set(variable_name,
-                                  inner_world.extend(world_module))
-            self.class.send(:define_method, namespace) do
-              instance_variable_get(variable_name)
+          define_method(:step) do |name, raw_multiline_arg=nil|
+            location = Core::Ast::Location.of_caller
+            runtime.invoke_dynamic_step(name, MultilineArgument.from(raw_multiline_arg, location))
+          end
+
+          define_method(:steps) do |steps_text|
+            location = Core::Ast::Location.of_caller
+            runtime.invoke_dynamic_steps(steps_text, language, location)
+          end
+
+          define_method(:puts) do |*messages|
+            # Even though they won't be output until later, converting the messages to
+            # strings right away will protect them from modifications to their original
+            # objects in the mean time
+            messages.collect! { |message| "#{message}" }
+
+            runtime.puts(*messages)
+          end
+
+          define_method(:ask) do |question, timeout_seconds=60|
+            runtime.ask(question, timeout_seconds)
+          end
+
+          define_method(:embed) do |file, mime_type, label='Screenshot'|
+            runtime.embed(file, mime_type, label)
+          end
+
+          # Prints the list of modules that are included in the World
+          def inspect
+            modules = [self.class]
+            (class << self; self; end).instance_eval do
+              modules += included_modules
+            end
+            modules << stringify_namespaced_modules
+            format('#<%s:0x%x>', modules.join('+'), self.object_id)
+          end
+
+          private
+
+          # @private
+          def add_world_modules!(modules)
+            modules.each do |world_module|
+              extend(world_module)
             end
           end
+
+          # @private
+          def add_namespaced_modules!(modules)
+            @__namespaced_modules = modules
+            modules.each do |namespace, world_modules|
+              world_modules.each do |world_module|
+                variable_name = "@__#{namespace}_world"
+
+                inner_world = if self.class.respond_to?(namespace)
+                                instance_variable_get(variable_name)
+                              else
+                                Object.new
+                              end
+                instance_variable_set(variable_name,
+                                      inner_world.extend(world_module))
+                self.class.send(:define_method, namespace) do
+                  instance_variable_get(variable_name)
+                end
+              end
+            end
+          end
+
+          # @private
+          def stringify_namespaced_modules
+            @__namespaced_modules.map { |k, v| "#{v.join(',')} (as #{k})" }.join('+')
+          end
+
         end
       end
 
-      def stringify_namespaced_modules
-        @__namespaced_modules.map { |k, v| "#{v.join(',')} (as #{k})" }.join('+')
-      end
+      # @private
+      AnsiEscapes = Cucumber::Gherkin::Formatter::AnsiEscapes
     end
   end
 end

--- a/lib/cucumber/glue/registry_and_more.rb
+++ b/lib/cucumber/glue/registry_and_more.rb
@@ -103,10 +103,11 @@ module Cucumber
       end
 
       def begin_scenario(test_case)
-        # TODO: create world with scenario, rather than connecting it later
-        create_world
-        extend_world
-        connect_world(test_case) # TODO: kill with fire
+        @current_world = WorldFactory.new(@world_proc).create_world
+        @current_world.extend(ProtoWorld.for(@runtime, test_case.language))
+        MultiTest.extend_with_best_assertion_library(@current_world)
+        @current_world.add_modules!(@world_modules || [],
+                                    @namespaced_world_modules || {})
       end
 
       def end_scenario
@@ -172,23 +173,6 @@ module Cucumber
 
       def transforms
         @transforms ||= []
-      end
-
-      def create_world
-        @current_world = WorldFactory.new(@world_proc).create_world
-      end
-
-      def extend_world
-        @current_world.extend(ProtoWorld)
-        MultiTest.extend_with_best_assertion_library(@current_world)
-
-        @current_world.add_modules!(@world_modules || [],
-                                    @namespaced_world_modules || {})
-      end
-
-      def connect_world(test_case)
-        @current_world.__cucumber_runtime = @runtime
-        @current_world.__natural_language = test_case.language
       end
 
       def self.cli_snippet_type_options

--- a/lib/cucumber/glue/registry_and_more.rb
+++ b/lib/cucumber/glue/registry_and_more.rb
@@ -103,7 +103,7 @@ module Cucumber
       end
 
       def begin_scenario(test_case)
-        # TODO: create world with scenario
+        # TODO: create world with scenario, rather than connecting it later
         create_world
         extend_world
         connect_world(test_case) # TODO: kill with fire
@@ -173,7 +173,7 @@ module Cucumber
       def transforms
         @transforms ||= []
       end
-            
+
       def create_world
         @current_world = WorldFactory.new(@world_proc).create_world
       end

--- a/lib/cucumber/glue/registry_and_more.rb
+++ b/lib/cucumber/glue/registry_and_more.rb
@@ -6,6 +6,7 @@ require 'cucumber/glue/hook'
 require 'cucumber/glue/proto_world'
 require 'cucumber/glue/step_definition'
 require 'cucumber/glue/transform'
+require 'cucumber/glue/world_factory'
 require 'cucumber/gherkin/i18n'
 require 'multi_test'
 require 'cucumber/step_match'
@@ -172,14 +173,9 @@ module Cucumber
       def transforms
         @transforms ||= []
       end
-
+            
       def create_world
-        if(@world_proc)
-          @current_world = @world_proc.call
-          check_nil(@current_world, @world_proc)
-        else
-          @current_world = Object.new
-        end
+        @current_world = WorldFactory.new(@world_proc).create_world
       end
 
       def extend_world
@@ -193,20 +189,6 @@ module Cucumber
       def connect_world(test_case)
         @current_world.__cucumber_runtime = @runtime
         @current_world.__natural_language = test_case.language
-      end
-
-      def check_nil(o, proc)
-        if o.nil?
-          begin
-            raise NilWorld.new
-          rescue NilWorld => e
-            e.backtrace.clear
-            e.backtrace.push(Glue.backtrace_line(proc, 'World'))
-            raise e
-          end
-        else
-          o
-        end
       end
 
       def self.cli_snippet_type_options

--- a/lib/cucumber/glue/snippet.rb
+++ b/lib/cucumber/glue/snippet.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Cucumber
-  module RbSupport
+  module Glue
     module Snippet
 
       ARGUMENT_PATTERNS = ['"([^"]*)"', '(\d+)']

--- a/lib/cucumber/glue/step_definition.rb
+++ b/lib/cucumber/glue/step_definition.rb
@@ -106,7 +106,7 @@ module Cucumber
       def invoke(args)
         begin
           args = @registry.execute_transforms(args)
-          @registry.current_world.cucumber_instance_exec(true, regexp_source, *args, &@proc)
+          cucumber_instance_exec_in(@registry.current_world, true, regexp_source, *args, &@proc)
         rescue Cucumber::ArityMismatchError => e
           e.backtrace.unshift(self.backtrace_line)
           raise e

--- a/lib/cucumber/glue/step_definition.rb
+++ b/lib/cucumber/glue/step_definition.rb
@@ -4,9 +4,9 @@ require 'cucumber/step_argument'
 require 'cucumber/core_ext/string'
 
 module Cucumber
-  module RbSupport
-    # A Ruby Step Definition holds a Regexp pattern and a Proc, and is
-    # typically created by calling {RbDsl#register_rb_step_definition Given, When or Then}
+  module Glue
+    # A Step Definition holds a Regexp pattern and a Proc, and is
+    # typically created by calling {Dsl#register_rb_step_definition Given, When or Then}
     # in the step_definitions Ruby files.
     #
     # Example:
@@ -15,7 +15,7 @@ module Cucumber
     #     # some code here
     #   end
     #
-    class RbStepDefinition
+    class StepDefinition
 
       class MissingProc < StandardError
         def message
@@ -24,9 +24,9 @@ module Cucumber
       end
 
       class << self
-        def new(rb_language, pattern, proc_or_sym, options)
+        def new(registry, pattern, proc_or_sym, options)
           raise MissingProc if proc_or_sym.nil?
-          super rb_language, parse_pattern(pattern), create_proc(proc_or_sym, options)
+          super registry, parse_pattern(pattern), create_proc(proc_or_sym, options)
         end
 
         private
@@ -70,9 +70,9 @@ module Cucumber
         end
       end
 
-      def initialize(rb_language, regexp, proc)
-        @rb_language, @regexp, @proc = rb_language, regexp, proc
-        @rb_language.available_step_definition(regexp_source, location)
+      def initialize(registry, regexp, proc)
+        @registry, @regexp, @proc = registry, regexp, proc
+        @registry.available_step_definition(regexp_source, location)
       end
 
       # @api private
@@ -97,15 +97,16 @@ module Cucumber
       # @api private
       def arguments_from(step_name)
         args = StepArgument.arguments_from(@regexp, step_name)
-        @rb_language.invoked_step_definition(regexp_source, location) if args
+        @registry.invoked_step_definition(regexp_source, location) if args
         args
       end
 
       # @api private
+      # TODO: inline this and step definition just be a value object
       def invoke(args)
         begin
-          args = @rb_language.execute_transforms(args)
-          @rb_language.current_world.cucumber_instance_exec(true, regexp_source, *args, &@proc)
+          args = @registry.execute_transforms(args)
+          @registry.current_world.cucumber_instance_exec(true, regexp_source, *args, &@proc)
         rescue Cucumber::ArityMismatchError => e
           e.backtrace.unshift(self.backtrace_line)
           raise e

--- a/lib/cucumber/glue/transform.rb
+++ b/lib/cucumber/glue/transform.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 module Cucumber
-  module RbSupport
+  module Glue
     # A Ruby Transform holds a Regexp and a Proc, and is created
     # by calling <tt>Transform in the <tt>support</tt> ruby files.
-    # See also RbDsl.
+    # See also Dsl.
     #
     # Example:
     #
@@ -11,7 +11,7 @@ module Cucumber
     #     cucumbers_string.to_i
     #   end
     #
-    class RbTransform
+    class Transform
       class MissingProc < StandardError
         def message
           'Transforms must always have a proc with at least one argument'

--- a/lib/cucumber/glue/transform.rb
+++ b/lib/cucumber/glue/transform.rb
@@ -18,9 +18,9 @@ module Cucumber
         end
       end
 
-      def initialize(rb_language, pattern, proc)
+      def initialize(registry, pattern, proc)
         raise MissingProc if proc.nil? || proc.arity < 1
-        @rb_language, @regexp, @proc = rb_language, Regexp.new(pattern), proc
+        @registry, @regexp, @proc = registry, Regexp.new(pattern), proc
       end
 
       def match(arg)
@@ -30,7 +30,7 @@ module Cucumber
       def invoke(arg)
         return unless matched = match(arg)
         args = matched.captures.empty? ? [arg] : matched.captures
-        @rb_language.current_world.cucumber_instance_exec(true, @regexp.inspect, *args, &@proc)
+        @registry.current_world.cucumber_instance_exec(true, @regexp.inspect, *args, &@proc)
       end
 
       def to_s

--- a/lib/cucumber/glue/transform.rb
+++ b/lib/cucumber/glue/transform.rb
@@ -30,7 +30,7 @@ module Cucumber
       def invoke(arg)
         return unless matched = match(arg)
         args = matched.captures.empty? ? [arg] : matched.captures
-        @registry.current_world.cucumber_instance_exec(true, @regexp.inspect, *args, &@proc)
+        cucumber_instance_exec_in(@registry.current_world, true, @regexp.inspect, *args, &@proc)
       end
 
       def to_s

--- a/lib/cucumber/glue/world_factory.rb
+++ b/lib/cucumber/glue/world_factory.rb
@@ -1,0 +1,23 @@
+module Cucumber
+  module Glue
+    
+    class WorldFactory
+      def initialize(proc)
+        @proc = proc || -> { Object.new }
+      end
+      
+      def create_world
+        @proc.call || raise_nil_world
+      end
+      
+      def raise_nil_world
+        raise NilWorld.new
+      rescue NilWorld => e
+        e.backtrace.clear
+        e.backtrace.push(Glue.backtrace_line(@proc, 'World'))
+        raise e
+      end
+    end
+
+  end
+end

--- a/lib/cucumber/glue/world_factory.rb
+++ b/lib/cucumber/glue/world_factory.rb
@@ -1,15 +1,15 @@
 module Cucumber
   module Glue
-    
+
     class WorldFactory
       def initialize(proc)
         @proc = proc || -> { Object.new }
       end
-      
+
       def create_world
         @proc.call || raise_nil_world
       end
-      
+
       def raise_nil_world
         raise NilWorld.new
       rescue NilWorld => e

--- a/lib/cucumber/rb_support/rb_language.rb
+++ b/lib/cucumber/rb_support/rb_language.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'cucumber/core_ext/instance_exec'
-require 'cucumber/rb_support/rb_dsl'
+require 'cucumber/glue/dsl'
 require 'cucumber/rb_support/rb_world'
 require 'cucumber/rb_support/rb_step_definition'
 require 'cucumber/rb_support/rb_hook'
@@ -29,7 +29,7 @@ module Cucumber
         message << "in 2 places:\n\n"
         message << RbSupport.backtrace_line(first_proc, 'World') << "\n"
         message << RbSupport.backtrace_line(second_proc, 'World') << "\n\n"
-        message << "Use Ruby modules instead to extend your worlds. See the Cucumber::RbSupport::RbDsl#World RDoc\n"
+        message << "Use Ruby modules instead to extend your worlds. See the Cucumber::Glue::Dsl#World RDoc\n"
         message << "or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.\n\n"
         super(message)
       end
@@ -45,13 +45,13 @@ module Cucumber
         dialect.given_keywords + dialect.when_keywords + dialect.then_keywords + dialect.and_keywords + dialect.but_keywords
       end
       Cucumber::Gherkin::I18n.code_keywords_for(all_keywords.flatten.uniq.sort).each do |adverb|
-        RbDsl.alias_adverb(adverb.strip)
+        Glue::Dsl.alias_adverb(adverb.strip)
       end
 
       def initialize(runtime, configuration)
         @runtime, @configuration = runtime, configuration
         @step_definitions = []
-        RbDsl.rb_language = self
+        Glue::Dsl.rb_language = self
         @world_proc = @world_modules = nil
         @configuration.register_snippet_generator(Snippet::Generator.new)
       end
@@ -98,7 +98,7 @@ module Cucumber
 
       def load_code_file(code_file)
         return unless File.extname(code_file) == '.rb'
-        load File.expand_path(code_file) # This will cause self.add_step_definition, self.add_hook, and self.add_transform to be called from RbDsl
+        load File.expand_path(code_file) # This will cause self.add_step_definition, self.add_hook, and self.add_transform to be called from Glue::Dsl
       end
 
       def begin_scenario(test_case)

--- a/lib/cucumber/rb_support/rb_language.rb
+++ b/lib/cucumber/rb_support/rb_language.rb
@@ -35,7 +35,7 @@ module Cucumber
       end
     end
 
-    # The Ruby implementation of the programming language API.
+    # TODO: Remove this abstraction - kill it with fire
     class RbLanguage
       attr_reader :current_world,
                   :step_definitions
@@ -63,12 +63,6 @@ module Cucumber
           end
           result
         }
-      end
-
-      def begin_rb_scenario(scenario)
-        create_world
-        extend_world
-        connect_world(scenario)
       end
 
       def register_rb_hook(phase, tag_expressions, proc)
@@ -107,8 +101,11 @@ module Cucumber
         load File.expand_path(code_file) # This will cause self.add_step_definition, self.add_hook, and self.add_transform to be called from RbDsl
       end
 
-      def begin_scenario(scenario)
-        begin_rb_scenario(scenario)
+      def begin_scenario(test_case)
+        # TODO: create world with scenario
+        create_world
+        extend_world
+        connect_world(test_case) # TODO: kill with fire
       end
 
       def end_scenario
@@ -193,9 +190,9 @@ module Cucumber
                                     @namespaced_world_modules || {})
       end
 
-      def connect_world(scenario)
+      def connect_world(test_case)
         @current_world.__cucumber_runtime = @runtime
-        @current_world.__natural_language = scenario.language
+        @current_world.__natural_language = test_case.language
       end
 
       def check_nil(o, proc)

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -246,7 +246,7 @@ module Cucumber
         filters << Cucumber::Core::Test::NameFilter.new(name_regexps)
         filters << Cucumber::Core::Test::LocationsFilter.new(filespecs.locations)
         filters << Filters::Randomizer.new(@configuration.seed) if @configuration.randomize?
-        # TODO: can we just use RbLanguages's step definitions directly?
+        # TODO: can we just use Glue::RegistryAndMore's step definitions directly?
         step_match_search = StepMatchSearch.new(@support_code.ruby.method(:step_matches), @configuration)
         filters << Filters::ActivateSteps.new(step_match_search, @configuration)
         @configuration.filters.each do |filter|

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -247,7 +247,7 @@ module Cucumber
         filters << Cucumber::Core::Test::LocationsFilter.new(filespecs.locations)
         filters << Filters::Randomizer.new(@configuration.seed) if @configuration.randomize?
         # TODO: can we just use Glue::RegistryAndMore's step definitions directly?
-        step_match_search = StepMatchSearch.new(@support_code.ruby.method(:step_matches), @configuration)
+        step_match_search = StepMatchSearch.new(@support_code.registry.method(:step_matches), @configuration)
         filters << Filters::ActivateSteps.new(step_match_search, @configuration)
         @configuration.filters.each do |filter|
           filters << filter

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -67,6 +67,7 @@ module Cucumber
       load_step_definitions
       install_wire_plugin
       fire_after_configuration_hook
+      # TODO: can we remove this state?
       self.visitor = report
 
       receiver = Test::Runner.new(@configuration.event_bus)

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -94,8 +94,8 @@ module Cucumber
       @support_code.unmatched_step_definitions
     end
 
-    def begin_scenario(scenario)
-      @support_code.fire_hook(:begin_scenario, scenario)
+    def begin_scenario(test_case)
+      @support_code.fire_hook(:begin_scenario, test_case)
     end
 
     def end_scenario(_scenario)

--- a/lib/cucumber/runtime/for_programming_languages.rb
+++ b/lib/cucumber/runtime/for_programming_languages.rb
@@ -28,13 +28,6 @@ module Cucumber
         :invoke_dynamic_steps,
         :invoke_dynamic_step,
         :load_programming_language
-
-      # Returns a Cucumber::MultilineArgument::DocString for +body+.
-      #
-      def doc_string(body, content_type='', _line_offset=0)
-        location = Core::Ast::Location.of_caller
-        MultilineArgument.doc_string(body, content_type, location)
-      end
     end
   end
 end

--- a/lib/cucumber/runtime/for_programming_languages.rb
+++ b/lib/cucumber/runtime/for_programming_languages.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'forwardable'
 require 'cucumber/core/ast/doc_string'
-require 'cucumber/core/ast/data_table'
 
 module Cucumber
   class Runtime
@@ -29,32 +28,6 @@ module Cucumber
         :invoke_dynamic_steps,
         :invoke_dynamic_step,
         :load_programming_language
-
-      # Returns a Cucumber::MultilineArgument::DataTable for +text_or_table+, which can either
-      # be a String:
-      #
-      #   table(%{
-      #     | account | description | amount |
-      #     | INT-100 | Taxi        | 114    |
-      #     | CUC-101 | Peeler      | 22     |
-      #   })
-      #
-      # or a 2D Array:
-      #
-      #   table([
-      #     %w{ account description amount },
-      #     %w{ INT-100 Taxi        114    },
-      #     %w{ CUC-101 Peeler      22     }
-      #   ])
-      #
-      def table(text_or_table, file=nil, line=0)
-        if !file
-          location = Core::Ast::Location.of_caller
-        else
-          location = Core::Ast::Location.new(file, line)
-        end
-        MultilineArgument::DataTable.from(text_or_table, location)
-      end
 
       # Returns a Cucumber::MultilineArgument::DocString for +body+.
       #

--- a/lib/cucumber/runtime/for_programming_languages.rb
+++ b/lib/cucumber/runtime/for_programming_languages.rb
@@ -26,8 +26,7 @@ module Cucumber
 
       def_delegators :@support_code,
         :invoke_dynamic_steps,
-        :invoke_dynamic_step,
-        :load_programming_language
+        :invoke_dynamic_step
     end
   end
 end

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -96,6 +96,7 @@ module Cucumber
       end
 
       def fire_hook(name, *args)
+        # TODO: kill with fire
         @ruby.send(name, *args)
       end
 

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -44,11 +44,17 @@ module Cucumber
 
       include Constantize
 
+      # TODO: Remove in favour of registry
       attr_reader :ruby
       def initialize(user_interface, configuration=Configuration.default)
         @configuration = configuration
+        # TODO: needs a better name, or inlining its methods
         @runtime_facade = Runtime::ForProgrammingLanguages.new(self, user_interface)
-        @ruby = Cucumber::RbSupport::RbLanguage.new(@runtime_facade, @configuration)
+        @ruby = Cucumber::Glue::RegistryAndMore.new(@runtime_facade, @configuration)
+      end
+
+      def registry
+        @ruby
       end
 
       def configure(new_configuration)

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -44,15 +44,13 @@ module Cucumber
 
       include Constantize
 
+      attr_reader :registry
+
       def initialize(user_interface, configuration=Configuration.default)
         @configuration = configuration
         # TODO: needs a better name, or inlining its methods
         @runtime_facade = Runtime::ForProgrammingLanguages.new(self, user_interface)
-        @ruby = Cucumber::Glue::RegistryAndMore.new(@runtime_facade, @configuration)
-      end
-
-      def registry
-        @ruby
+        @registry = Cucumber::Glue::RegistryAndMore.new(@runtime_facade, @configuration)
       end
 
       def configure(new_configuration)
@@ -96,40 +94,40 @@ module Cucumber
       end
 
       def unmatched_step_definitions
-        @ruby.unmatched_step_definitions
+        registry.unmatched_step_definitions
       end
 
       def fire_hook(name, *args)
         # TODO: kill with fire
-        @ruby.send(name, *args)
+        registry.send(name, *args)
       end
 
       def step_definitions
-        @ruby.step_definitions
+        registry.step_definitions
       end
 
       def find_after_step_hooks(test_case)
         scenario = RunningTestCase.new(test_case)
-        hooks = @ruby.hooks_for(:after_step, scenario)
+        hooks = registry.hooks_for(:after_step, scenario)
         StepHooks.new hooks
       end
 
       def apply_before_hooks(test_case)
         scenario = RunningTestCase.new(test_case)
-        hooks = @ruby.hooks_for(:before, scenario)
+        hooks = registry.hooks_for(:before, scenario)
         BeforeHooks.new(hooks, scenario).apply_to(test_case)
       end
 
       def apply_after_hooks(test_case)
         scenario = RunningTestCase.new(test_case)
-        hooks = @ruby.hooks_for(:after, scenario)
+        hooks = registry.hooks_for(:after, scenario)
         AfterHooks.new(hooks, scenario).apply_to(test_case)
       end
 
       def find_around_hooks(test_case)
         scenario = RunningTestCase.new(test_case)
 
-        @ruby.hooks_for(:around, scenario).map do |hook|
+        registry.hooks_for(:around, scenario).map do |hook|
           Hooks.around_hook(test_case.source) do |run_scenario|
             hook.invoke('Around', scenario, &run_scenario)
           end
@@ -139,12 +137,12 @@ module Cucumber
       private
 
       def step_matches(step_name)
-        StepMatchSearch.new(@ruby.method(:step_matches), @configuration).call(step_name)
+        StepMatchSearch.new(registry.method(:step_matches), @configuration).call(step_name)
       end
 
       def load_file(file)
         log.debug("  * #{file}\n")
-        @ruby.load_code_file(file)
+        registry.load_code_file(file)
       end
 
       def log

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -44,8 +44,6 @@ module Cucumber
 
       include Constantize
 
-      # TODO: Remove in favour of registry
-      attr_reader :ruby
       def initialize(user_interface, configuration=Configuration.default)
         @configuration = configuration
         # TODO: needs a better name, or inlining its methods

--- a/lib/cucumber/runtime/user_interface.rb
+++ b/lib/cucumber/runtime/user_interface.rb
@@ -7,10 +7,6 @@ module Cucumber
     module UserInterface
       attr_writer :visitor
 
-      def visitor=(visitor)
-        @visitor = visitor
-      end
-
       # Output +messages+ alongside the formatted output.
       # This is an alternative to using Kernel#puts - it will display
       # nicer, and in all outputs (in case you use several formatters)

--- a/lib/cucumber/step_definition_light.rb
+++ b/lib/cucumber/step_definition_light.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 module Cucumber
+  # TODO: pointless, ancient, kill with fire.
   # Only used for keeping track of available and invoked step definitions
   # in a way that also works for other programming languages (i.e. cuke4duke)
   # Used for reporting purposes only (usage formatter).

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'cucumber/formatter/spec_helper'
 require 'cucumber/formatter/html'
 require 'nokogiri'
-require 'cucumber/rb_support/rb_language'
+require 'cucumber/glue/registry_and_more'
 require 'rspec/mocks'
 
 module Cucumber

--- a/spec/cucumber/formatter/spec_helper.rb
+++ b/spec/cucumber/formatter/spec_helper.rb
@@ -71,7 +71,7 @@ module Cucumber
         return unless step_defs = self.class.step_defs
         runtime.support_code.ruby
         dsl = Object.new
-        dsl.extend RbSupport::RbDsl
+        dsl.extend Glue::Dsl
         dsl.instance_exec &step_defs
       end
 

--- a/spec/cucumber/formatter/spec_helper.rb
+++ b/spec/cucumber/formatter/spec_helper.rb
@@ -25,7 +25,7 @@ module Cucumber
         receiver = Test::Runner.new(event_bus)
         filters = [
           Filters::ActivateSteps.new(
-            StepMatchSearch.new(actual_runtime.support_code.ruby.method(:step_matches), actual_runtime.configuration),
+            StepMatchSearch.new(actual_runtime.support_code.registry.method(:step_matches), actual_runtime.configuration),
             actual_runtime.configuration
           ),
           Filters::ApplyAfterStepHooks.new(actual_runtime.support_code),
@@ -69,7 +69,7 @@ module Cucumber
 
       def define_steps
         return unless step_defs = self.class.step_defs
-        runtime.support_code.ruby
+        runtime.support_code.registry
         dsl = Object.new
         dsl.extend Glue::Dsl
         dsl.instance_exec &step_defs

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -7,7 +7,9 @@ module Cucumber
   module Glue
     describe ProtoWorld do
 
-      let(:world) { Object.new.extend(ProtoWorld) }
+      let(:runtime) { double('runtime') }
+      let(:language) { double('language') }
+      let(:world) { Object.new.extend(ProtoWorld.for(runtime, language)) }
 
       describe '#table' do
         it 'produces Ast::Table by #table' do

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -9,6 +9,17 @@ module Cucumber
       extend Cucumber::Formatter::SpecHelperDsl
       include Cucumber::Formatter::SpecHelper
 
+      describe '#table' do
+        it 'produces Ast::Table by #table' do
+          world = Object.new.extend(ProtoWorld)
+          expect(world.table(%{
+        | account | description | amount |
+        | INT-100 | Taxi        | 114    |
+        | CUC-101 | Peeler      | 22     |
+          })).to be_kind_of(MultilineArgument::DataTable)
+        end
+      end
+
       describe 'Handling puts in step definitions' do
         before(:each) do
           Cucumber::Term::ANSIColor.coloring = false

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -6,12 +6,11 @@ require 'cucumber/formatter/pretty'
 module Cucumber
   module Glue
     describe ProtoWorld do
-      extend Cucumber::Formatter::SpecHelperDsl
-      include Cucumber::Formatter::SpecHelper
+
+      let(:world) { Object.new.extend(ProtoWorld) }
 
       describe '#table' do
         it 'produces Ast::Table by #table' do
-          world = Object.new.extend(ProtoWorld)
           expect(world.table(%{
         | account | description | amount |
         | INT-100 | Taxi        | 114    |
@@ -21,6 +20,9 @@ module Cucumber
       end
 
       describe 'Handling puts in step definitions' do
+        extend Cucumber::Formatter::SpecHelperDsl
+        include Cucumber::Formatter::SpecHelper
+
         before(:each) do
           Cucumber::Term::ANSIColor.coloring = false
           @out = StringIO.new

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -35,7 +35,7 @@ module Cucumber
           end
 
           it 'prints the variable value at the time puts was called' do
-            expect( @out.string ).to include <<OUTPUT
+            expect(@out.string).to include <<OUTPUT
     When puts is called twice for the same variable
       a
       A

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -4,8 +4,8 @@ require 'cucumber/formatter/spec_helper'
 require 'cucumber/formatter/pretty'
 
 module Cucumber
-  module RbSupport
-    describe RbWorld do
+  module Glue
+    describe ProtoWorld do
       extend Cucumber::Formatter::SpecHelperDsl
       include Cucumber::Formatter::SpecHelper
 

--- a/spec/cucumber/glue/registry_and_more_spec.rb
+++ b/spec/cucumber/glue/registry_and_more_spec.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 require 'spec_helper'
-require 'cucumber/rb_support/rb_language'
+require 'cucumber/glue/registry_and_more'
 
 module Cucumber
-  module RbSupport
-    describe RbStepDefinition do
+  module Glue
+    describe StepDefinition do
       let(:user_interface) { double('user interface') }
-      let(:rb)             { support_code.ruby }
+      let(:registry)       { support_code.registry }
       let(:support_code) do
         Cucumber::Runtime::SupportCode.new(user_interface)
       end
       let(:dsl) do
-        rb
-        Object.new.extend(RbSupport::RbDsl)
+        registry
+        Object.new.extend(Glue::Dsl)
       end
 
       describe '#load_code_file' do
@@ -32,14 +32,14 @@ module Cucumber
             '$foo = 1'
           end
 
-          rb.load_code_file('tmp.rb')
+          registry.load_code_file('tmp.rb')
           expect($foo).to eq 1
 
           a_file_called('tmp.rb') do
             '$foo = 2'
           end
 
-          rb.load_code_file('tmp.rb')
+          registry.load_code_file('tmp.rb')
 
           expect($foo).to eq 2
         end
@@ -48,7 +48,7 @@ module Cucumber
           a_file_called('docs.md') do
             'yo'
           end
-          rb.load_code_file('docs.md')
+          registry.load_code_file('docs.md')
         end
       end
 
@@ -57,12 +57,12 @@ module Cucumber
           dsl.World {}
 
           begin
-            rb.begin_scenario(nil)
+            registry.begin_scenario(nil)
             raise 'Should fail'
-          rescue RbSupport::NilWorld => e
+          rescue Glue::NilWorld => e
             expect(e.message).to eq 'World procs should never return nil'
             expect(e.backtrace.length).to eq 1
-            expect(e.backtrace[0]).to match(/spec\/cucumber\/rb_support\/rb_language_spec\.rb\:\d+\:in `World'/)
+            expect(e.backtrace[0]).to match(/spec\/cucumber\/glue\/registry_and_more_spec\.rb\:\d+\:in `World'/)
           end
         end
 
@@ -77,24 +77,24 @@ module Cucumber
 
         it 'implicitlys extend world with modules' do
           dsl.World(ModuleOne, ModuleTwo)
-          rb.begin_scenario(double('scenario').as_null_object)
-          class << rb.current_world
+          registry.begin_scenario(double('scenario').as_null_object)
+          class << registry.current_world
             extend RSpec::Matchers
 
             expect(included_modules.inspect).to match(/ModuleOne/) # Workaround for RSpec/Ruby 1.9 issue with namespaces
             expect(included_modules.inspect).to match(/ModuleTwo/)
           end
-          expect(rb.current_world.class).to eq Object
+          expect(registry.current_world.class).to eq Object
         end
 
         it 'raises error when we try to register more than one World proc' do
           expected_error = %{You can only pass a proc to #World once, but it's happening
 in 2 places:
 
-spec/cucumber/rb_support/rb_language_spec.rb:\\d+:in `World'
-spec/cucumber/rb_support/rb_language_spec.rb:\\d+:in `World'
+spec/cucumber/glue/registry_and_more_spec.rb:\\d+:in `World'
+spec/cucumber/glue/registry_and_more_spec.rb:\\d+:in `World'
 
-Use Ruby modules instead to extend your worlds. See the Cucumber::RbSupport::RbDsl#World RDoc
+Use Ruby modules instead to extend your worlds. See the Cucumber::Glue::Dsl#World RDoc
 or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
 
 }
@@ -102,7 +102,7 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
 
           expect(-> {
             dsl.World { Array.new }
-          }).to raise_error(RbSupport::MultipleWorld, /#{expected_error}/)
+          }).to raise_error(Glue::MultipleWorld, /#{expected_error}/)
         end
       end
 
@@ -133,52 +133,52 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
 
         it 'extends the world with namespaces' do
           dsl.World(ModuleOne, module_two: ModuleTwo, module_three: ModuleThree)
-          rb.begin_scenario(double('scenario').as_null_object)
-          class << rb.current_world
+          registry.begin_scenario(double('scenario').as_null_object)
+          class << registry.current_world
             extend RSpec::Matchers
             expect(included_modules.inspect).to match(/ModuleOne/)
           end
-          expect(rb.current_world.class).to eq Object
-          expect(rb.current_world).to respond_to(:method_one)
+          expect(registry.current_world.class).to eq Object
+          expect(registry.current_world).to respond_to(:method_one)
 
-          expect(rb.current_world.module_two.class).to eq Object
-          expect(rb.current_world.module_two).to respond_to(:method_two)
+          expect(registry.current_world.module_two.class).to eq Object
+          expect(registry.current_world.module_two).to respond_to(:method_two)
 
-          expect(rb.current_world.module_three.class).to eq Object
-          expect(rb.current_world.module_three).to respond_to(:method_three)
+          expect(registry.current_world.module_three.class).to eq Object
+          expect(registry.current_world.module_three).to respond_to(:method_three)
         end
 
         it 'allows to inspect the included modules' do
           dsl.World(ModuleOne, module_two: ModuleTwo, module_three: ModuleThree)
-          rb.begin_scenario(double('scenario').as_null_object)
-          class << rb.current_world
+          registry.begin_scenario(double('scenario').as_null_object)
+          class << registry.current_world
             extend RSpec::Matchers
           end
-          expect(rb.current_world.inspect).to match(/ModuleOne/)
-          expect(rb.current_world.inspect).to include('ModuleTwo (as module_two)')
-          expect(rb.current_world.inspect).to include('ModuleThree (as module_three)')
+          expect(registry.current_world.inspect).to match(/ModuleOne/)
+          expect(registry.current_world.inspect).to include('ModuleTwo (as module_two)')
+          expect(registry.current_world.inspect).to include('ModuleThree (as module_three)')
         end
 
         it 'merges methods when assigning different modules to the same namespace' do
           dsl.World(namespace: ModuleOne)
           dsl.World(namespace: ModuleTwo)
-          rb.begin_scenario(double('scenario').as_null_object)
-          class << rb.current_world
+          registry.begin_scenario(double('scenario').as_null_object)
+          class << registry.current_world
             extend RSpec::Matchers
           end
-          expect(rb.current_world.namespace).to respond_to(:method_one)
-          expect(rb.current_world.namespace).to respond_to(:method_two)
+          expect(registry.current_world.namespace).to respond_to(:method_one)
+          expect(registry.current_world.namespace).to respond_to(:method_two)
         end
 
         it 'resolves conflicts when assigning different modules to the same namespace' do
           dsl.World(namespace: ModuleOne)
           dsl.World(namespace: ModuleMinusOne)
-          rb.begin_scenario(double('scenario').as_null_object)
-          class << rb.current_world
+          registry.begin_scenario(double('scenario').as_null_object)
+          class << registry.current_world
             extend RSpec::Matchers
           end
-          expect(rb.current_world.namespace).to respond_to(:method_one)
-          expect(rb.current_world.namespace.method_one).to eql(-1)
+          expect(registry.current_world.namespace).to respond_to(:method_one)
+          expect(registry.current_world.namespace.method_one).to eql(-1)
         end
       end
 
@@ -187,35 +187,35 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
           it 'complains when registering with a with no transform block' do
             expect(-> {
               dsl.Transform('^abc$')
-            }).to raise_error(Cucumber::RbSupport::RbTransform::MissingProc)
+            }).to raise_error(Cucumber::Glue::Transform::MissingProc)
           end
 
           it 'complains when registering with a zero-arg transform block' do
             expect(-> {
               dsl.Transform('^abc$') {42}
-            }).to raise_error(Cucumber::RbSupport::RbTransform::MissingProc)
+            }).to raise_error(Cucumber::Glue::Transform::MissingProc)
           end
 
           it 'complains when registering with a splat-arg transform block' do
             expect(-> {
               dsl.Transform('^abc$') {|*splat| 42 }
-            }).to raise_error(Cucumber::RbSupport::RbTransform::MissingProc)
+            }).to raise_error(Cucumber::Glue::Transform::MissingProc)
           end
 
           it 'complains when transforming with an arity mismatch' do
             expect(-> {
               dsl.Transform('^abc$') {|one, two| 42 }
-              rb.execute_transforms(['abc'])
+              registry.execute_transforms(['abc'])
             }).to raise_error(Cucumber::ArityMismatchError)
           end
 
           it 'allows registering a regexp pattern that yields the step_arg matched' do
             dsl.Transform(/^ab*c$/) {|arg| 42}
 
-            expect(rb.execute_transforms(['ab'])).to eq ['ab']
-            expect(rb.execute_transforms(['ac'])).to eq [42]
-            expect(rb.execute_transforms(['abc'])).to eq [42]
-            expect(rb.execute_transforms(['abbc'])).to eq [42]
+            expect(registry.execute_transforms(['ab'])).to eq ['ab']
+            expect(registry.execute_transforms(['ac'])).to eq [42]
+            expect(registry.execute_transforms(['abc'])).to eq [42]
+            expect(registry.execute_transforms(['abbc'])).to eq [42]
           end
 
           it 'transforms times' do
@@ -223,8 +223,8 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
             dsl.Transform(/^(\d\d-\d\d-\d\d\d\d)$/) do |arg|
               Time.parse(arg)
             end
-            expect(rb.execute_transforms(['10-0E-1971'])).to eq ['10-0E-1971']
-            expect(rb.execute_transforms(['10-03-1971'])).to eq [Time.parse('10-03-1971')]
+            expect(registry.execute_transforms(['10-0E-1971'])).to eq ['10-0E-1971']
+            expect(registry.execute_transforms(['10-03-1971'])).to eq [Time.parse('10-03-1971')]
           end
         end
 
@@ -232,25 +232,25 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
           it 'complains when registering with a with no transform block' do
             expect(-> {
               dsl.Transform('^a(.)c$')
-            }).to raise_error(Cucumber::RbSupport::RbTransform::MissingProc)
+            }).to raise_error(Cucumber::Glue::Transform::MissingProc)
           end
 
           it 'complains when registering with a zero-arg transform block' do
             expect(-> {
               dsl.Transform('^a(.)c$') { 42 }
-            }).to raise_error(Cucumber::RbSupport::RbTransform::MissingProc)
+            }).to raise_error(Cucumber::Glue::Transform::MissingProc)
           end
 
           it 'complains when registering with a splat-arg transform block' do
             expect(-> {
               dsl.Transform('^a(.)c$') {|*splat| 42 }
-            }).to raise_error(Cucumber::RbSupport::RbTransform::MissingProc)
+            }).to raise_error(Cucumber::Glue::Transform::MissingProc)
           end
 
           it 'complains when transforming with an arity mismatch' do
             expect(-> {
               dsl.Transform('^a(.)c$') {|one, two| 42 }
-              rb.execute_transforms(['abc'])
+              registry.execute_transforms(['abc'])
             }).to raise_error(Cucumber::ArityMismatchError)
           end
 
@@ -259,19 +259,19 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
               {shape.to_sym => color.to_sym}
             end
 
-            expect(rb.execute_transforms(['shape: circle, color: blue'])).to eq [{:circle => :blue}]
-            expect(rb.execute_transforms(['shape: square, color: red'])).to eq [{:square => :red}]
-            expect(rb.execute_transforms(['not shape: square, not color: red'])).to eq ['not shape: square, not color: red']
+            expect(registry.execute_transforms(['shape: circle, color: blue'])).to eq [{:circle => :blue}]
+            expect(registry.execute_transforms(['shape: square, color: red'])).to eq [{:square => :red}]
+            expect(registry.execute_transforms(['not shape: square, not color: red'])).to eq ['not shape: square, not color: red']
           end
         end
 
         it 'allows registering a string pattern' do
           dsl.Transform('^ab*c$') {|arg| 42}
 
-          expect(rb.execute_transforms(['ab'])).to eq ['ab']
-          expect(rb.execute_transforms(['ac'])).to eq [42]
-          expect(rb.execute_transforms(['abc'])).to eq [42]
-          expect(rb.execute_transforms(['abbc'])).to eq [42]
+          expect(registry.execute_transforms(['ab'])).to eq ['ab']
+          expect(registry.execute_transforms(['ac'])).to eq [42]
+          expect(registry.execute_transforms(['abc'])).to eq [42]
+          expect(registry.execute_transforms(['abbc'])).to eq [42]
         end
 
         it 'gives match priority to transforms defined last' do
@@ -279,14 +279,14 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
           dsl.Transform(/^transform_me$/) {|arg| :bar }
           dsl.Transform(/^transform_me$/) {|arg| :baz }
 
-          expect(rb.execute_transforms(['transform_me'])).to eq [:baz]
+          expect(registry.execute_transforms(['transform_me'])).to eq [:baz]
         end
 
         it 'allows registering a transform which returns nil' do
           dsl.Transform('^ac$') {|arg| nil}
 
-          expect(rb.execute_transforms(['ab'])).to eq ['ab']
-          expect(rb.execute_transforms(['ac'])).to eq [nil]
+          expect(registry.execute_transforms(['ab'])).to eq ['ab']
+          expect(registry.execute_transforms(['ac'])).to eq [nil]
         end
       end
 
@@ -299,7 +299,7 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
 
           expect(scenario).to receive(:accept_hook?).with(fish) { true }
           expect(scenario).to receive(:accept_hook?).with(meat) { false }
-          expect(rb.hooks_for(:before, scenario)).to eq [fish]
+          expect(registry.hooks_for(:before, scenario)).to eq [fish]
         end
 
         it 'finds around hooks' do
@@ -313,7 +313,7 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
 
           expect(scenario).to receive(:accept_hook?).with(a) { true }
           expect(scenario).to receive(:accept_hook?).with(b) { false }
-          expect(rb.hooks_for(:around, scenario)).to eq [a]
+          expect(registry.hooks_for(:around, scenario)).to eq [a]
         end
       end
     end

--- a/spec/cucumber/glue/snippet_spec.rb
+++ b/spec/cucumber/glue/snippet_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 require 'spec_helper'
-require 'cucumber/rb_support/snippet'
+require 'cucumber/glue/snippet'
 
 module Cucumber
-  module RbSupport
+  module Glue
     describe Snippet do
       let(:code_keyword) { 'Given' }
 

--- a/spec/cucumber/glue/step_definition_spec.rb
+++ b/spec/cucumber/glue/step_definition_spec.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 require 'spec_helper'
-require 'cucumber/rb_support/rb_language'
+require 'cucumber/glue/registry_and_more'
 
 module Cucumber
-  module RbSupport
-    describe RbStepDefinition do
+  module Glue
+    describe StepDefinition do
       let(:user_interface) { double('user interface') }
       let(:support_code)   { Cucumber::Runtime::SupportCode.new(user_interface) }
-      let(:rb)             { support_code.ruby }
+      let(:registry)       { support_code.registry }
       let(:scenario)       { double('scenario', iso_code: 'en').as_null_object }
       let(:dsl) do
-        rb
-        Object.new.extend(Cucumber::RbSupport::RbDsl)
+        registry
+        Object.new.extend(Cucumber::Glue::Dsl)
       end
 
       before do
-        rb.begin_scenario(scenario)
+        registry.begin_scenario(scenario)
         $inside = nil
       end
 
@@ -24,7 +24,7 @@ module Cucumber
       end
 
       def step_match(text)
-        StepMatchSearch.new(rb.method(:step_matches), Configuration.default).call(text).first
+        StepMatchSearch.new(registry.method(:step_matches), Configuration.default).call(text).first
       end
 
       it 'allows calling of other steps' do
@@ -55,7 +55,7 @@ module Cucumber
 
       context 'mapping to world methods' do
         it 'calls a method on the world when specified with a symbol' do
-          expect(rb.current_world).to receive(:with_symbol)
+          expect(registry.current_world).to receive(:with_symbol)
 
           dsl.Given(/With symbol/, :with_symbol)
 
@@ -65,7 +65,7 @@ module Cucumber
         it 'calls a method on a specified object' do
           target = double('target')
 
-          allow(rb.current_world).to receive(:target) { target }
+          allow(registry.current_world).to receive(:target) { target }
 
           dsl.Given(/With symbol on block/, :with_symbol, :on => lambda { target })
 
@@ -77,7 +77,7 @@ module Cucumber
         it 'calls a method on a specified world attribute' do
           target = double('target')
 
-          allow(rb.current_world).to receive(:target) { target }
+          allow(registry.current_world).to receive(:target) { target }
 
           dsl.Given(/With symbol on symbol/, :with_symbol, :on => :target)
 
@@ -88,7 +88,7 @@ module Cucumber
 
         it 'has the correct location' do
           dsl.Given(/With symbol/, :with_symbol)
-          expect(step_match('With symbol').file_colon_line).to eq "spec/cucumber/rb_support/rb_step_definition_spec.rb:#{__LINE__-1}"
+          expect(step_match('With symbol').file_colon_line).to eq "spec/cucumber/glue/step_definition_spec.rb:#{__LINE__-1}"
         end
       end
 
@@ -192,7 +192,7 @@ module Cucumber
       end
 
       it 'has a JSON representation of the signature' do
-        expect(RbStepDefinition.new(rb, /I CAN HAZ (\d+) CUKES/i, lambda{}, {}).to_hash).to eq({ 'source' => 'I CAN HAZ (\\d+) CUKES', 'flags' => 'i' })
+        expect(StepDefinition.new(registry, /I CAN HAZ (\d+) CUKES/i, lambda{}, {}).to_hash).to eq({ 'source' => 'I CAN HAZ (\\d+) CUKES', 'flags' => 'i' })
       end
     end
   end

--- a/spec/cucumber/glue/transform_spec.rb
+++ b/spec/cucumber/glue/transform_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 require 'spec_helper'
-require 'cucumber/rb_support/rb_transform'
+require 'cucumber/glue/transform'
 
 module Cucumber
-  module RbSupport
-    describe RbTransform do
+  module Glue
+    describe Transform do
       def transform(regexp)
-        RbTransform.new(nil, regexp, lambda { |a| })
+        Transform.new(nil, regexp, lambda { |a| })
       end
 
       describe '#to_s' do

--- a/spec/cucumber/glue/transform_spec.rb
+++ b/spec/cucumber/glue/transform_spec.rb
@@ -6,7 +6,7 @@ module Cucumber
   module Glue
     describe Transform do
       def transform(regexp)
-        Transform.new(nil, regexp, lambda { |a| })
+        Transform.new(nil, regexp, -> (a) { })
       end
 
       describe '#to_s' do

--- a/spec/cucumber/runtime/for_programming_languages_spec.rb
+++ b/spec/cucumber/runtime/for_programming_languages_spec.rb
@@ -3,25 +3,6 @@ require 'spec_helper'
 
 module Cucumber
   describe Runtime::ForProgrammingLanguages do
-
-    let(:user_interface)  { double('user interface') }
-    subject               { Runtime::SupportCode.new(user_interface) }
-    let(:runtime_facade)  { Runtime::ForProgrammingLanguages.new(subject, user_interface) }
-
-    describe '#doc_string' do
-
-      it 'defaults to a blank content-type' do
-        str = runtime_facade.doc_string('DOC')
-        expect(str).to be_kind_of(MultilineArgument::DocString)
-        expect(str.content_type).to eq('')
-      end
-
-      it 'can have a content type' do
-        str = runtime_facade.doc_string('DOC','ruby')
-        expect(str.content_type).to eq('ruby')
-      end
-
-    end
-
+    it 'should probably be inlined'
   end
 end

--- a/spec/cucumber/runtime/for_programming_languages_spec.rb
+++ b/spec/cucumber/runtime/for_programming_languages_spec.rb
@@ -23,15 +23,5 @@ module Cucumber
 
     end
 
-    describe '#table' do
-
-      it 'produces Ast::Table by #table' do
-        expect(runtime_facade.table(%{
-      | account | description | amount |
-      | INT-100 | Taxi        | 114    |
-      | CUC-101 | Peeler      | 22     |
-        })).to be_kind_of(MultilineArgument::DataTable)
-      end
-    end
   end
 end

--- a/spec/cucumber/step_match_search_spec.rb
+++ b/spec/cucumber/step_match_search_spec.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 require 'cucumber/step_match_search'
-require 'cucumber/rb_support/rb_dsl'
-require 'cucumber/rb_support/rb_language'
+require 'cucumber/glue/dsl'
+require 'cucumber/glue/registry_and_more'
 require 'cucumber/configuration'
 
 module Cucumber
   describe StepMatchSearch do
 
-    let(:search) { StepMatchSearch.new(rb_language.method(:step_matches), configuration) }
-    let(:rb_language) { RbSupport::RbLanguage.new(runtime, configuration) }
+    let(:search) { StepMatchSearch.new(registry.method(:step_matches), configuration) }
+    let(:registry) { Glue::RegistryAndMore.new(runtime, configuration) }
     let(:runtime) do
-      # TODO: break out step definitions collection from RbLanguage so we don't need this
+      # TODO: break out step definitions collection from Glue::RegistryAndMore so we don't need this
       :unused
     end
     let(:configuration) { Configuration.new(options) }
     let(:options) { {} }
     let(:dsl) do
       # TODO: stop relying on implicit global state
-      rb_language
-      Object.new.extend(RbSupport::RbDsl)
+      registry
+      Object.new.extend(Glue::Dsl)
     end
 
     context 'caching' do
@@ -27,7 +27,7 @@ module Cucumber
 
         step_match = search.call('it snows in april').first
 
-        expect(rb_language).not_to receive(:step_matches)
+        expect(registry).not_to receive(:step_matches)
         second_step_match = search.call('it snows in april').first
 
         expect(step_match).to equal(second_step_match)

--- a/spec/cucumber/step_match_spec.rb
+++ b/spec/cucumber/step_match_spec.rb
@@ -1,19 +1,19 @@
 # encoding: utf-8
 # frozen_string_literal: true
 require 'spec_helper'
-require 'cucumber/rb_support/rb_step_definition'
-require 'cucumber/rb_support/rb_language'
+require 'cucumber/glue/step_definition'
+require 'cucumber/glue/registry_and_more'
 
 module Cucumber
   describe StepMatch do
     WORD = '[[:word:]]'
 
     before do
-      @rb_language = RbSupport::RbLanguage.new(nil, Configuration.new)
+      @registry = Glue::RegistryAndMore.new(nil, Configuration.new)
     end
 
     def stepdef(regexp)
-      RbSupport::RbStepDefinition.new(@rb_language, regexp, lambda{}, {})
+      Glue::StepDefinition.new(@registry, regexp, lambda{}, {})
     end
 
     def step_match(regexp, name)

--- a/spec/cucumber/world/pending_spec.rb
+++ b/spec/cucumber/world/pending_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 require 'spec_helper'
-require 'cucumber/rb_support/rb_language'
+require 'cucumber/glue/registry_and_more'
 require 'cucumber/configuration'
 
 module Cucumber
   describe 'Pending' do
     before(:each) do
-      l = RbSupport::RbLanguage.new(Runtime.new, Configuration.new)
-      l.begin_rb_scenario(double('scenario').as_null_object)
-      @world = l.current_world
+      registry = Glue::RegistryAndMore.new(Runtime.new, Configuration.new)
+      registry.begin_scenario(double('scenario').as_null_object)
+      @world = registry.current_world
     end
 
     it 'raises a Pending if no block is supplied' do


### PR DESCRIPTION
The old programming language abstraction is confusing. This starts to improve the names and lay the groundwork to get rid of all the mess it hides.

There's lots of global state and mutation that we can clean up.