### PR TITLE
Add script to update history.md

### DIFF
--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -29,6 +29,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rubocop', '~> 0.40.0'
 
+  # For maintainer scripts
+  s.add_development_dependency 'octokit'
+
   # For Documentation:
   s.add_development_dependency 'bcat', '~> 0.6.2'
   s.add_development_dependency 'kramdown', '~> 0.14'

--- a/scripts/update-history
+++ b/scripts/update-history
@@ -1,0 +1,84 @@
+#!/usr/bin/env ruby
+require 'octokit'
+
+class PullRequest
+  attr_reader :gh, :num
+
+  def initialize(gh, num)
+    @gh = gh
+    @num = num
+  end
+
+  def entry
+    pr = gh.pull_request('cucumber/cucumber-ruby', num)
+    entry = "#{pr['title']} ([##{num}(#{pr['url']}) @#{pr['user']['login']})"
+  end
+
+  def labels
+    gh.labels_for_issue('cucumber/cucumber-ruby', num).map { |label| label['name'] }
+  end
+
+  def type_label
+    types = labels.select { |label| label =~ /^type: / }
+    if (types.length < 1)
+      raise("This pull request does not have a 'type' label on it. Please add one.")
+    end
+
+    if (types.length > 1)
+      raise("This pull request has more than one 'type' label on it. Please choose just one.")
+    end
+
+    types.first
+  end
+end
+
+class HistoryFile
+  def self.open(path, &block)
+    full_path = File.expand_path(File.dirname(__FILE__) + "/" + path + "/History.md") 
+    history = self.new(File.read(full_path))
+    history.instance_exec(&block)
+    File.write(full_path, history.body)
+  end
+
+  attr_reader :lines
+
+  def initialize(body)
+    @lines = body.lines
+  end
+
+  def insert(label, entry)
+    section_index = lines.index { |line| line.strip == heading_for(label) }
+    unless section_index
+      raise("Unable to find matching heading in History.md for '#{label}' (#{heading_for(label)})")
+    end
+    lines.insert(section_index + 2, "* #{entry}\n")
+  end
+
+  def heading_for(label)
+    text = {
+      "type: new feature" => "New Features",
+      "type: bug" => "Bugfixes",
+      "type: refactoring / developer experience" => "Refactoring / Developer Experience"
+    }.fetch(label)
+    "### #{text}"
+  end
+
+  def body
+    lines.join
+  end
+end
+
+begin
+  token = ENV['GITHUB_TOKEN'] || raise("You need to set GITHUB_TOKEN")
+  num = (ARGV[0] || raise("syntax: #{$0} <PULL-REQUEST-NUMBER>")).to_i
+
+  gh = Octokit::Client.new(access_token: token)
+  pr = PullRequest.new(gh, num)
+
+  HistoryFile.open('..') do
+    insert(pr.type_label, pr.entry)
+  end
+rescue StandardError => error
+  $stderr.puts error.message
+  exit 1
+end


### PR DESCRIPTION
As discussed at CukenFest, this will avoid manual error when updating
history. It still needs to be run manually, and requires that one of the
`type: *` labels has been applied to the PR.

It's still going to save me time!