### PR TITLE
Fix Style/AlignArray

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -146,16 +146,6 @@ Style/Alias:
   Exclude:
     - 'lib/cucumber/formatter/ansicolor.rb'
 
-# Offense count: 1197
-# Cop supports --auto-correct.
-Style/AlignArray:
-  Exclude:
-    - 'lib/cucumber/cli/options.rb'
-    - 'lib/cucumber/rake/task.rb'
-    - 'spec/cucumber/formatter/legacy_api/adapter_spec.rb'
-    - 'spec/cucumber/multiline_argument/data_table_spec.rb'
-    - 'spec/cucumber/rake/forked_spec.rb'
-
 # Offense count: 20
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -25,20 +25,21 @@ module Cucumber
         'junit'       => ['Cucumber::Formatter::Junit',       'Generates a report similar to Ant+JUnit.'],
         'json'        => ['Cucumber::Formatter::Json',        'Prints the feature as JSON'],
         'json_pretty' => ['Cucumber::Formatter::JsonPretty',  'Prints the feature as prettified JSON'],
-        'summary'       => ['Cucumber::Formatter::Summary',   'Summary output of feature and scenarios']
+        'summary'     => ['Cucumber::Formatter::Summary',     'Summary output of feature and scenarios']
       }
       max = BUILTIN_FORMATS.keys.map{|s| s.length}.max
