### PR TITLE
Fix Rubocop violations in Legacy API AST file

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,7 +10,6 @@
 Lint/AmbiguousOperator:
   Exclude:
     - 'lib/cucumber/formatter/legacy_api/adapter.rb'
-    - 'lib/cucumber/formatter/legacy_api/ast.rb'
     - 'lib/cucumber/multiline_argument/data_table.rb'
     - 'lib/cucumber/running_test_case.rb'
     - 'spec/cucumber/formatter/legacy_api/adapter_spec.rb'

--- a/lib/cucumber/formatter/legacy_api/ast.rb
+++ b/lib/cucumber/formatter/legacy_api/ast.rb
@@ -110,11 +110,11 @@ module Cucumber
             Ast::Comments.new(step.comments).accept(formatter)
             messages.each { |message| formatter.puts(message) }
             embeddings.each { |embedding| embedding.send_to_formatter(formatter) }
-            formatter.before_step_result *step_result_attributes
+            formatter.before_step_result(*step_result_attributes)
             print_step_name(formatter)
             Ast::MultilineArg.for(multiline_arg).accept(formatter)
             print_exception(formatter)
-            formatter.after_step_result *step_result_attributes
+            formatter.after_step_result(*step_result_attributes)
             formatter.after_step(self)
           end
 


### PR DESCRIPTION
## Summary

This PR fixes Rubocop violations in the `legacy_api/ast.rb` file and configures Rubocop not to ignore this file.

## Details

Removed `legacy_api/ast.rb` from the .rubocop-todo.yml file. Fixed violations in the file by enclosing arguments to two method calls in parens.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
