### PR TITLE
Rake task: list contributors encoding workaround

### DIFF
--- a/gem_tasks/contributors.rake
+++ b/gem_tasks/contributors.rake
@@ -1,10 +1,13 @@
 # encoding: utf-8
 # frozen_string_literal: true
+
 desc 'List contributors'
 task :contributors do
-  contributors = `git log --pretty=short --no-merges | git shortlog -ne | egrep -ve '^ +' | egrep -ve '^$'`.split("\n")
-  puts contributors
-  puts "Total: #{contributors.length}"
+  IO.popen("git log --pretty=short --no-merges | git shortlog -ne | egrep -ve '^ +' | egrep -ve '^$'") do |f|
+    contributors = f.readlines
+    puts contributors
+    puts "Total: #{contributors.length}"
+  end
 end
 
 task :codeswarm do


### PR DESCRIPTION
## Summary

This PR works around an encoding issue in `rake contributors`.

Without this workaround, the output is:

```
rake aborted!
ArgumentError: invalid byte sequence in UTF-8
gem_tasks/contributors.rake:6:in `split'
gem_tasks/contributors.rake:6:in `block in <top (required)>'
```

## Details

The solution propsed (to allow the Rake task to run without error) is to run the `git` command pipeline in a `IO.popen`, which is also supported on Windows.


Wrong fixes tried:

- I first used the same `iconv` transform from latin1 to utf8 used in the same file to transform the Git log output with the contributor names. That's quite bad since many contributors' names have characters which would be mangled by that transform.
- The other wrong fix is to run the command using Open3.popen3. Non-Windows.

## Motivation and Context

The change allows the `rake contributors` output to be presented.

## How Has This Been Tested?

On my laptop only.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
