### PR TITLE
Adds scenario for the ambiguous step reporting

### DIFF
--- a/features/docs/defining_steps/ambiguous_steps.feature
+++ b/features/docs/defining_steps/ambiguous_steps.feature
@@ -15,11 +15,11 @@ Feature: Ambiguous Steps
     """
     Feature:
 
-      Scenario: test 1
+      Scenario:
       * a step
       * an ambiguous step
 
-      Scenario: test 2
+      Scenario:
       * step 1
       * step 2
 

--- a/features/docs/defining_steps/ambiguous_steps.feature
+++ b/features/docs/defining_steps/ambiguous_steps.feature
@@ -70,3 +70,39 @@ Feature: Ambiguous Steps
     4 steps (1 failed, 3 passed)
     0m0.012s
     """
+
+
+  Scenario: Ambiguous steps with guess mode
+
+    Given a file named "features/ambiguous.feature" with:
+    """
+    Feature:
+
+      Scenario:
+      * a step
+      * an ambiguous step
+    """
+    And a file named "features/step_definitions.rb" with:
+    """
+      When(/^a.*step$/) do
+        'foo'
+      end
+
+      When(/^an ambiguous step$/) do
+        'bar'
+      end
+    """
+    When I run `cucumber -g`
+    Then it should pass with exactly:
+    """
+    Feature:
+
+      Scenario:             # features/ambiguous.feature:3
+        * a step            # features/step_definitions.rb:1
+        * an ambiguous step # features/step_definitions.rb:5
+
+    1 scenario (1 passed)
+    2 steps (2 passed)
+    0m0.012s
+
+    """

--- a/features/docs/defining_steps/ambiguous_steps.feature
+++ b/features/docs/defining_steps/ambiguous_steps.feature
@@ -16,8 +16,8 @@ Feature: Ambiguous Steps
     Feature:
 
       Scenario:
-      * a step
-      * an ambiguous step
+      When a step
+      Then an ambiguous step
 
     """
     And a file named "features/step_definitions.rb" with:
@@ -26,7 +26,7 @@ Feature: Ambiguous Steps
         'foo'
       end
 
-      When(/^an ambiguous step$/) do
+      Then(/^an ambiguous step$/) do
         'bar'
       end
 
@@ -52,8 +52,8 @@ Feature: Ambiguous Steps
     Feature:
 
       Scenario:
-      * a step
-      * an ambiguous step
+      When a step
+      Then an ambiguous step
     """
     And a file named "features/step_definitions.rb" with:
     """
@@ -61,18 +61,18 @@ Feature: Ambiguous Steps
         'foo'
       end
 
-      When(/^an ambiguous step$/) do
+      Then(/^an ambiguous step$/) do
         'bar'
       end
     """
     When I run `cucumber -g`
     Then it should pass with exactly:
     """
-    Feature:
+    Feature: 
 
-      Scenario:             # features/ambiguous.feature:3
-        * a step            # features/step_definitions.rb:1
-        * an ambiguous step # features/step_definitions.rb:5
+      Scenario:                # features/ambiguous.feature:3
+        When a step            # features/step_definitions.rb:1
+        Then an ambiguous step # features/step_definitions.rb:5
 
     1 scenario (1 passed)
     2 steps (2 passed)

--- a/features/docs/defining_steps/ambiguous_steps.feature
+++ b/features/docs/defining_steps/ambiguous_steps.feature
@@ -8,7 +8,7 @@ Feature: Ambiguous Steps
   out which of those two step definitions is most likely to be the one you meant it
   to use. Use it with caution!
 
-  @wip
+
   Scenario: Ambiguous steps
 
     Given a file named "features/ambiguous.feature" with:
@@ -18,10 +18,6 @@ Feature: Ambiguous Steps
       Scenario:
       * a step
       * an ambiguous step
-
-      Scenario:
-      * step 1
-      * step 2
 
     """
     And a file named "features/step_definitions.rb" with:
@@ -34,41 +30,18 @@ Feature: Ambiguous Steps
         'bar'
       end
 
