### PR TITLE
Update cucumber yaml to use new tag syntax

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -9,11 +9,11 @@ wip_opts = "--color -r features"
 wip_opts << " --tags @wip" if !defined?(JRUBY_VERSION)
 wip_opts << " --tags @wip,@wip-jruby" if defined?(JRUBY_VERSION)
 %>
-default:     <%= std_opts %> --tags ~@jruby
-jruby:       <%= std_opts %> --tags ~@wire
-jruby_win:   <%= std_opts %> --tags ~@wire CUCUMBER_FORWARD_SLASH_PATHS=true
-windows_mri: <%= std_opts %> --tags ~@jruby --tags ~@wire --tags ~@needs-many-fonts --tags ~@todo-windows CUCUMBER_FORWARD_SLASH_PATHS=true
-ruby:        <%= std_opts %> --tags ~@todo-windows --tags ~@jruby
+default:     <%= std_opts %> --tags "not @jruby"
+jruby:       <%= std_opts %> --tags "not @wire"
+jruby_win:   <%= std_opts %> --tags "not @wire" CUCUMBER_FORWARD_SLASH_PATHS=true
+windows_mri: <%= std_opts %> --tags "not @jruby" --tags "not @wire" --tags "not @needs-many-fonts" --tags "not @todo-windows" CUCUMBER_FORWARD_SLASH_PATHS=true
+ruby:        <%= std_opts %> --tags "not @todo-windows" --tags "not @jruby"
 wip:         --wip <%= wip_opts %> features <%= cucumber_pro_opts %>
 none:        --format pretty --format Cucumber::Pro --out /dev/null
-rerun:       <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip-new-core <%= cucumber_pro_opts %>
+rerun:       <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags "not @wip-new-core" <%= cucumber_pro_opts %>


### PR DESCRIPTION
This PR updates the Cucumber YAML file to use the new tag syntax, such as `"not @wire"` instead of the old syntax `~@wire`.

## Motivation and Context

This change will remove deprecation warnings that are currently appearing in CI.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
