### PR TITLE
RuboCop setting: add name of failed cop rule; URL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,13 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
+  # Cop names are not displayed in offense messages by default. Change behavior
+  # by overriding DisplayCopNames, or by giving the `-D/--display-cop-names`
+  # option.
+  DisplayCopNames: true
+  # Style guide URLs are not displayed in offense messages by default. Change
+  # behavior by overriding `DisplayStyleGuide`, or by giving the
+  # `-S/--display-style-guide` option.
+  DisplayStyleGuide: true
   Exclude:
     - 'tmp/**/*'


### PR DESCRIPTION
## Summary

This PR enables displaying RuboCop **cop names** and **styleguide URLs** for each failed cop.

## Details

To help people trying to fix or disable cop warnings, the name and URL helps.

We are currently on RuboCop 0.40.0, and [these are that version's configuration option defaults](https://github.com/bbatsov/rubocop/blob/v0.40.0/config/default.yml).

## Motivation and Context

I saw someone struggling with cop output. The tool ought to present all it knows.

## Screenshot

Here is a picture with some failures that I added to one file. 

In practice, this is what it looks like **with extra information:**

<img width="1478" alt="screenshot 2017-06-27 11 11 00" src="https://user-images.githubusercontent.com/211/27579906-64b35fde-5b29-11e7-88c1-bb9dc00cbea5.png">

Contrast this with the before **without extra information:**

<img width="875" alt="screenshot 2017-06-27 11 18 18" src="https://user-images.githubusercontent.com/211/27580276-66de340e-5b2a-11e7-94bc-be1f5efd4954.png">

