### PR TITLE
Handle selective strict options.

### DIFF
--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -26,7 +26,7 @@ module Cucumber
         @args = args
         @options.parse!(args)
         arrange_formats
-        raise("You can't use both --strict and --wip") if strict? && wip?
+        raise("You can't use both --strict and --wip") if strict.strict? && wip?
         set_environment_variables
       end
 
@@ -42,7 +42,7 @@ module Cucumber
         Integer(@options[:seed] || rand(0xFFFF))
       end
 
-      def strict?
+      def strict
         @options[:strict]
       end
 

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -3,6 +3,7 @@ require 'cucumber/constantize'
 require 'cucumber/cli/rerun_file'
 require 'cucumber/events'
 require 'cucumber/core/event_bus'
+require 'cucumber/core/test/result'
 require 'forwardable'
 require 'cucumber'
 
@@ -71,7 +72,7 @@ module Cucumber
       @options[:guess]
     end
 
-    def strict?
+    def strict
       @options[:strict]
     end
 
@@ -243,7 +244,7 @@ module Cucumber
       {
         :autoload_code_paths => ['features/support', 'features/step_definitions'],
         :filters             => [],
-        :strict              => false,
+        :strict              => Cucumber::Core::Test::Result::StrictConfiguration.new,
         :require             => [],
         :dry_run             => false,
         :fail_fast           => false,

--- a/lib/cucumber/formatter/console_issues.rb
+++ b/lib/cucumber/formatter/console_issues.rb
@@ -12,9 +12,9 @@ module Cucumber
         @config.on_event(:test_case_finished) do |event|
           if event.test_case != @previous_test_case
             @previous_test_case = event.test_case
-            @issues[event.result.to_sym] << event.test_case unless event.result.ok?(@config.strict?)
+            @issues[event.result.to_sym] << event.test_case unless event.result.ok?(@config.strict)
           elsif event.result.passed?
-            @issues[:flaky] << event.test_case unless Core::Test::Result::Flaky.ok?(@config.strict?)
+            @issues[:flaky] << event.test_case unless Core::Test::Result::Flaky.ok?(@config.strict)
             @issues[:failed].delete(event.test_case)
           end
         end

--- a/lib/cucumber/formatter/fail_fast.rb
+++ b/lib/cucumber/formatter/fail_fast.rb
@@ -10,7 +10,7 @@ module Cucumber
       def initialize(configuration)
         configuration.on_event :test_case_finished do |event|
           _test_case, result = *event.attributes
-          Cucumber.wants_to_quit = true unless result.ok?(configuration.strict?)
+          Cucumber.wants_to_quit = true unless result.ok?(configuration.strict)
         end
       end
 

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -52,7 +52,7 @@ module Cucumber
         test_step, result = *event.attributes
         return if @failing_step_source
 
-        @failing_step_source = test_step.source.last unless result.ok?(@config.strict?)
+        @failing_step_source = test_step.source.last unless result.ok?(@config.strict)
       end
 
       def on_test_case_finished(event)
@@ -102,7 +102,7 @@ module Cucumber
 
       def create_output_string(test_case, scenario, result, row_name)
         output = "#{test_case.keyword}: #{scenario}\n\n"
-        return output if result.ok?(@config.strict?)
+        return output if result.ok?(@config.strict)
         if test_case.keyword == 'Scenario'
           output += @failing_step_source.keyword.to_s unless hook?(@failing_step_source)
           output += "#{@failing_step_source.name}\n"
@@ -123,7 +123,7 @@ module Cucumber
         name = scenario_designation
 
         @current_feature_data[:builder].testcase(:classname => classname, :name => name, :time => format('%.6f', duration)) do
-          if !result.passed? && result.ok?(@config.strict?)
+          if !result.passed? && result.ok?(@config.strict)
             @current_feature_data[:builder].skipped
             @current_feature_data[:skipped] += 1
           elsif !result.passed?

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -989,7 +989,7 @@ module Cucumber
 
           def step_exception(step, configuration)
             return filtered_step_exception(step) if @exception
-            return nil unless @status == :undefined && configuration.strict?
+            return nil unless @status == :undefined && configuration.strict.strict?(:undefined)
             @exception = Cucumber::Undefined.from(@result, step.name)
             @exception.backtrace << step.backtrace_line
             filtered_step_exception(step)

--- a/lib/cucumber/formatter/rerun.rb
+++ b/lib/cucumber/formatter/rerun.rb
@@ -12,7 +12,7 @@ module Cucumber
         @failures = {}
         config.on_event :test_case_finished do |event|
           test_case, result = *event.attributes
-          next if result.ok?(@config.strict?)
+          next if result.ok?(@config.strict)
           @failures[test_case.location.file] ||= []
           @failures[test_case.location.file] << test_case.location.line
         end

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -229,7 +229,7 @@ module Cucumber
       if @configuration.wip?
         summary_report.test_cases.total_passed > 0
       else
-        !summary_report.ok?(@configuration.strict?)
+        !summary_report.ok?(@configuration.strict)
       end
     end
     public :failure?

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -71,7 +71,19 @@ module Cli
 
         config.parse!(%w{--profile bongo})
 
-        expect(config.options[:strict]).to be true
+        expect(config.options[:strict].strict?(:undefined)).to be true
+        expect(config.options[:strict].strict?(:pending)).to be true
+        expect(config.options[:strict].strict?(:flaky)).to be true
+      end
+
+      it 'allows --strict from a profile to be selectively overridden' do
+        given_cucumber_yml_defined_as({'bongo' => '--strict'})
+
+        config.parse!(%w{--profile bongo --no-strict-flaky})
+
+        expect(config.options[:strict].strict?(:undefined)).to be true
+        expect(config.options[:strict].strict?(:pending)).to be true
+        expect(config.options[:strict].strict?(:flaky)).to be false
       end
 
       it 'parses ERB syntax in the cucumber.yml file' do

--- a/spec/cucumber/formatter/fail_fast_spec.rb
+++ b/spec/cucumber/formatter/fail_fast_spec.rb
@@ -75,7 +75,7 @@ module Cucumber::Formatter
       end
 
       context 'in strict mode' do
-        let(:configuration) { Cucumber::Configuration.new strict: true }
+        let(:configuration) { Cucumber::Configuration.new strict: Cucumber::Core::Test::Result::StrictConfiguration.new([:undefined]) }
 
         it 'sets Cucumber.wants_to_quit' do
           execute [@gherkin], [StandardStepActions.new], configuration.event_bus

--- a/spec/cucumber/formatter/legacy_api/adapter_spec.rb
+++ b/spec/cucumber/formatter/legacy_api/adapter_spec.rb
@@ -2126,7 +2126,7 @@ module Cucumber
       end
 
       context 'in strict mode' do
-        let(:runtime) { Runtime.new strict: true }
+        let(:runtime) { Runtime.new strict: Cucumber::Core::Test::Result::StrictConfiguration.new([:undefined]) }
 
         it 'passes an exception to the formatter for undefined steps' do
           expect( formatter ).to receive(:exception) do |exception|


### PR DESCRIPTION
## Summary

Let the result types affected the the strict settings be controlled individually, so only a subset of the can be set to be handled strict.

## Details

Add the options 
* `--[no-]strict-undefined`, 
* `--[no-]strict-pending`, and
* `--[no-]strict-flaky`, 

so each of the result type affected by the strict settings be controlled individually. 
The `--[no-]strict` option is equivalent to `--[no-]strict-undefined --[no-]strict-pending --[no-]strict-flaky`. 
Also make sure that it is possible from the command line to adjust the strict setting from a profile, for instance:
Given that a profile includes the `--strict` option
When using `--no-strict-flaky` on the command line
Then only `undefined` and `pending` will be handled strict

Depends on cucumber/cucumber-core#143.

## Motivation and Context

Fixes #1160.

## How Has This Been Tested?

The automated test suite has been updated to verify this behaviour.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly (the `--help` option will describe the new options).