-      When(/^step 1$/) do
-        'baz'
-      end
-
-      When(/^step 2$/) do
-        'buzz'
-      end
     """
     When I run `cucumber`
-    Then it should fail with exactly:
+    Then it should fail with:
     """
-    Feature:
+    Ambiguous match of "an ambiguous step":
 
-      Scenario: test 1      # features/ambiguous.feature:3
-        * a step            # features/step_definitions.rb:1
-        * an ambiguous step # features/step_definitions.rb:5
-           Error matching steps.
-           Step text "an ambiguous step" would be match by
-           - /^a.*step$/ at ./features/step_definitions.rb:1
-           - /^an ambiguous step$/ at ./features/step_definitions.rb:6
-           (Cucumber::Ambiguous)
-          -e:1:in `load'
-          -e:1:in `<main>'
-          features/ambiguous.feature:5:in `* an ambiguous step'
+    features/step_definitions.rb:1:in `/^a.*step$/'
+    features/step_definitions.rb:5:in `/^an ambiguous step$/'
 
-      Scenario: test 2 # features/ambiguous.feature:7
-        * step 1       # features/step_definitions.rb:9
-        * step 2       # features/step_definitions.rb:13
+    You can run again with --guess to make Cucumber be more smart about it
+     (Cucumber::Ambiguous)
 
-    Failing Scenarios:
-    cucumber features/ambiguous.feature:3 # Scenario: test 1
-
-    2 scenarios (1 failed, 1 passed)
-    4 steps (1 failed, 3 passed)
-    0m0.012s
     """
 
 

--- a/features/docs/defining_steps/ambiguous_steps.feature
+++ b/features/docs/defining_steps/ambiguous_steps.feature
@@ -9,7 +9,6 @@ Feature: Ambiguous Steps
   to use. Use it with caution!
 
 
-  @wip
   Scenario: Ambiguous steps
 
     Given a file named "features/ambiguous.feature" with:
@@ -35,13 +34,17 @@ Feature: Ambiguous Steps
     When I run `cucumber`
     Then it should fail with:
     """
-    Ambiguous match of "an ambiguous step":
+          Ambiguous match of "an ambiguous step":
+          
+          features/step_definitions.rb:1:in `/^a.*step$/'
+          features/step_definitions.rb:5:in `/^an ambiguous step$/'
+          
+          You can run again with --guess to make Cucumber be more smart about it
+           (Cucumber::Ambiguous)
+          features/ambiguous.feature:5:in `Then an ambiguous step'
 
-    features/step_definitions.rb:1:in `/^a.*step$/'
-    features/step_definitions.rb:5:in `/^an ambiguous step$/'
-
-    You can run again with --guess to make Cucumber be more smart about it
-     (Cucumber::Ambiguous)
+    Failing Scenarios:
+    cucumber features/ambiguous.feature:3 # Scenario: 
 
     1 scenario (1 failed)
     2 steps (1 failed, 1 passed)

--- a/features/docs/defining_steps/ambiguous_steps.feature
+++ b/features/docs/defining_steps/ambiguous_steps.feature
@@ -42,6 +42,10 @@ Feature: Ambiguous Steps
     You can run again with --guess to make Cucumber be more smart about it
      (Cucumber::Ambiguous)
 
