### PR TITLE
Fix for issue: #1199: Changed DataTable#symbolic_hashes to not change the state of the table

### DIFF
--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -159,8 +159,10 @@ module Cucumber
       #   [{:foo => '2', :bar => '3', :foo_bar => '5'}, {:foo => '7', :bar => '9', :foo_bar => '16'}]
       #
       def symbolic_hashes
-        @header_conversion_proc = lambda { |h| symbolize_key(h) }
-        @symbolic_hashes ||= build_hashes
+        @symbolic_hashes ||=
+          self.hashes.map do |string_hash|
+            Hash[string_hash.map{ |a,b| [symbolize_key(a), b] }]
+          end
       end
 
       # Converts this table into a Hash where the first column is

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -53,6 +53,11 @@ module Cucumber
           expect{@table.symbolic_hashes}.to_not raise_error
         end
 
+        it 'should not interfere with use of #hashes' do
+          @table.symbolic_hashes
+          expect{@table.hashes}.to_not raise_error
+        end
+
       end
 
       describe '#map_column!' do


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

DataTable#symbolic_hashes will no longer set the instance variable `@header_conversion_proc` but instead will act in a similar manner to DataTable#hashes except returning a new array of hashes with symbolic keys.

## Details

Changed DataTable#symbolic_hashes to call DataTable#hashes and then map the return value to a new hash with all keys changed to symbols using the method DataTable#symbolize_key(key).

## Motivation and Context

Solves the issue reported here #1199 

## How Has This Been Tested?

Added the following test: `spec/cucumber/multiline_argument/data_table_spec.rb`.  This is intended to ensure that after using DataTable#symbolic_hashes, no error is raised when using DataTable#hashes (see issue: #1199 )

The test only been run in the following environments so far:
 - Ruby 2.3.0 using `bundle exec rake`

## Types of changes

- [x] Refactor (code change that does not change external functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
