### PR TITLE
Improve relativization of paths inside backtrace

### DIFF
--- a/lib/cucumber/formatter/backtrace_filter.rb
+++ b/lib/cucumber/formatter/backtrace_filter.rb
@@ -31,7 +31,7 @@ module Cucumber
       def exception
         return @exception if ::Cucumber.use_full_backtrace
 
-        pwd_pattern = /#{::Regexp.escape(::Dir.pwd)}\//m
+        pwd_pattern = /^#{::Regexp.escape(::Dir.pwd)}\//m
         backtrace = @exception.backtrace.map { |line| line.gsub(pwd_pattern, './') }
 
         filtered = (backtrace || []).reject do |line|


### PR DESCRIPTION
## Summary

Improve relativization of paths inside backtrace

## Details

The current regex triggers false positive replacements.
For example, when cucumber filters backtrace for a rails
application installed in /app, then it removes an extra /app
from paths. 

In other words, the following backtrace line `/app/app/controllers/books_controller.rb:3`
becomes this `../controllers/books_controller.rb:3`.

## How Has This Been Tested?

I've added a spec to cover the correct behavior and catch the edge case I'm trying to fix. Also I am using this version on my project and backtraces look good now.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
