### PR TITLE
Fix AssignmentInCondition violations in Rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,16 +16,6 @@ Lint/AmbiguousOperator:
     - 'spec/cucumber/formatter/legacy_api/adapter_spec.rb'
     - 'spec/cucumber/formatter/spec_helper.rb'
 
-# Offense count: 6
-# Configuration parameters: AllowSafeAssignment.
-Lint/AssignmentInCondition:
-  Exclude:
-    - 'features/lib/step_definitions/wire_steps.rb'
-    - 'features/lib/support/fake_wire_server.rb'
-    - 'lib/cucumber/glue/transform.rb'
-    - 'lib/cucumber/runtime/support_code.rb'
-    - 'spec/cucumber/formatter/spec_helper.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Lint/DeprecatedClassMethods:

--- a/features/lib/step_definitions/wire_steps.rb
+++ b/features/lib/step_definitions/wire_steps.rb
@@ -34,8 +34,11 @@ module WireHelper
     }
     writer.close
     Thread.new do
-      while message = reader.gets
+      message = reader.gets
+
+      while message
         @messages_received << message.strip
+        message = reader.gets
       end
     end
     at_exit { stop_wire_server }

--- a/features/lib/support/fake_wire_server.rb
+++ b/features/lib/support/fake_wire_server.rb
@@ -43,15 +43,20 @@ class FakeWireServer
     end
 
     def start
-      while message = @socket.gets
+      message = @socket.gets
+
+      while message
         handle(message)
+        message = @socket.gets
       end
     end
 
     private
 
     def handle(data)
-      if protocol_entry = response_to(data.strip)
+      protocol_entry = response_to(data.strip)
+
+      if protocol_entry
         sleep delay(data)
         @on_message.call(MultiJson.load(protocol_entry['request'])[0])
         send_response(protocol_entry['response'])

--- a/lib/cucumber/glue/transform.rb
+++ b/lib/cucumber/glue/transform.rb
@@ -28,7 +28,9 @@ module Cucumber
       end
 
       def invoke(arg)
-        return unless matched = match(arg)
+        matched = match(arg)
+
+        return unless matched
         args = matched.captures.empty? ? [arg] : matched.captures
         cucumber_instance_exec_in(@registry.current_world, true, @regexp.inspect, *args, &@proc)
       end

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -30,7 +30,9 @@ module Cucumber
         end
 
         def multiline_arg(step, location)
-          if argument = step[:argument]
+          argument = step[:argument]
+
+          if argument
             if argument[:type] == :DocString
               MultilineArgument.doc_string(argument[:content], argument[:content_type], location)
             else

--- a/spec/cucumber/formatter/spec_helper.rb
+++ b/spec/cucumber/formatter/spec_helper.rb
@@ -71,7 +71,6 @@ module Cucumber
         step_defs = self.class.step_defs
 
         return unless step_defs
-        runtime.support_code.ruby
         dsl = Object.new
         dsl.extend Glue::Dsl
         dsl.instance_exec &step_defs

--- a/spec/cucumber/formatter/spec_helper.rb
+++ b/spec/cucumber/formatter/spec_helper.rb
@@ -68,8 +68,10 @@ module Cucumber
       end
 
       def define_steps
-        return unless step_defs = self.class.step_defs
-        runtime.support_code.registry
+        step_defs = self.class.step_defs
+
+        return unless step_defs
+        runtime.support_code.ruby
         dsl = Object.new
         dsl.extend Glue::Dsl
         dsl.instance_exec &step_defs


### PR DESCRIPTION
## Summary

This PR fixes the AssignmentInCondition violations currently being ignored by Rubocop and configures Rubocop not to ignore these files.

## Details

Separated variable assignments from conditionals/loop conditions.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