+    1 scenario (1 failed)
+    2 steps (1 failed, 1 passed)
+    0m0.012s
+
     """
 
 

--- a/features/docs/defining_steps/ambiguous_steps.feature
+++ b/features/docs/defining_steps/ambiguous_steps.feature
@@ -9,6 +9,7 @@ Feature: Ambiguous Steps
   to use. Use it with caution!
 
 
+  @wip
   Scenario: Ambiguous steps
 
     Given a file named "features/ambiguous.feature" with:

--- a/features/docs/defining_steps/ambiguous_steps.feature
+++ b/features/docs/defining_steps/ambiguous_steps.feature
@@ -1,5 +1,13 @@
 Feature: Ambiguous Steps
 
+  When Cucumber searches for a step definition for a step, it might find multiple step
+  definitions that could match. In that case, it will give you an error that the step
+  definitions are ambiguous.
+
+  You can also use a `--guess` mode, where it uses magic powers to try and figure
+  out which of those two step definitions is most likely to be the one you meant it
+  to use. Use it with caution!
+
   @wip
   Scenario: Ambiguous steps
 

--- a/features/docs/defining_steps/ambiguous_steps.feature
+++ b/features/docs/defining_steps/ambiguous_steps.feature
@@ -1,5 +1,6 @@
 Feature: Ambiguous Steps
- 
+
+  @wip
   Scenario: Ambiguous steps
 
     Given a file named "features/ambiguous.feature" with:

--- a/features/docs/defining_steps/ambiguous_steps.feature
+++ b/features/docs/defining_steps/ambiguous_steps.feature
@@ -1,0 +1,63 @@
+Feature: Ambiguous Steps
+ 
+  Scenario: Ambiguous steps
+
+    Given a file named "features/ambiguous.feature" with:
+    """
+    Feature:
+
+      Scenario: test 1
+      * a step
+      * an ambiguous step
+
+      Scenario: test 2
+      * step 1
+      * step 2
+
+    """
+    And a file named "features/step_definitions.rb" with:
+    """
+      When(/^a.*step$/) do
+        'foo'
+      end
+
+      When(/^an ambiguous step$/) do
+        'bar'
+      end
+
+      When(/^step 1$/) do
+        'baz'
+      end
+
+      When(/^step 2$/) do
+        'buzz'
+      end
+    """
+    When I run `cucumber`
+    Then it should fail with exactly:
+    """
+    Feature:
+
+      Scenario: test 1      # features/ambiguous.feature:3
+        * a step            # features/step_definitions.rb:1
+        * an ambiguous step # features/step_definitions.rb:5
+           Error matching steps.
+           Step text "an ambiguous step" would be match by
+           - /^a.*step$/ at ./features/step_definitions.rb:1
+           - /^an ambiguous step$/ at ./features/step_definitions.rb:6
+           (Cucumber::Ambiguous)
+          -e:1:in `load'
+          -e:1:in `<main>'
+          features/ambiguous.feature:5:in `* an ambiguous step'
+
+      Scenario: test 2 # features/ambiguous.feature:7
+        * step 1       # features/step_definitions.rb:9
+        * step 2       # features/step_definitions.rb:13
+
+    Failing Scenarios:
+    cucumber features/ambiguous.feature:3 # Scenario: test 1
+
+    2 scenarios (1 failed, 1 passed)
+    4 steps (1 failed, 3 passed)
+    0m0.012s
+    """

--- a/lib/cucumber/filters/activate_steps.rb
+++ b/lib/cucumber/filters/activate_steps.rb
@@ -43,7 +43,12 @@ module Cucumber
           end
 
           def result
-            return NoStepMatch.new(test_step.source.last, test_step.name) unless matches.any?
+            begin
+              return NoStepMatch.new(test_step.source.last, test_step.name) unless matches.any?
+            rescue Cucumber::Ambiguous => e
+              return AmbiguousStepMatch.new(e)
+            end
+
             configuration.notify :step_activated, test_step, match
             return SkippingStepMatch.new if configuration.dry_run?
             match

--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -147,7 +147,7 @@ module Cucumber
     end
 
     def activate(test_step)
-      return test_step.with_action { raise Core::Test::Result::Ambiguous.new(@error.message) }
+      return test_step.with_action { raise @error }
     end
 
   end

--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -139,4 +139,17 @@ module Cucumber
       return test_step
     end
   end
+
+  class AmbiguousStepMatch
+
+    def initialize(error)
+      @error = error
+    end
+
+    def activate(test_step)
+      return test_step.with_action { raise Core::Test::Result::Ambiguous.new(@error.message) }
+    end
+
+  end
+
 end


### PR DESCRIPTION
## Summary

Added scenario about how the reporting of ambiguous step match should be. See #1113 

## Details

Spike of an example we think reporting could be.

## Motivation and Context
Fixes #1113 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] I've added tests for my code
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
