### PR TITLE
Rake task fix_cr_lf: exclude iso-8859-1 files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=lf
+
+# Explicitly declare text files to always be normalized and converted
+# to native line endings on checkout.
+*.css text eol=lf
+*.feature text eol=lf
+*.gemspec text eol=lf
+*.js text eol=lf
+*.md text eol=lf
+*.rake text eol=lf
+*.rb text eol=lf
+*.sass text eol=lf
+*.tcl text eol=lf
+*.textile text eol=lf
+*.txt text eol=lf
+*.xml text eol=lf
+*.yml text eol=lf
+Gemfile text eol=lf
+LICENSE text eol=lf
+Rakefile text eol=lf
+.cucumberproignore text eol=lf
+.gitignore text eol=lf
+.rspec text eol=lf
+.ruby-gemset text eol=lf
+.yardopts text eol=lf
+scripts/* text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+# These patterns are here as an example; we have 0 of these.
+*.png binary
+*.jpg binary

--- a/gem_tasks/fix_cr_lf.rake
+++ b/gem_tasks/fix_cr_lf.rake
@@ -1,11 +1,22 @@
 # frozen_string_literal: true
+
+require 'pathname'
+
 desc 'Make all files use UNIX (\n) line endings'
 task :fix_cr_lf do
-  files = FileList['**/*']
-  files.each do |f|
-    next if File.directory?(f) || f =~ /dos/
-    s = IO.read(f)
-    s.gsub!(/\r?\n/, "\n")
-    File.open(f, 'w') { |io| io.write(s) }
+  iso_8859_1_files = FileList.new(
+    'features/docs/iso-8859-1.feature',
+    'features/lib/step_definitions/iso-8859-1_steps.rb'
+  )
+
+  utf8_files = FileList.new('**/*') do |fl|
+    fl.exclude { |f| File.directory?(f) }
+  end
+
+  paths = (utf8_files - iso_8859_1_files).map { |f| Pathname(f) }
+
+  paths.each do |path|
+    content = path.read.gsub(/\r?\n/, "\n")
+    path.write(content)
   end
 end


### PR DESCRIPTION
This PR changes the `fix_cr_lf` Rake task: it now fixes CRLF **on the right files**.

The previous exclusion rules were for files with `dos` in the filename – these files are no longer a part of the codebase.

Also: tell Git how to clone files using the [Dealing with line endings](https://help.github.com/articles/dealing-with-line-endings/) documentation that GitHub wrote.