-      FORMAT_HELP_MSG = ['Use --format rerun --out rerun.txt to write out failing',
-        'features. You can rerun them with cucumber @rerun.txt.',
-        'FORMAT can also be the fully qualified class name of',
-        "your own custom formatter. If the class isn't loaded,",
-        'Cucumber will attempt to require a file with a relative',
-        'file name that is the underscore name of the class name.',
-        'Example: --format Foo::BarZap -> Cucumber will look for',
-        'foo/bar_zap.rb. You can place the file with this relative',
-        'path underneath your features/support directory or anywhere',
-        "on Ruby's LOAD_PATH, for example in a Ruby gem."
-      ]
+      FORMAT_HELP_MSG = [
+                          'Use --format rerun --out rerun.txt to write out failing',
+                          'features. You can rerun them with cucumber @rerun.txt.',
+                          'FORMAT can also be the fully qualified class name of',
+                          "your own custom formatter. If the class isn't loaded,",
+                          'Cucumber will attempt to require a file with a relative',
+                          'file name that is the underscore name of the class name.',
+                          'Example: --format Foo::BarZap -> Cucumber will look for',
+                          'foo/bar_zap.rb. You can place the file with this relative',
+                          'path underneath your features/support directory or anywhere',
+                          "on Ruby's LOAD_PATH, for example in a Ruby gem."
+                        ]
 
       FORMAT_HELP = (BUILTIN_FORMATS.keys.sort.map do |key|
         "  #{key}#{' ' * (max - key.length)} : #{BUILTIN_FORMATS[key][1]}"
@@ -49,11 +50,12 @@ module Cucumber
       NO_PROFILE_LONG_FLAG = '--no-profile'
       FAIL_FAST_FLAG = '--fail-fast'
       RETRY_FLAG = '--retry'
-      OPTIONS_WITH_ARGS = ['-r', '--require', '--i18n-keywords', '-f', '--format', '-o', '--out',
-                                  '-t', '--tags', '-n', '--name', '-e', '--exclude',
-                                  PROFILE_SHORT_FLAG, PROFILE_LONG_FLAG, RETRY_FLAG,
-                                  '-l', '--lines', '--port',
-                                  '-I', '--snippet-type']
+      OPTIONS_WITH_ARGS = [
+                            '-r', '--require', '--i18n-keywords', '-f', '--format', '-o',
+                            '--out', '-t', '--tags', '-n', '--name', '-e', '--exclude',
+                            PROFILE_SHORT_FLAG, PROFILE_LONG_FLAG, RETRY_FLAG, '-l',
+                            '--lines', '--port', '-I', '--snippet-type'
+                          ]
       ORDER_TYPES = %w{defined random}
       TAG_LIMIT_MATCHER = /(?<tag_name>\@\w+):(?<limit>\d+)/x
 
@@ -329,12 +331,13 @@ TEXT
       end
 
       def banner
-        ['Usage: cucumber [options] [ [FILE|DIR|URL][:LINE[:LINE]*] ]+', '',
-          'Examples:',
-          'cucumber examples/i18n/en/features',
-          'cucumber @rerun.txt (See --format rerun)',
-          'cucumber examples/i18n/it/features/somma.feature:6:98:113',
-          'cucumber -s -i http://rubyurl.com/eeCl', '', ''
+        [
+         'Usage: cucumber [options] [ [FILE|DIR|URL][:LINE[:LINE]*] ]+', '',
+         'Examples:',
+         'cucumber examples/i18n/en/features',
+         'cucumber @rerun.txt (See --format rerun)',
+         'cucumber examples/i18n/it/features/somma.feature:6:98:113',
+         'cucumber -s -i http://rubyurl.com/eeCl', '', ''
         ].join("\n")
       end
 
@@ -521,21 +524,24 @@ TEXT
         require 'gherkin/dialect'
         language = ::Gherkin::Dialect.for(lang)
         data = Cucumber::MultilineArgument::DataTable.from(
-          [['feature', to_keywords_string(language.feature_keywords)],
-          ['background', to_keywords_string(language.background_keywords)],
-          ['scenario', to_keywords_string(language.scenario_keywords)],
-          ['scenario_outline', to_keywords_string(language.scenario_outline_keywords)],
-          ['examples', to_keywords_string(language.examples_keywords)],
-          ['given', to_keywords_string(language.given_keywords)],
-          ['when', to_keywords_string(language.when_keywords)],
-          ['then', to_keywords_string(language.then_keywords)],
-          ['and', to_keywords_string(language.and_keywords)],
-          ['but', to_keywords_string(language.but_keywords)],
-          ['given (code)', to_code_keywords_string(language.given_keywords)],
-          ['when (code)', to_code_keywords_string(language.when_keywords)],
-          ['then (code)', to_code_keywords_string(language.then_keywords)],
-          ['and (code)', to_code_keywords_string(language.and_keywords)],
-          ['but (code)', to_code_keywords_string(language.but_keywords)]])
+          [
+            ['feature', to_keywords_string(language.feature_keywords)],
+            ['background', to_keywords_string(language.background_keywords)],
+            ['scenario', to_keywords_string(language.scenario_keywords)],
+            ['scenario_outline', to_keywords_string(language.scenario_outline_keywords)],
+            ['examples', to_keywords_string(language.examples_keywords)],
+            ['given', to_keywords_string(language.given_keywords)],
+            ['when', to_keywords_string(language.when_keywords)],
+            ['then', to_keywords_string(language.then_keywords)],
+            ['and', to_keywords_string(language.and_keywords)],
+            ['but', to_keywords_string(language.but_keywords)],
+            ['given (code)', to_code_keywords_string(language.given_keywords)],
+            ['when (code)', to_code_keywords_string(language.when_keywords)],
+            ['then (code)', to_code_keywords_string(language.then_keywords)],
+            ['and (code)', to_code_keywords_string(language.and_keywords)],
+            ['but (code)', to_code_keywords_string(language.but_keywords)]
+          ]
+        )
         @out_stream.write(data.to_s({ color: false, prefixes: Hash.new('') }))
         Kernel.exit(0)
       end

--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -81,11 +81,15 @@ module Cucumber
 
         def cmd
           if use_bundler
-            [ Cucumber::RUBY_BINARY, '-S', 'bundle', 'exec', 'cucumber', @cucumber_opts,
-            @feature_files ].flatten
+            [
+              Cucumber::RUBY_BINARY,'-S', 'bundle', 'exec', 'cucumber',
+              @cucumber_opts, @feature_files
+            ].flatten
           else
-            [ Cucumber::RUBY_BINARY, '-I', load_path, quoted_binary(@cucumber_bin),
-            @cucumber_opts, @feature_files ].flatten
+            [
+              Cucumber::RUBY_BINARY, '-I', load_path,
+              quoted_binary(@cucumber_bin), @cucumber_opts, @feature_files
+            ].flatten
           end
         end
 

--- a/spec/cucumber/formatter/legacy_api/adapter_spec.rb
+++ b/spec/cucumber/formatter/legacy_api/adapter_spec.rb
@@ -111,6 +111,7 @@ module Cucumber
           runner = Core::Test::Runner.new(events)
           compile gherkin_docs, runner, default_filters
           events.test_run_finished
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
             :before_features,
               :before_feature,
@@ -149,6 +150,7 @@ module Cucumber
               :after_feature,
             :after_features
           ]
