### PR TITLE
Fixing the profile loader

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -65,7 +65,6 @@ Lint/RescueException:
   Exclude:
     - 'features/lib/support/fake_wire_server.rb'
     - 'lib/cucumber/cli/main.rb'
-    - 'lib/cucumber/cli/profile_loader.rb'
     - 'lib/cucumber/configuration.rb'
     - 'lib/cucumber/core_ext/instance_exec.rb'
     - 'lib/cucumber/formatter/ansicolor.rb'
@@ -260,7 +259,6 @@ Style/BracesAroundHashParameters:
     - 'lib/cucumber/multiline_argument/data_table.rb'
     - 'spec/cucumber/cli/configuration_spec.rb'
     - 'spec/cucumber/cli/options_spec.rb'
-    - 'spec/cucumber/cli/profile_loader_spec.rb'
     - 'spec/cucumber/formatter/html_spec.rb'
     - 'spec/cucumber/formatter/junit_spec.rb'
     - 'spec/cucumber/formatter/pretty_spec.rb'

--- a/lib/cucumber/cli/profile_loader.rb
+++ b/lib/cucumber/cli/profile_loader.rb
@@ -35,7 +35,6 @@ Defined profiles in cucumber.yml:
 
             args_from_yml = Shellwords.shellwords(sanitized_line).collect { |argument| argument.gsub(placeholder, '\\') }
           else
-            require 'shellwords'
             args_from_yml = Shellwords.shellwords(args_from_yml)
           end
         when Array

--- a/lib/cucumber/cli/profile_loader.rb
+++ b/lib/cucumber/cli/profile_loader.rb
@@ -67,7 +67,7 @@ Defined profiles in cucumber.yml:
         require 'yaml'
         begin
           @cucumber_erb = ERB.new(IO.read(cucumber_file), nil, '%').result(binding)
-        rescue Exception
+        rescue StandardError
           raise(YmlLoadError,"cucumber.yml was found, but could not be parsed with ERB.  Please refer to cucumber's documentation on correct profile usage.\n#{$!.inspect}")
         end
 

--- a/spec/cucumber/cli/profile_loader_spec.rb
+++ b/spec/cucumber/cli/profile_loader_spec.rb
@@ -43,8 +43,17 @@ default: <%= x %>
         expect(loader.args_from('default')).to eq ['--format','pretty','features/sync_imap_mailbox.feature:16:22']
       end
 
-      it 'correctly parses a profile that uses tag expressions' do
+      it 'correctly parses a profile that uses tag expressions (with double quotes)' do
         given_cucumber_yml_defined_as({'default' => '--format "pretty" features\sync_imap_mailbox.feature:16:22 --tags "not @jruby"'})
+        if(Cucumber::WINDOWS)
+          expect(loader.args_from('default')).to eq ['--format','pretty','features\sync_imap_mailbox.feature:16:22','--tags','not @jruby']
+        else
+          expect(loader.args_from('default')).to eq ['--format','pretty','featuressync_imap_mailbox.feature:16:22','--tags','not @jruby']
+        end
+      end
+
+      it 'correctly parses a profile that uses tag expressions (with single quotes)' do
+        given_cucumber_yml_defined_as({'default' => "--format 'pretty' features\\sync_imap_mailbox.feature:16:22 --tags 'not @jruby'"})
         if(Cucumber::WINDOWS)
           expect(loader.args_from('default')).to eq ['--format','pretty','features\sync_imap_mailbox.feature:16:22','--tags','not @jruby']
         else

--- a/spec/cucumber/cli/profile_loader_spec.rb
+++ b/spec/cucumber/cli/profile_loader_spec.rb
@@ -48,7 +48,7 @@ default: <%= x %>
         if(Cucumber::WINDOWS)
           expect(loader.args_from('default')).to eq ['--format','pretty','features\sync_imap_mailbox.feature:16:22','--tags','not @jruby']
         else
-          expect(loader.args_from('default')).to eq ['--format','pretty','featuressync_imap_mailbox.feature:16:22']
+          expect(loader.args_from('default')).to eq ['--format','pretty','featuressync_imap_mailbox.feature:16:22','--tags','not @jruby']
         end
       end
 

