### PR TITLE
Frozen-string-literal fixes in eval'd code.

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,9 +1,9 @@
 <%
 cucumber_pro_opts = ENV['ENABLE_CUCUMBER_PRO'] ? "--format Cucumber::Pro --out /dev/null" : ""
-std_opts = "--format progress features -r features --strict #{cucumber_pro_opts}"
+std_opts = "--format progress features -r features --strict #{cucumber_pro_opts}".dup
 std_opts << " --tags ~@wip-jruby" if defined?(JRUBY_VERSION)
 
-wip_opts = "--color -r features"
+wip_opts = "--color -r features".dup
 wip_opts << " --tags @wip" if !defined?(JRUBY_VERSION)
 wip_opts << " --tags @wip,@wip-jruby" if defined?(JRUBY_VERSION)
 %>

--- a/lib/cucumber/term/ansicolor.rb
+++ b/lib/cucumber/term/ansicolor.rb
@@ -56,7 +56,7 @@ module Cucumber
       ATTRIBUTES.each do |c, v|
         eval %Q{
             def #{c}(string = nil)
-              result = ''
+              result = String.new
               result << "\e[#{v}m" if Cucumber::Term::ANSIColor.coloring?
               if block_given?
                 result << yield


### PR DESCRIPTION
## Summary

The pragma comment doesn't pick up these uses because the code is eval'd on the fly.

Related:
* https://github.com/dblock/syntax/pull/6
* https://github.com/cucumber/aruba/pull/436
* https://github.com/rspec/rspec-core/pull/2437

## How Has This Been Tested?

I've managed to get the test suite passing locally with the `--enable-frozen-string-literal` `RUBYOPT` flag, using my own copy of Aruba plus some related upgrading changes because Cucumber's been locked to an old Aruba version for quite some time. I've also used the rspec-core test suite (which makes use of Cucumber) and my local cucumber copy to confirm their test suite is green as well.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Given the pragma comments, I'm presuming being frozen-string-literal-friendly is a goal of Cucumber, hence pretty confident in labelling this a bug fix :)

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

None of the checklist items here apply.