+          # rubocop:enable AlignArray
         end
 
         it 'a scenario with one step' do
@@ -159,6 +161,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -180,6 +184,7 @@ module Cucumber
                 :after_feature,
               :after_features
           ]
+          # rubocop:enable AlignArray
         end
 
         it 'a scenario with two steps, one of them failing' do
@@ -231,6 +236,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -264,6 +271,7 @@ module Cucumber
                 :after_feature,
               :after_features
           ]
+          # rubocop:enable AlignArray
         end
 
         it 'a feature with a background and an empty scenario' do
@@ -275,6 +283,8 @@ module Cucumber
               scenario
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
             :before_features,
               :before_feature,
@@ -299,6 +309,7 @@ module Cucumber
               :after_feature,
             :after_features
           ]
+          # rubocop:enable AlignArray
         end
 
         it 'a feature with a background and two scenarios' do
@@ -315,6 +326,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -358,6 +371,7 @@ module Cucumber
                 :after_feature,
               :after_features
           ]
+          # rubocop:enable AlignArray
         end
 
         it 'a feature with a background and one scenario and one scenario outline' do
@@ -378,6 +392,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -440,6 +456,7 @@ module Cucumber
                 :after_feature,
               :after_features
           ]
+          # rubocop:enable AlignArray
         end
 
         it 'a feature with a background and one scenario outline and one scenario' do
@@ -460,6 +477,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -522,6 +541,7 @@ module Cucumber
                 :after_feature,
               :after_features
           ]
+          # rubocop:enable AlignArray
         end
 
         it 'a feature with a background and two scenario outlines' do
@@ -546,6 +566,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -627,6 +649,7 @@ module Cucumber
                 :after_feature,
               :after_features
           ]
+          # rubocop:enable AlignArray
         end
 
         it 'a feature with a background and one scenario outline with two rows' do
@@ -645,6 +668,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -700,6 +725,7 @@ module Cucumber
                 :after_feature,
               :after_features
           ]
+          # rubocop:enable AlignArray
         end
 
         it 'a feature with a background and one scenario outline with two examples tables' do
@@ -721,6 +747,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -788,6 +816,7 @@ module Cucumber
                 :after_feature,
               :after_features
           ]
+          # rubocop:enable AlignArray
         end
 
         it 'a feature with a background with two steps' do
@@ -802,6 +831,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -838,6 +869,7 @@ module Cucumber
                 :after_feature,
               :after_features
           ]
+          # rubocop:enable AlignArray
         end
 
         it 'a feature with a background' do
@@ -896,6 +928,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -936,6 +970,7 @@ module Cucumber
                 :after_feature,
               :after_features
           ]
+          # rubocop:enable AlignArray
         end
 
         it 'scenario outline after scenario' do
@@ -953,6 +988,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -1005,6 +1042,7 @@ module Cucumber
                 :after_feature,
               :after_features
           ]
+          # rubocop:enable AlignArray
         end
 
         it 'scenario outline before scenario' do
@@ -1022,6 +1060,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -1074,6 +1114,7 @@ module Cucumber
                 :after_feature,
               :after_features
             ]
+          # rubocop:enable AlignArray
         end
 
         it 'scenario outline two rows' do
@@ -1089,6 +1130,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -1134,6 +1177,7 @@ module Cucumber
                 :after_feature,
               :after_features
             ]
+          # rubocop:enable AlignArray
         end
 
         it 'scenario outline two examples tables' do
@@ -1152,6 +1196,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -1209,6 +1255,7 @@ module Cucumber
                 :after_feature,
               :after_features
             ]
+          # rubocop:enable AlignArray
         end
 
         it 'two scenario outline' do
@@ -1230,6 +1277,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -1301,6 +1350,7 @@ module Cucumber
                 :after_feature,
               :after_features
             ]
+          # rubocop:enable AlignArray
         end
 
         it 'failing scenario outline' do