--- a/spec/cucumber/cli/profile_loader_spec.rb
+++ b/spec/cucumber/cli/profile_loader_spec.rb
@@ -42,6 +42,16 @@ default: <%= x %>
         given_cucumber_yml_defined_as yml
         expect(loader.args_from('default')).to eq ['--format','pretty','features/sync_imap_mailbox.feature:16:22']
       end
+
+      it 'correctly parses a profile that uses tag expressions' do
+        given_cucumber_yml_defined_as({'default' => '--format "pretty" features\sync_imap_mailbox.feature:16:22 --tags "not @jruby"'})
+        if(Cucumber::WINDOWS)
+          expect(loader.args_from('default')).to eq ['--format','pretty','features\sync_imap_mailbox.feature:16:22','--tags','not @jruby']
+        else
+          expect(loader.args_from('default')).to eq ['--format','pretty','featuressync_imap_mailbox.feature:16:22']
+        end
+      end
+
     end
   end
 end

--- a/spec/cucumber/cli/profile_loader_spec.rb
+++ b/spec/cucumber/cli/profile_loader_spec.rb
@@ -19,7 +19,7 @@ module Cucumber
       end
 
       it 'treats backslashes as literals in rerun.txt when on Windows (JRuby or MRI)' do
-        given_cucumber_yml_defined_as({'default' => '--format "pretty" features\sync_imap_mailbox.feature:16:22'})
+        given_cucumber_yml_defined_as('default' => '--format "pretty" features\sync_imap_mailbox.feature:16:22')
         if(Cucumber::WINDOWS)
           expect(loader.args_from('default')).to eq ['--format','pretty','features\sync_imap_mailbox.feature:16:22']
         else
@@ -28,7 +28,7 @@ module Cucumber
       end
 
       it 'treats forward slashes as literals' do
-        given_cucumber_yml_defined_as({'default' => '--format "ugly" features/sync_imap_mailbox.feature:16:22'})
+        given_cucumber_yml_defined_as('default' => '--format "ugly" features/sync_imap_mailbox.feature:16:22')
 
         expect(loader.args_from('default')).to eq ['--format','ugly','features/sync_imap_mailbox.feature:16:22']
       end
@@ -44,7 +44,7 @@ default: <%= x %>
       end
 
       it 'correctly parses a profile that uses tag expressions (with double quotes)' do
-        given_cucumber_yml_defined_as({'default' => '--format "pretty" features\sync_imap_mailbox.feature:16:22 --tags "not @jruby"'})
+        given_cucumber_yml_defined_as('default' => '--format "pretty" features\sync_imap_mailbox.feature:16:22 --tags "not @jruby"')
         if(Cucumber::WINDOWS)
           expect(loader.args_from('default')).to eq ['--format','pretty','features\sync_imap_mailbox.feature:16:22','--tags','not @jruby']
         else
@@ -53,7 +53,7 @@ default: <%= x %>
       end
 
       it 'correctly parses a profile that uses tag expressions (with single quotes)' do
-        given_cucumber_yml_defined_as({'default' => "--format 'pretty' features\\sync_imap_mailbox.feature:16:22 --tags 'not @jruby'"})
+        given_cucumber_yml_defined_as('default' => "--format 'pretty' features\\sync_imap_mailbox.feature:16:22 --tags 'not @jruby'")
         if(Cucumber::WINDOWS)
           expect(loader.args_from('default')).to eq ['--format','pretty','features\sync_imap_mailbox.feature:16:22','--tags','not @jruby']
         else


### PR DESCRIPTION
Fixed a profile parsing bug that was only affecting Windows.

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

A bug in the profile loader was discovered while working on #1116. This PR fixes that bug.

## Details

Bug fix + tests. Rather than try to re-implement the parsing being done by Shellwords, I simply _temporarily_ adjusted the input data so that Shellwords could handle it as usual.
 
## Motivation and Context

The problem was discovered during #1116 but it was decided to handle it separately rather than making it a blocking problem on that PR.

## How Has This Been Tested?

New spec added for the profile loader.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
