### PR TITLE
Fix AmbiguousOperator violations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,10 +10,7 @@
 Lint/AmbiguousOperator:
   Exclude:
     - 'lib/cucumber/formatter/legacy_api/adapter.rb'
-    - 'lib/cucumber/multiline_argument/data_table.rb'
-    - 'lib/cucumber/running_test_case.rb'
-    - 'spec/cucumber/formatter/legacy_api/adapter_spec.rb'
-    - 'spec/cucumber/formatter/spec_helper.rb'
+    - 'lib/cucumber/formatter/legacy_api/ast.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -205,7 +205,7 @@ module Cucumber
 
       def rows
         hashes.map do |hash|
-          hash.values_at *headers
+          hash.values_at(*headers)
         end
       end
 

--- a/lib/cucumber/running_test_case.rb
+++ b/lib/cucumber/running_test_case.rb
@@ -81,7 +81,7 @@ module Cucumber
       end
 
       def source_tag_names
-        tags.map &:name
+        tags.map(&:name)
       end
 
       def outline?

--- a/spec/cucumber/formatter/legacy_api/adapter_spec.rb
+++ b/spec/cucumber/formatter/legacy_api/adapter_spec.rb
@@ -28,7 +28,7 @@ module Cucumber
         end
 
         def activate(test_step)
-          test_step.with_action &@block
+          test_step.with_action(&@block)
         end
       end
 

--- a/spec/cucumber/formatter/spec_helper.rb
+++ b/spec/cucumber/formatter/spec_helper.rb
@@ -72,9 +72,8 @@ module Cucumber
 
         return unless step_defs
         dsl = Object.new
-
-        dsl.extend RbSupport::RbDsl
-        dsl.instance_exec(&step_defs)
+        dsl.extend Glue::Dsl
+        dsl.instance_exec &step_defs
       end
 
       def options

--- a/spec/cucumber/formatter/spec_helper.rb
+++ b/spec/cucumber/formatter/spec_helper.rb
@@ -72,8 +72,9 @@ module Cucumber
 
         return unless step_defs
         dsl = Object.new
-        dsl.extend Glue::Dsl
-        dsl.instance_exec &step_defs
+
+        dsl.extend RbSupport::RbDsl
+        dsl.instance_exec(&step_defs)
       end
 
       def options


### PR DESCRIPTION
## Summary

This PR fixes the AmbiguousOperator Rubocop violations not already resolved in existing PRs.

## Details

Added parens to method calls where required and configured Rubocop not to ignore the files in question.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
