### PR TITLE
Fix Multiple Cops

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -288,63 +288,10 @@ Style/ClassAndModuleChildren:
     - 'spec/cucumber/formatter/legacy_api/adapter_spec.rb'
     - 'spec/cucumber/hooks_spec.rb'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: is_a?, kind_of?
-Style/ClassCheck:
-  Exclude:
-    - 'lib/cucumber/formatter/legacy_api/ast.rb'
-    - 'lib/cucumber/hooks.rb'
-    - 'lib/cucumber/multiline_argument/data_table.rb'
-
 # Offense count: 2
 Style/ClassVars:
   Exclude:
-    - 'lib/cucumber/formatter/html.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/ClosingParenthesisIndentation:
-  Exclude:
-    - 'spec/cucumber/cli/options_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/ColonMethodCall:
-  Exclude:
-    - 'lib/cucumber/cli/profile_loader.rb'
-
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: Keywords.
-# Keywords: TODO, FIXME, OPTIMIZE, HACK, REVIEW
-Style/CommentAnnotation:
-  Exclude:
-    - 'lib/cucumber/cli/configuration.rb'
-    - 'lib/cucumber/configuration.rb'
-    - 'lib/cucumber/formatter/legacy_api/adapter.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-Style/CommentIndentation:
-  Exclude:
-    - 'lib/cucumber/formatter/html.rb'
-    - 'spec/cucumber/world/pending_spec.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles, SingleLineConditionsOnly.
-# SupportedStyles: assign_to_condition, assign_inside_condition
-Style/ConditionalAssignment:
-  Exclude:
-    - 'lib/cucumber/runtime/for_programming_languages.rb'
-    - 'lib/cucumber/runtime/user_interface.rb'
-
-# Offense count: 1
-Style/ConstantName:
-  Exclude:
-    - 'lib/cucumber/deprecate.rb'
+   - 'lib/cucumber/formatter/html.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/lib/cucumber/cli/profile_loader.rb
+++ b/lib/cucumber/cli/profile_loader.rb
@@ -72,7 +72,7 @@ Defined profiles in cucumber.yml:
         end
 
         begin
-          @cucumber_yml = YAML::load(@cucumber_erb)
+          @cucumber_yml = YAML.load(@cucumber_erb)
         rescue StandardError
           raise(YmlLoadError,"cucumber.yml was found, but could not be parsed. Please refer to cucumber's documentation on correct profile usage.\n")
         end

--- a/lib/cucumber/deprecate.rb
+++ b/lib/cucumber/deprecate.rb
@@ -20,11 +20,11 @@ module Cucumber
       end
     end
 
-    Strategy = $0.match(/rspec$/) ? ForDevelopers : ForUsers
+    STRATEGY = $0.match(/rspec$/) ? ForDevelopers : ForUsers
   end
 
   def self.deprecate(*args)
-    Deprecate::Strategy.call(*args)
+    Deprecate::STRATEGY.call(*args)
   end
 
 end

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -366,7 +366,7 @@ module Cucumber
       def print_messages
         return if @delayed_messages.empty?
 
-        #builder.ol do
+          #builder.ol do
           @delayed_messages.each do |ann|
             builder.li(:class => 'step message') do
               builder << ann

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -612,7 +612,7 @@ module Cucumber
 
           def after
             @child.after if @child
-            # TODO - the last step result might not accurately reflect the
+            # TODO: the last step result might not accurately reflect the
             # overall scenario result.
             scenario_outline = last_step_result.scenario_outline(node.name, node.location)
             formatter.after_feature_element(scenario_outline)

--- a/lib/cucumber/formatter/legacy_api/ast.rb
+++ b/lib/cucumber/formatter/legacy_api/ast.rb
@@ -119,7 +119,7 @@ module Cucumber
           end
 
           def step_result_attributes
-            legacy_multiline_arg = if multiline_arg.kind_of?(Core::Ast::EmptyMultilineArgument)
+            legacy_multiline_arg = if multiline_arg.is_a?(Core::Ast::EmptyMultilineArgument)
                                      nil
                                    else
                                      step.multiline_arg

--- a/lib/cucumber/hooks.rb
+++ b/lib/cucumber/hooks.rb
@@ -19,7 +19,7 @@ module Cucumber
       end
 
       def after_step_hook(source, location, &block)
-        raise ArgumentError unless source.last.kind_of?(Core::Ast::Step)
+        raise ArgumentError unless source.last.is_a?(Core::Ast::Step)
         build_hook_step(source, location, block, AfterStepHook, Core::Test::Action)
       end
 

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -82,7 +82,7 @@ module Cucumber
       # @param header_mappings [Hash] see map_headers!
       # @param header_conversion_proc [Proc] see map_headers!
       def initialize(data, conversion_procs = NULL_CONVERSIONS.dup, header_mappings = {}, header_conversion_proc = nil)
-        raise ArgumentError, 'data must be a Core::Ast::DataTable' unless data.kind_of? Core::Ast::DataTable
+        raise ArgumentError, 'data must be a Core::Ast::DataTable' unless data.is_a? Core::Ast::DataTable
         ast_table = data
         # Verify that it's square
         ast_table.transpose

--- a/lib/cucumber/runtime/user_interface.rb
+++ b/lib/cucumber/runtime/user_interface.rb
@@ -33,11 +33,11 @@ module Cucumber
         STDOUT.flush
         puts(question)
 
-        if(Cucumber::JRUBY)
-          answer = jruby_gets(timeout_seconds)
-        else
-          answer = mri_gets(timeout_seconds)
-        end
+        answer = if(Cucumber::JRUBY)
+                   jruby_gets(timeout_seconds)
+                 else
+                   mri_gets(timeout_seconds)
+                 end
 
         raise("Waited for input for #{timeout_seconds} seconds, then timed out.") unless answer
         puts(answer)

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -310,7 +310,7 @@ module Cucumber
               <% $cucumber_yml_read_count += 1 %>
               default: --format pretty
               END
-              )
+                                           )
               options = Options.new(output_stream, error_stream, :default_profile => 'default')
               options.parse!(%w(-f progress))
 

--- a/spec/cucumber/world/pending_spec.rb
+++ b/spec/cucumber/world/pending_spec.rb
@@ -40,7 +40,7 @@ module Cucumber
     it 'raises a Pending if a supplied block starts working' do
       expect(-> {
         @world.pending 'TODO' do
-        # success!
+          # success!
         end
       }).to raise_error(Cucumber::Pending, /TODO/)
     end


### PR DESCRIPTION
## Summary

Fixing multiple, low offense count, cops.

## Details

* Offenses:
  * Style/ClassCheck: 3
  * Style/ClosingParenthesisIndentation: 1
  * Style/ColonMethodCall: 1
  * Style/CommentAnnotation: 1
  * Style/CommentIndentation: 2
  * Style/ConditionalAssignment: 1
  * Style/ConstantName: 1

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)