### PR TITLE
Fix Metrics/LineLength - PARTIAL - 01

### DIFF
--- a/examples/i18n/ar/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/ar/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/bg/features/support/env.rb
+++ b/examples/i18n/bg/features/support/env.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/bg/lib/calculator.rb
+++ b/examples/i18n/bg/lib/calculator.rb
@@ -18,7 +18,8 @@ class Calculator
   end
 
   def /
-    divisor, dividend = [@stack.pop, @stack.pop] # Hm, @stack.pop(2) doesn't work
+    divisor, dividend = [@stack.pop, @stack.pop]
+    # Hm, @stack.pop(2) doesn't work
     @stack.push dividend / divisor
   end
 end

--- a/examples/i18n/ca/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/ca/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculadora'

--- a/examples/i18n/cs/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/cs/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/da/features/step_definitions/lommeregner_steps.rb
+++ b/examples/i18n/da/features/step_definitions/lommeregner_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'lommeregner'

--- a/examples/i18n/de/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/de/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/el/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/el/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/en-lol/features/support/env.rb
+++ b/examples/i18n/en-lol/features/support/env.rb
@@ -1,7 +1,11 @@
 # encoding: utf-8
-require 'cucumber/formatter/unicode'
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
 
+require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'basket'
 require 'belly'

--- a/examples/i18n/en/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/en/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/eo/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/eo/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/es/features/step_definitions/calculador_steps.rb
+++ b/examples/i18n/es/features/step_definitions/calculador_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculador'

--- a/examples/i18n/et/features/step_definitions/kalkulaator_steps.rb
+++ b/examples/i18n/et/features/step_definitions/kalkulaator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'kalkulaator'

--- a/examples/i18n/fi/features/step_definitions/laskin_steps.rb
+++ b/examples/i18n/fi/features/step_definitions/laskin_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'laskin'

--- a/examples/i18n/fr/features/support/env.rb
+++ b/examples/i18n/fr/features/support/env.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculatrice'

--- a/examples/i18n/he/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/he/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/hi/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/hi/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/ht/features/step_definitions/kalkilatris_steps.rb
+++ b/examples/i18n/ht/features/step_definitions/kalkilatris_steps.rb
@@ -1,6 +1,10 @@
-
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'kalkilatris'

--- a/examples/i18n/hu/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/hu/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/id/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/id/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/it/features/step_definitions/calcolatrice_steps.rb
+++ b/examples/i18n/it/features/step_definitions/calcolatrice_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calcolatrice'

--- a/examples/i18n/ja/features/support/env.rb
+++ b/examples/i18n/ja/features/support/env.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/ko/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/ko/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/lt/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/lt/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/lv/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/lv/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/no/features/support/env.rb
+++ b/examples/i18n/no/features/support/env.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 
 $:.unshift(File.dirname(__FILE__) + '/../../lib')

--- a/examples/i18n/pl/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/pl/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/pl/features/support/env.rb
+++ b/examples/i18n/pl/features/support/env.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/pt/features/support/env.rb
+++ b/examples/i18n/pt/features/support/env.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculadora'

--- a/examples/i18n/ro/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/ro/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/ru/features/support/env.rb
+++ b/examples/i18n/ru/features/support/env.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/ru/lib/calculator.rb
+++ b/examples/i18n/ru/lib/calculator.rb
@@ -18,7 +18,8 @@ class Calculator
   end
 
   def /
-    divisor, dividend = [@stack.pop, @stack.pop] # Hm, @stack.pop(2) doesn't work
+    divisor, dividend = [@stack.pop, @stack.pop]
+    # Hm, @stack.pop(2) doesn't work
     @stack.push dividend / divisor
   end
 end

--- a/examples/i18n/sk/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/sk/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/sr-Cyrl/features/support/env.rb
+++ b/examples/i18n/sr-Cyrl/features/support/env.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/sr-Latn/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/sr-Latn/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/sv/features/step_definitions/kalkulator_steps.rb
+++ b/examples/i18n/sv/features/step_definitions/kalkulator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'kalkulator'

