### PR TITLE
List all not ok scenarios in the summary

### DIFF
--- a/features/docs/cli/dry_run.feature
+++ b/features/docs/cli/dry_run.feature
@@ -64,6 +64,9 @@ Feature: Dry Run
             Undefined step: "this step is undefined" (Cucumber::Undefined)
             features/test.feature:3:in `Given this step is undefined'
 
+      Undefined Scenarios:
+      cucumber features/test.feature:2 # Scenario: 
+
       1 scenario (1 undefined)
       1 step (1 undefined)
 

--- a/features/docs/cli/strict_mode.feature
+++ b/features/docs/cli/strict_mode.feature
@@ -28,6 +28,9 @@ Feature: Strict mode
             Undefined step: "this step passes" (Cucumber::Undefined)
             features/missing.feature:3:in `Given this step passes'
 
+      Undefined Scenarios:
+      cucumber features/missing.feature:2
+
       1 scenario (1 undefined)
       1 step (1 undefined)
       """
@@ -44,6 +47,9 @@ Feature: Strict mode
             TODO (Cucumber::Pending)
             ./features/step_definitions/steps.rb:3:in `/^this step is pending$/'
             features/pending.feature:3:in `Given this step is pending'
+
+      Pending Scenarios:
+      cucumber features/pending.feature:2
 
       1 scenario (1 pending)
       1 step (1 pending)

--- a/lib/cucumber/formatter/console_issues.rb
+++ b/lib/cucumber/formatter/console_issues.rb
@@ -6,27 +6,41 @@ module Cucumber
       include Console
 
       def initialize(config)
-        @failures = []
+        @issues = Hash.new { |h, k| h[k] = [] }
         @config = config
         @config.on_event(:test_case_finished) do |event|
-          @failures << event.test_case if event.result.failed?
+          @issues[event.result.to_sym] << event.test_case unless event.result.ok?(@config.strict?)
         end
       end
 
       def to_s
-        return if @failures.empty?
-        result = [ format_string('Failing Scenarios:', :failed) ] + @failures.map { |failure|
-          source = @config.source? ? format_string(" # #{failure.keyword}: #{failure.name}", :comment) : ''
-          format_string("cucumber #{profiles_string}" + failure.location, :failed) + source
-        }
-        result.join("\n")
+        return if @issues.empty?
+        result = Core::Test::Result::TYPES.map { |type| scenario_listing(type, @issues[type]) }
+        result.flatten.join("\n")
       end
 
       def any?
-        @failures.any?
+        @issues.any?
       end
 
       private
+
+      def scenario_listing(type, test_cases)
+        return [] if test_cases.empty?
+        [ format_string("#{type_heading(type)} Scenarios:", type) ] + test_cases.map { |test_case|
+          source = @config.source? ? format_string(" # #{test_case.keyword}: #{test_case.name}", :comment) : ''
+          format_string("cucumber #{profiles_string}" + test_case.location, type) + source
+        }
+      end
+
+      def type_heading(type)
+        case type
+        when :failed
+          'Failing'
+        else
+          type.to_s.slice(0, 1).capitalize + type.to_s.slice(1..-1)
+        end
+      end
 
       def profiles_string
         return if @config.custom_profiles.empty?

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -229,8 +229,7 @@ module Cucumber
       if @configuration.wip?
         summary_report.test_cases.total_passed > 0
       else
-        summary_report.test_cases.total_failed > 0 || summary_report.test_steps.total_failed > 0 ||
-          (@configuration.strict? && (summary_report.test_steps.total_undefined > 0 || summary_report.test_steps.total_pending > 0))
+        !summary_report.ok?(@configuration.strict?)
       end
     end
     public :failure?


### PR DESCRIPTION
## Summary

List all not ok scenarios in the summary.

## Details

Currently only failed scenarios are listed in the summary, but also scenarios of other result types can force the exit code to be non-zero (currently `pending` and `undefined` scenarios - in strict mode). Therefore list the scenarios of all result type the each would have made the exit code non-zero.

Also reduce the duplication between Cucumber-Ruby and Cucumber-Ruby-Core by using
* `Cucumber::Core::Report::Summary#ok?` to calculate the exit code
* `Cucumber::Core::Test::Result::TYPES` and `Cucumber::Core::Report::Summary` in `ConsoleCounts`

These changes also paves the way for the introduction of [`ambiguous` results](https://github.com/cucumber/cucumber-ruby/pull/1132) and [`flaky` results](https://github.com/cucumber/cucumber-ruby/pull/1121#issuecomment-314385987).

Depends on https://github.com/cucumber/cucumber-ruby-core/pull/140.

## How Has This Been Tested?

Existing feature files has been modified to verify the changed listing of scenarios in the summary.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
