### PR TITLE
Detect and list flaky scenarios in the list of not ok scenarios

### DIFF
--- a/features/docs/cli/retry_failing_tests.feature
+++ b/features/docs/cli/retry_failing_tests.feature
@@ -14,14 +14,14 @@ Feature: Retry failing tests
     Given a scenario "Fails-once" that fails once, then passes
     And a scenario "Fails-twice" that fails twice, then passes
     And a scenario "Solid" that passes
-    And a scenario "Fails-forever" that fails
 
   @todo-windows
   Scenario: Retry once, so Fails-once starts to pass
+    Given a scenario "Fails-forever" that fails
     When I run `cucumber -q --retry 1 --format summary`
     Then it should fail with:
       """
-      7 scenarios (5 failed, 2 passed)
+      4 scenarios (2 failed, 1 flaky, 1 passed)
       """
     And it should fail with:
       """
@@ -43,10 +43,11 @@ Feature: Retry failing tests
 
   @todo-windows
   Scenario: Retry twice, so Fails-twice starts to pass too
+    Given a scenario "Fails-forever" that fails
     When I run `cucumber -q --retry 2 --format summary`
     Then it should fail with:
       """
-      9 scenarios (6 failed, 3 passed)
+      4 scenarios (1 failed, 2 flaky, 1 passed)
       """
     And it should fail with:
       """
@@ -66,4 +67,26 @@ Feature: Retry failing tests
         Fails-twice ✗
         Fails-twice ✗
         Fails-twice ✓
+      """
+
+  @todo-windows
+  Scenario: Flaky scenarios gives exit code zero in non-strict mode
+    When I run `cucumber -q --retry 2 --format summary`
+    Then it should pass with:
+      """
+
+
+      3 scenarios (2 flaky, 1 passed)
+      """
+
+  @todo-windows
+  Scenario: Flaky scenarios gives non-zero exit code in strict mode
+    When I run `cucumber -q --retry 2 --format summary --strict`
+    Then it should fail with:
+      """
+      Flaky Scenarios:
+      cucumber features/fails_once.feature:2
+      cucumber features/fails_twice.feature:2
+
+      3 scenarios (2 flaky, 1 passed)
       """

--- a/lib/cucumber/formatter/ansicolor.rb
+++ b/lib/cucumber/formatter/ansicolor.rb
@@ -60,6 +60,7 @@ module Cucumber
       end.merge({
         'undefined' => 'yellow',
         'pending'   => 'yellow',
+        'flaky'     => 'yellow',
         'failed'    => 'red',
         'passed'    => 'green',
         'outline'   => 'cyan',


### PR DESCRIPTION

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Detect and list flaky scenarios in the list of not ok scenarios

## Details

* Detect and list flaky scenarios in the list of not ok scenarios
* Add a colour definition for `flaky` results.
* Also updated the retry feature for the separation of flaky scenarios to a separate category in the scenario counts.

Depends on https://github.com/cucumber/cucumber-ruby-core/pull/141.

## Motivation and Context

This is needed to complete the introduction of the `flaky` result type in https://github.com/cucumber/cucumber-ruby-core/pull/141.

## How Has This Been Tested?

The retry feature has been updated to verify this behaviour.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
