### PR TITLE
Fix Lint/DuplicateMethods

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,11 +22,6 @@ Lint/DeprecatedClassMethods:
     - 'lib/cucumber/project_initializer.rb'
 
 # Offense count: 2
-Lint/DuplicateMethods:
-  Exclude:
-    - 'lib/cucumber/multiline_argument.rb'
-
-# Offense count: 2
 Lint/Eval:
   Exclude:
     - 'lib/cucumber/formatter/ansicolor.rb'

--- a/lib/cucumber/multiline_argument.rb
+++ b/lib/cucumber/multiline_argument.rb
@@ -11,14 +11,14 @@ module Cucumber
         builder.wrap(node)
       end
 
-      def from(argument, location=nil)
+      def from(argument, location=nil, content_type=nil)
         location ||= Core::Ast::Location.of_caller
         case argument
         when String
-          doc_string(argument, 'text/plain', location)
+          builder.doc_string(Core::Ast::DocString.new(argument, content_type, location))
         when Array
           location = location.on_line(argument.first.line..argument.last.line)
-          data_table(argument.map{ |row| row.cells }, location)
+          builder.data_table(argument.map{ |row| row.cells }, location)
         when DataTable, DocString, None
           argument
         when nil
@@ -26,14 +26,6 @@ module Cucumber
         else
           raise ArgumentError, "Don't know how to convert #{argument.class} #{argument.inspect} into a MultilineArgument"
         end
-      end
-
-      def doc_string(argument, content_type, location)
-        builder.doc_string(Core::Ast::DocString.new(argument, content_type, location))
-      end
-
-      def data_table(data, location)
-        builder.data_table(Core::Ast::DataTable.new(data, location))
       end
 
       private

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -34,7 +34,7 @@ module Cucumber
 
           if argument
             if argument[:type] == :DocString
-              MultilineArgument.doc_string(argument[:content], argument[:content_type], location)
+              MultilineArgument.from(argument[:content], location, argument[:content_type])
             else
               MultilineArgument::DataTable.from(argument[:rows].map { |row| row[:cells].map { |cell| cell[:value] } })
             end


### PR DESCRIPTION
## Summary

Investigated the Lint/DuplicateMethods offenses and need guidance on how best to address them.

## Details

* Offense count: 2
* Added review note as I'm unsure how these should be handled.
* Review note: In the two instances of duplication, both methods are under MultilineArgument, but one self method calls another that belongs to the private Builder class.
* [Here's the code in question](https://github.com/jaysonesmith/cucumber-ruby/blob/1021-fix-style-violations-2/lib/cucumber/multiline_argument.rb#L31*L58)

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)