### PR TITLE
Fix Lint/DeprecatedClassMethods

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,12 +15,6 @@ Lint/AmbiguousOperator:
     - 'spec/cucumber/formatter/legacy_api/adapter_spec.rb'
     - 'spec/cucumber/formatter/spec_helper.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Lint/DeprecatedClassMethods:
-  Exclude:
-    - 'lib/cucumber/project_initializer.rb'
-
 # Offense count: 2
 Lint/DuplicateMethods:
   Exclude:

--- a/lib/cucumber/project_initializer.rb
+++ b/lib/cucumber/project_initializer.rb
@@ -27,7 +27,7 @@ module Cucumber
                     :touch
                   end
 
-      report_exists(file_name) || return if File.exists?(file_name)
+      report_exists(file_name) || return if File.exist?(file_name)
 
       report_creating(file_name)
       FileUtils.send file_type, file_name


### PR DESCRIPTION
## Summary

Fix Lint/DeprecatedClassMethods

## Details

* Offense count: 1

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