@@ -1315,6 +1365,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -1355,6 +1407,7 @@ module Cucumber
                 :after_feature,
               :after_features
             ]
+          # rubocop:enable AlignArray
         end
 
         it 'a feature with a failing background and two scenarios' do
@@ -1371,6 +1424,8 @@ module Cucumber
               end
             end
           end
+
+          # rubocop:disable AlignArray
           expect( formatter.legacy_messages ).to eq [
               :before_features,
                 :before_feature,
@@ -1415,6 +1470,7 @@ module Cucumber
                 :after_feature,
               :after_features
             ]
+          # rubocop:enable AlignArray
         end
 
         context 'in expand mode' do
@@ -1434,6 +1490,8 @@ module Cucumber
                 end
               end
             end
+
+            # rubocop:disable AlignArray
             expect( formatter.legacy_messages ).to eq [
                 :before_features,
                   :before_feature,
@@ -1476,6 +1534,7 @@ module Cucumber
                   :after_feature,
                 :after_features
               ]
+            # rubocop:enable AlignArray
           end
         end
 
@@ -1501,6 +1560,8 @@ module Cucumber
                 end
               end
             end
+
+            # rubocop:disable AlignArray
             expect( formatter.legacy_messages ).to eq([
                 :before_features,
                   :before_feature,
@@ -1522,7 +1583,8 @@ module Cucumber
                     :after_feature_element,
                   :after_feature,
                 :after_features
-                ])
+              ])
+            # rubocop:enable AlignArray
           end
         end
 
@@ -1548,6 +1610,7 @@ module Cucumber
               end
             end
 
+            # rubocop:disable AlignArray
             expect( formatter.legacy_messages ).to eq([
                 :before_features,
                   :before_feature,
@@ -1569,7 +1632,8 @@ module Cucumber
                     :after_feature_element,
                   :after_feature,
                 :after_features
-                ])
+              ])
+            # rubocop:enable AlignArray
           end
 
           it 'prints the exception after the background name' do
@@ -1589,6 +1653,7 @@ module Cucumber
               end
             end
 
+            # rubocop:disable AlignArray
             expect( formatter.legacy_messages ).to eq([
                 :before_features,
                   :before_feature,
@@ -1620,7 +1685,8 @@ module Cucumber
                     :after_feature_element,
                   :after_feature,
                 :after_features
-                ])
+              ])
+            # rubocop:enable AlignArray
           end
 
 
@@ -1642,6 +1708,7 @@ module Cucumber
               end
             end
 
+            # rubocop:disable AlignArray
             expect( formatter.legacy_messages ).to eq([
                 :before_features,
                   :before_feature,
@@ -1683,6 +1750,7 @@ module Cucumber
                   :after_feature,
                 :after_features
               ])
+            # rubocop:enable AlignArray
           end
         end
 
@@ -1711,6 +1779,7 @@ module Cucumber
               end
             end
 
+            # rubocop:disable AlignArray
             expect( formatter.legacy_messages ).to eq([
                 :before_features,
                   :before_feature,
@@ -1732,7 +1801,8 @@ module Cucumber
                     :after_feature_element,
                   :after_feature,
                 :after_features
-                ])
+              ])
+            # rubocop:enable AlignArray
           end
         end
 
@@ -1759,6 +1829,7 @@ module Cucumber
               end
             end
 
+            # rubocop:disable AlignArray
             expect( formatter.legacy_messages ).to eq([
               :before_features,
                 :before_feature,
@@ -1781,6 +1852,7 @@ module Cucumber
                 :after_feature,
               :after_features
             ])
+            # rubocop:enable AlignArray
           end
 
           it 'prints the exception after the examples table row' do
@@ -1801,6 +1873,7 @@ module Cucumber
               end
             end
 
+            # rubocop:disable AlignArray
             expect( formatter.legacy_messages ).to eq([
               :before_features,
                 :before_feature,
@@ -1842,6 +1915,7 @@ module Cucumber
                 :after_feature,
               :after_features
             ])
+            # rubocop:enable AlignArray
           end
         end
 
@@ -1868,6 +1942,7 @@ module Cucumber
               end
             end
 
