### PR TITLE
Extract HTMLBuilder#string_to_embed method to DRY up code

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -42,10 +42,9 @@ module Cucumber
       def embed(src, mime_type, label)
         if image?(mime_type)
           src = src_is_file_or_data?(src) ? src : "data:#{standardize_mime_type(mime_type)},#{src}"
-
-          builder.embed_image(src: set_path(src), label: label, id: next_id(:img))
+          builder.embed(type: :image, src: set_path(src), label: label, id: next_id(:img))
         else
-          builder.embed_text(src: src, label: label, id: next_id(:text))
+          builder.embed(type: :text, src: src, label: label, id: next_id(:text))
         end
       end
 

--- a/lib/cucumber/formatter/html_builder.rb
+++ b/lib/cucumber/formatter/html_builder.rb
@@ -5,7 +5,15 @@ require 'pathname'
 module Cucumber
   module Formatter
     class HtmlBuilder < Builder::XmlMarkup
-      class InvalidEmbedTypeError < ::StandardError; end
+      VALID_EMBED_TYPES = [:text, :image].freeze
+
+      class InvalidEmbedTypeError < ::StandardError
+        MESSAGE = 'Invalid embed type. Valid types are :text and :image.'.freeze
+
+        def initialize(message=MESSAGE)
+          super(message)
+        end
+      end
 
       def embed(type: nil, src: nil, label: nil, id: nil)
         prepend_to_span('embed', string_to_embed(type: type, src: src, label: label, id: id))
@@ -43,7 +51,7 @@ module Cucumber
 
       def string_to_embed(type: nil, src: nil, label: nil, id: nil)
         raise ::ArgumentError, 'missing required argument' unless type && src && label && id # for Ruby 2.0 compatibility
-        raise InvalidEmbedTypeError, 'Invalid type. Valid types are :text and :image.' unless [:text, :image].include? type
+        raise InvalidEmbedTypeError unless VALID_EMBED_TYPES.include?(type)
 
         if type == :image
           %{<a href="" onclick="img=document.getElementById('#{id}'); img.style.display = (img.style.display == 'none' ? 'block' : 'none');return false">#{label}</a><br>&nbsp;

--- a/lib/cucumber/formatter/html_builder.rb
+++ b/lib/cucumber/formatter/html_builder.rb
@@ -5,20 +5,10 @@ require 'pathname'
 module Cucumber
   module Formatter
     class HtmlBuilder < Builder::XmlMarkup
-      def embed_text(src: nil, label: nil, id: nil)
-        raise ArgumentError, 'missing required argument' unless src && label && id # for Ruby 2.0 compatibility
+      class InvalidEmbedTypeError < ::StandardError; end
 
-        prepend_to_span('embed', %{<a id="#{id}" href="#{src}" title="#{label}">#{label}</a>})
-      end
-
-      def embed_image(src: nil, label: nil, id: nil)
-        raise ArgumentError, 'missing required argument' unless src && label && id # for Ruby 2.0 compatibility
-
-        prepend_to_span(
-          'embed',
-          %{<a href="" onclick="img=document.getElementById('#{id}'); img.style.display = (img.style.display == 'none' ? 'block' : 'none');return false">#{label}</a><br>&nbsp;
-            <img id="#{id}" style="display: none" src="#{src}"/>}
-        )
+      def embed(type: nil, src: nil, label: nil, id: nil)
+        prepend_to_span('embed', string_to_embed(type: type, src: src, label: label, id: id))
       end
 
       def declare!
@@ -50,6 +40,18 @@ module Cucumber
       end
 
       private
+
+      def string_to_embed(type: nil, src: nil, label: nil, id: nil)
+        raise ::ArgumentError, 'missing required argument' unless type && src && label && id # for Ruby 2.0 compatibility
+        raise InvalidEmbedTypeError, 'Invalid type. Valid types are :text and :image.' unless [:text, :image].include? type
+
+        if type == :image
+          %{<a href="" onclick="img=document.getElementById('#{id}'); img.style.display = (img.style.display == 'none' ? 'block' : 'none');return false">#{label}</a><br>&nbsp;
+          <img id="#{id}" style="display: none" src="#{src}"/>}
+        else
+          %{<a id="#{id}" href="#{src}" title="#{label}">#{label}</a>}
+        end
+      end
 
       def summary_div
         div(id: 'summary') do

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -355,7 +355,7 @@ module Cucumber
 
         describe 'with a step that embeds a text' do
           define_steps do
-            Given(/log/) { embed('log.txt', 'text/plain') }
+            Given(/log/) { embed('log.txt', 'text/plain', 'foo') }
           end
 
           define_feature(<<-FEATURE)


### PR DESCRIPTION
## Summary

This PR builds on #1138, DRYing up some code in the `Formatter::HTMLBuilder` class in response to CodeClimate analysis.

## Details

I extracted the `Formatter::HTMLBuilder#string_to_embed` private method to deduplicate code in the `Formatter::HTMLBuilder#embed_string` and `Formatter::HTMLBuilder#embed_image` methods. These methods have been combined into a single `Formatter::HTMLBuilder#embed` method, which is called from the HTML formatter class.

## Motivation and Context

After #1138 got merged, I saw that the class still had a low rating in CodeClimate. I wanted to keep quality high, at least for my own code, so I made some of the changes CodeClimate suggested.

## How Has This Been Tested?

Since this is a refactor, it didn't require additional tests. I just made sure that the existing tests passed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactor (code change that does not modify external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- ~~[ ] I've added tests for my code~~
- ~~[ ] My change requires a change to the documentation.~~
- ~~[ ] I have updated the documentation accordingly.~~
