### PR TITLE
Use a special result type for ambiguous steps and scenarios

### DIFF
--- a/features/docs/defining_steps/ambiguous_steps.feature
+++ b/features/docs/defining_steps/ambiguous_steps.feature
@@ -40,14 +40,14 @@ Feature: Ambiguous Steps
           features/step_definitions.rb:5:in `/^an ambiguous step$/'
           
           You can run again with --guess to make Cucumber be more smart about it
-           (Cucumber::Ambiguous)
+           (Cucumber::Core::Test::Result::Ambiguous)
           features/ambiguous.feature:5:in `Then an ambiguous step'
 
-    Failing Scenarios:
+    Ambiguous Scenarios:
     cucumber features/ambiguous.feature:3 # Scenario: 
 
-    1 scenario (1 failed)
-    2 steps (1 failed, 1 passed)
+    1 scenario (1 ambiguous)
+    2 steps (1 ambiguous, 1 passed)
     0m0.012s
 
     """

--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -148,7 +148,7 @@ module Cucumber
     end
 
     def activate(test_step)
-      return test_step.with_action { raise @error }
+      return test_step.with_action { raise Core::Test::Result::Ambiguous.new(@error.message) }
     end
 
   end


### PR DESCRIPTION
## Summary

Use a special result type for ambiguous steps and scenarios.

## Details

Depends on cucumber/cucumber-ruby-core#139. 

## Motivation and Context

To be consistent with Cucumber-JS and Cucumber-JVM

## How Has This Been Tested?

Still WIP.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