+            # rubocop:disable AlignArray
             expect( formatter.legacy_messages ).to eq([
               :before_features,
                 :before_feature,
@@ -1890,6 +1965,7 @@ module Cucumber
                 :after_feature,
               :after_features
             ])
+            # rubocop:enable AlignArray
           end
         end
 
@@ -1916,6 +1992,7 @@ module Cucumber
               end
             end
 
+            # rubocop:disable AlignArray
             expect( formatter.legacy_messages ).to eq([
               :before_features,
                 :before_feature,
@@ -1931,6 +2008,7 @@ module Cucumber
                 :after_feature,
               :after_features
             ])
+            # rubocop:enable AlignArray
           end
         end
 
@@ -1956,7 +2034,7 @@ module Cucumber
                 end
               end
             end
-
+            # rubocop:disable AlignArray
             expect( formatter.legacy_messages ).to eq([
               :before_features,
                 :before_feature,
@@ -1979,6 +2057,7 @@ module Cucumber
                 :after_feature,
               :after_features
             ])
+            # rubocop:enable AlignArray
           end
         end
       end

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -457,7 +457,7 @@ module Cucumber
           ])
           t2 = DataTable.from([
             %w(name    male   lastname   swedish),
-             ['aslak', true, 'hellesøy', false]
+            ['aslak', true, 'hellesøy', false]
           ])
           expect { t1.diff!(t2) }.to raise_error(DataTable::Different) do |error|
             expect(error.table.to_s(indent: 14, color: false)).to eq %{
@@ -476,7 +476,7 @@ module Cucumber
           t1.map_column!('male') { |m| m == 'true' }
           t2 = DataTable.from([
             %w(name    male),
-             ['aslak', true]
+            ['aslak', true]
           ])
           t1.diff!(t2)
           expect( t1.to_s(:indent => 12, :color => false) ).to eq %{
@@ -488,7 +488,7 @@ module Cucumber
         it 'should allow column mapping of argument before diffing' do
           t1 = DataTable.from([
             %w(name    male),
-             ['aslak', true]
+            ['aslak', true]
           ])
           t1.map_column!('male') {
             'true'
@@ -513,7 +513,7 @@ module Cucumber
           t1.map_column!('male') { |m| m == 'true' }
           t2 = DataTable.from([
             %w(name    male),
-             ['aslak', true]
+            ['aslak', true]
           ])
           t1.diff!(t2)
           expect( t1.to_s(:indent => 12, :color => false) ).to eq %{
@@ -529,7 +529,7 @@ module Cucumber
           ])
           t2 = DataTable.from([
             %w(X  Y),
-              [2, 1]
+            [2, 1]
           ])
           expect { t1.diff!(t2) }.to raise_error(DataTable::Different) do |error|
             expect(error.table.to_s(indent: 14, color: false)).to eq %{

--- a/spec/cucumber/rake/forked_spec.rb
+++ b/spec/cucumber/rake/forked_spec.rb
@@ -22,12 +22,14 @@ module Cucumber
         end
 
         it 'uses bundle exec to find cucumber and libraries' do
-          expect(subject.cmd).to eq [Cucumber::RUBY_BINARY,
-            '-S',
-            'bundle',
-            'exec',
-            'cucumber',
-            '--cuke-option'] + feature_files
+          expect(subject.cmd).to eq [
+              Cucumber::RUBY_BINARY,
+              '-S',
+              'bundle',
+              'exec',
+              'cucumber',
+              '--cuke-option'
+            ] + feature_files
         end
       end
 
@@ -42,11 +44,13 @@ module Cucumber
         end
 
         it 'uses well known cucumber location and specified libraries' do
-          expect(subject.cmd).to eq [Cucumber::RUBY_BINARY,
-            '-I',
-            '"lib"',
-            "\"#{Cucumber::BINARY}\"",
-            '--cuke-option'] + feature_files
+          expect(subject.cmd).to eq [
+              Cucumber::RUBY_BINARY,
+              '-I',
+              '"lib"',
+              "\"#{Cucumber::BINARY}\"",
+              '--cuke-option'
+            ] + feature_files
         end
       end
     end


### PR DESCRIPTION
## Summary

Partially Fixing Metrics/AlignArray

## Details

* All offending directories except 'spec/cucumber/formatter/legacy_api/adapter_spec.rb' which has 1106 offenses

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)