--- a/examples/i18n/tr/features/step_definitions/hesap_makinesi_adimlari.rb
+++ b/examples/i18n/tr/features/step_definitions/hesap_makinesi_adimlari.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'hesap_makinesi'

--- a/examples/i18n/uk/features/support/env.rb
+++ b/examples/i18n/uk/features/support/env.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/uk/lib/calculator.rb
+++ b/examples/i18n/uk/lib/calculator.rb
@@ -18,7 +18,8 @@ class Calculator
   end
 
   def /
-    divisor, dividend = [@stack.pop, @stack.pop] # Hm, @stack.pop(2) doesn't work
+    divisor, dividend = [@stack.pop, @stack.pop]
+    # Hm, @stack.pop(2) doesn't work
     @stack.push dividend / divisor
   end
 end

--- a/examples/i18n/uz/features/support/env.rb
+++ b/examples/i18n/uz/features/support/env.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/uz/lib/calculator.rb
+++ b/examples/i18n/uz/lib/calculator.rb
@@ -18,7 +18,8 @@ class Calculator
   end
 
   def /
-    divisor, dividend = [@stack.pop, @stack.pop] # Hm, @stack.pop(2) doesn't work
+    divisor, dividend = [@stack.pop, @stack.pop]
+    # Hm, @stack.pop(2) doesn't work
     @stack.push dividend / divisor
   end
 end

--- a/examples/i18n/zh-CN/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/zh-CN/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/i18n/zh-TW/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/zh-TW/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'cucumber/formatter/unicode'
 $:.unshift(File.dirname(__FILE__) + '/../../lib')
 require 'calculator'

--- a/examples/sinatra/features/support/env.rb
+++ b/examples/sinatra/features/support/env.rb
@@ -3,7 +3,12 @@
 
 require File.dirname(__FILE__) + '/../../app'
 
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
+
 require 'rack/test'
 require 'capybara/cucumber'
 

--- a/examples/tcl/features/support/env.rb
+++ b/examples/tcl/features/support/env.rb
@@ -2,5 +2,6 @@ require 'rubygems'
 require 'tcl'
 
 Before do
-  @fib = Tcl::Interp.load_from_file(File.dirname(__FILE__) + '/../../src/fib.tcl')
+  file_name = File.dirname(__FILE__) + '/../../src/fib.tcl'
+  @fib = Tcl::Interp.load_from_file(file_name)
 end

--- a/examples/watir/features/step_definitions/search_steps.rb
+++ b/examples/watir/features/step_definitions/search_steps.rb
@@ -18,9 +18,10 @@ end
 # consider creating classes for your pages - such as this:
 # http://github.com/cucumber/cucumber/tree/v0.1.15/examples/watir/features/step_definitons/search_steps.rb
 #
-# You may keep the page classes along your steps, or even better, put them in separate files, e.g.
-# support/pages/google_search.rb
+# You may keep the page classes along your steps, or even better, put them in
+# separate files, e.g. support/pages/google_search.rb
 #
 # This technique is called "Page Objects", and you can read more about it here:
 # http://github.com/marekj/watirloo/tree/master
-# We're not using this technique here, since we want to illustrate the basics only.
+# We're not using this technique here, since we want to illustrate the
+# basics only.

--- a/examples/watir/features/support/env.rb
+++ b/examples/watir/features/support/env.rb
@@ -1,4 +1,8 @@
-begin require 'rspec/expectations'; rescue LoadError; require 'spec/expectations'; end
+begin
+  require 'rspec/expectations'
+rescue LoadError
+  require 'spec/expectations'
+end
 
 browser = nil
 


### PR DESCRIPTION
## Summary

Partially Fixing Metrics/LineLength

## Details

* Changes to line length 80. If 100 is desired, let me know!
* Only fixed examples directory to keep change down.
* Most of the change in this PR happened at the beginning of files that load rspec and spec expectations. 

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)