### PR TITLE
Fix Rubocop violations in the legacy API adapter

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,7 +9,6 @@
 # Offense count: 8
 Lint/AmbiguousOperator:
   Exclude:
-    - 'lib/cucumber/formatter/legacy_api/adapter.rb'
     - 'lib/cucumber/formatter/legacy_api/ast.rb'
     - 'lib/cucumber/multiline_argument/data_table.rb'
     - 'lib/cucumber/running_test_case.rb'

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -287,7 +287,7 @@ module Cucumber
           end
 
           def puts(messages)
-            @delayed_messages.push *messages
+            @delayed_messages.push(*messages)
           end
 
           def embed(src, mime_type, label)
@@ -313,7 +313,7 @@ module Cucumber
           private :before_hook_results
 
           def any_test_steps_failed?
-            @test_step_results.any? &:failed?
+            @test_step_results.any?(&:failed?)
           end
 
           def switch_step_container(source = current_test_step_source)


### PR DESCRIPTION
This PR fixes the Rubocop violations in the legacy API adapter and reconfigures Rubocop not to ignore this file.

## Summary

Removed the legacy API adapter file from the .rubocop-todo.yml file and then fixes the Rubocop violations that occur in that file.

## Details

There were two method calls where the args needed to be enclosed in parentheses; I added parens to both.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
