### PR TITLE
CHANGELOG updates for monorepo's #251

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Changed
 
-* As per [#251](https://github.com/cucumber/cucumber/issues/251): renamed History.md to CHANGELOG.md, added contributing message at beginning, and misc formatting.
+* As per [#251](https://github.com/cucumber/cucumber/issues/251): renamed History.md to CHANGELOG.md, added contributing message at beginning, and misc formatting. ([#1185](https://github.com/cucumber/cucumber-ruby/pull/1185) [jaysonesmith](https://github.com/jaysonesmith))
 * Use past tense in event names (`xStarting` -> `xStarted`) ([#1166](https://github.com/cucumber/cucumber-ruby/issues/1166) @brasmusson).
 * Fix Lint/DeprecatedClassMethods ([#1172(https://api.github.com/repos/cucumber/cucumber-ruby/pulls/1172) @jaysonesmith)
 * Fix Lint/DuplicateMethods ([#1173(https://api.github.com/repos/cucumber/cucumber-ruby/pulls/1173) @jaysonesmith)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,21 @@
+Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
+
 ## [In Git](https://github.com/cucumber/cucumber-ruby/compare/v3.0.0.pre.2...master) (targetting 3.0.0.pre.3)
 
 ### Breaking changes
 
-### New Features
+### Added
+
 * Handle selective strict options. ([#1169](https://github.com/cucumber/cucumber-ruby/pull/1169), [1160](https://github.com/cucumber/cucumber-ruby/issues/1160) @brasmusson)
 
-### Bugfixes
+### Fixed
+
 * Handle ambiguous steps as failed steps, when not using `--guess` ([#1132](https://github.com/cucumber/cucumber-ruby/pull/1132), [1113](https://github.com/cucumber/cucumber-ruby/issues/1113) @MadameSheema, @enkessler, @brasmusson)
 
-### Refactoring / Developer Experience
-* Use past tense in event names (`xStarting` -> `xStarted`) ([#1166](https://github.com/cucumber/cucumber-ruby/issues/1166) @brasmusson). 
+### Changed
+
+* As per [#251](https://github.com/cucumber/cucumber/issues/251): renamed History.md to CHANGELOG.md, added contributing message at beginning, and misc formatting.
+* Use past tense in event names (`xStarting` -> `xStarted`) ([#1166](https://github.com/cucumber/cucumber-ruby/issues/1166) @brasmusson).
 * Fix Lint/DeprecatedClassMethods ([#1172(https://api.github.com/repos/cucumber/cucumber-ruby/pulls/1172) @jaysonesmith)
 * Fix Lint/DuplicateMethods ([#1173(https://api.github.com/repos/cucumber/cucumber-ruby/pulls/1173) @jaysonesmith)
 * Fix Metrics/LineLength - PARTIAL - 02 ([#1175(https://api.github.com/repos/cucumber/cucumber-ruby/pulls/1175) @jaysonesmith)


### PR DESCRIPTION
## Summary

CHANGELOG.md updates as per [cucumber/cucumber #251](https://github.com/cucumber/cucumber/issues/251)

## Details

* Renamed History.md to CHANGELOG.md (did this directly against master in some dopey attempts at fixing something that wasn't broken.)
* Changed category names
* Added contributing message at top

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Documentation update
