### PR TITLE
Emulate Cucumber-JS's new i18n CLI options

### DIFF
--- a/features/docs/cli/i18n.feature
+++ b/features/docs/cli/i18n.feature
@@ -1,5 +1,5 @@
 @needs-many-fonts
-Feature: Language help
+Feature: i18n
 
   It's possible to ask cucumber which keywords are used for any
   particular language by running:

--- a/features/docs/cli/i18n.feature
+++ b/features/docs/cli/i18n.feature
@@ -4,14 +4,14 @@ Feature: i18n
   It's possible to ask cucumber which keywords are used for any
   particular language by running:
 
-  `cucumber --i18n <language code> help`
+  `cucumber --i18n-keywords <LANG>`
 
   This will print a table showing all the different words we use for
   that language, to allow you to easily write features in any language
   you choose.
 
   Scenario: Get help for Portuguese language
-    When I run `cucumber --i18n pt help`
+    When I run `cucumber --i18n-keywords pt`
     Then it should pass with:
       """
         | feature          | "Funcionalidade", "Característica", "Caracteristica"                                         |
@@ -33,10 +33,10 @@ Feature: i18n
       """
 
   Scenario: List languages
-    When I run `cucumber --i18n help`
+    When I run `cucumber --i18n-languages`
     Then cucumber lists all the supported languages
 
   Scenario: Seek help for invalid language
-    When I run `cucumber --i18n foo`
+    When I run `cucumber --i18n-keywords foo`
     Then the output includes the message "Invalid language 'foo'"
     And cucumber lists all the supported languages

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -82,7 +82,7 @@ module Cucumber
         @options[key] = value
       end
 
-      def parse!(args)
+      def parse!(args) # rubocop:disable Metrics/AbcSize
         @args = args
         @expanded_args = @args.dup
 

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -341,11 +341,8 @@ TEXT
       def set_language(lang)
         require 'gherkin/dialect'
 
-        if ::Gherkin::DIALECTS.keys.include? lang
-          list_keywords_and_exit(lang)
-        else
-          indicate_invalid_language_and_exit(lang)
-        end
+        return indicate_invalid_language_and_exit(lang) unless ::Gherkin::DIALECTS.keys.include? lang
+        list_keywords_and_exit(lang)
       end
 
       def disable_profile_loading

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -48,7 +48,7 @@ module Cucumber
       NO_PROFILE_LONG_FLAG = '--no-profile'
       FAIL_FAST_FLAG = '--fail-fast'
       RETRY_FLAG = '--retry'
-      OPTIONS_WITH_ARGS = ['-r', '--require', '--i18n', '-f', '--format', '-o', '--out',
+      OPTIONS_WITH_ARGS = ['-r', '--require', '--i18n-keywords', '-f', '--format', '-o', '--out',
                                   '-t', '--tags', '-n', '--name', '-e', '--exclude',
                                   PROFILE_SHORT_FLAG, PROFILE_LONG_FLAG, RETRY_FLAG,
                                   '-l', '--lines', '--port',
@@ -97,7 +97,8 @@ module Cucumber
           end
 
           opts.on("#{RETRY_FLAG} ATTEMPTS", *retry_msg) {|v| set_option :retry, v.to_i }
-          opts.on('--i18n LANG', *i18n_msg) {|lang| set_language lang }
+          opts.on('--i18n-languages', *i18n_languages_msg) { list_languages_and_exit }
+          opts.on('--i18n-keywords LANG', *i18n_keywords_msg) {|lang| set_language lang }
           opts.on(FAIL_FAST_FLAG, 'Exit immediately following the first failing scenario') { set_option :fail_fast }
           opts.on('-f FORMAT', '--format FORMAT', *format_msg, *FORMAT_HELP) do |v|
             add_option :formats, [*parse_formats(v), @out_stream]
@@ -201,7 +202,13 @@ TEXT
         [ 'How to format features (Default: pretty). Available formats:' ]
       end
 
-      def i18n_msg
+      def i18n_languages_msg
+        [
+          'List all available languages'
+        ]
+      end
+
+      def i18n_keywords_msg
         [
           'List keywords for in a particular language',
           %{Run with "--i18n help" to see all languages}
@@ -334,12 +341,10 @@ TEXT
       def set_language(lang)
         require 'gherkin/dialect'
 
-        if lang == 'help'
-          list_languages_and_exit
-        elsif !::Gherkin::DIALECTS.keys.include? lang
-          indicate_invalid_language_and_exit(lang)
-        else
+        if ::Gherkin::DIALECTS.keys.include? lang
           list_keywords_and_exit(lang)
+        else
+          indicate_invalid_language_and_exit(lang)
         end
       end
 

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -56,38 +56,38 @@ module Cucumber
           end
         end
 
-        context '--i18n' do
-          context "with LANG specified as 'help'" do
-            include RSpec::WorkInProgress
+        context '--i18n-languages' do
+          include RSpec::WorkInProgress
 
-            it 'lists all known languages' do
-              when_parsing '--i18n help' do
-                expect(Kernel).to receive(:exit)
-              end
-            end
-
-            it 'exits the program' do
-              when_parsing('--i18n help') { expect(Kernel).to receive(:exit) }
+          it 'lists all known languages' do
+            when_parsing '--i18n-languages' do
+              expect(Kernel).to receive(:exit)
             end
           end
 
+          it 'exits the program' do
+            when_parsing('--i18n-languages') { expect(Kernel).to receive(:exit) }
+          end
+        end
+
+        context '--i18n-keywords' do
           context 'with invalid LANG' do
             include RSpec::WorkInProgress
 
             it 'exits' do
-              when_parsing '--i18n foo' do
+              when_parsing '--i18n-keywords foo' do
                 expect(Kernel).to receive(:exit)
               end
             end
 
             it 'says the language was invalid' do
-              after_parsing '--i18n foo' do
+              after_parsing '--i18n-keywords foo' do
                 expect(@output_stream.string).to include("Invalid language 'foo'. Available languages are:")
               end
             end
 
             it 'displays the language table' do
-              after_parsing '--i18n foo' do
+              after_parsing '--i18n-keywords foo' do
                 ::Gherkin::DIALECTS.keys.map do |key|
                   expect(@output_stream.string).to include(key.to_s);
                 end

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -60,8 +60,10 @@ module Cucumber
           include RSpec::WorkInProgress
 
           it 'lists all known languages' do
-            when_parsing '--i18n-languages' do
-              expect(Kernel).to receive(:exit)
+            after_parsing '--i18n-languages' do
+              ::Gherkin::DIALECTS.keys.map do |key|
+                expect(@output_stream.string).to include(key.to_s);
+              end
             end
           end
 


### PR DESCRIPTION
## Summary

Emulates Cucumber-JS's new i18n CLI options.
Fixes https://github.com/cucumber/cucumber-ruby/issues/1137 and fixes a test.

## Details

See issue https://github.com/cucumber/cucumber-ruby/issues/1137

## Motivation and Context

Keeping things consistent between implementations.

## How Has This Been Tested?

Existing tests have been modified to meet the new requirements.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've added tests for my code
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Please review @mattwynne @tooky 