### PR TITLE
Spec: Always include spec_helper

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+-r spec_helper

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'yaml'
 
 module Cucumber

--- a/spec/cucumber/cli/main_spec.rb
+++ b/spec/cucumber/cli/main_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'yaml'
 
 module Cucumber

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'yaml'
 require 'cucumber/cli/options'
 

--- a/spec/cucumber/cli/profile_loader_spec.rb
+++ b/spec/cucumber/cli/profile_loader_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'yaml'
 
 module Cucumber

--- a/spec/cucumber/cli/rerun_spec.rb
+++ b/spec/cucumber/cli/rerun_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'spec_helper'
 
 module Cucumber
   module Cli

--- a/spec/cucumber/configuration_spec.rb
+++ b/spec/cucumber/configuration_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'spec_helper'
 
 module Cucumber
   describe Configuration do

--- a/spec/cucumber/constantize_spec.rb
+++ b/spec/cucumber/constantize_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'spec_helper'
 
 module Html end
 

--- a/spec/cucumber/formatter/ansicolor_spec.rb
+++ b/spec/cucumber/formatter/ansicolor_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/formatter/ansicolor'
 
 module Cucumber

--- a/spec/cucumber/formatter/duration_spec.rb
+++ b/spec/cucumber/formatter/duration_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/formatter/duration'
 
 module Cucumber

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/formatter/spec_helper'
 require 'cucumber/formatter/html'
 require 'nokogiri'

--- a/spec/cucumber/formatter/interceptor_spec.rb
+++ b/spec/cucumber/formatter/interceptor_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/formatter/interceptor'
 
 module Cucumber::Formatter

--- a/spec/cucumber/formatter/json_spec.rb
+++ b/spec/cucumber/formatter/json_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/formatter/spec_helper'
 require 'cucumber/formatter/json'
 require 'cucumber/cli/options'

--- a/spec/cucumber/formatter/junit_spec.rb
+++ b/spec/cucumber/formatter/junit_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/formatter/spec_helper'
 
 require 'cucumber/formatter/junit'

--- a/spec/cucumber/formatter/legacy_api/adapter_spec.rb
+++ b/spec/cucumber/formatter/legacy_api/adapter_spec.rb
@@ -6,7 +6,7 @@ require 'cucumber/runtime/step_hooks'
 require 'cucumber/runtime/before_hooks'
 require 'cucumber/runtime/after_hooks'
 require 'cucumber/filters'
-require 'spec_helper'
+
 
 module Cucumber
   module Formatter::LegacyApi

--- a/spec/cucumber/formatter/pretty_spec.rb
+++ b/spec/cucumber/formatter/pretty_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/formatter/spec_helper'
 require 'cucumber/formatter/pretty'
 require 'cucumber/cli/options'

--- a/spec/cucumber/formatter/progress_spec.rb
+++ b/spec/cucumber/formatter/progress_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/formatter/spec_helper'
 require 'cucumber/formatter/progress'
 require 'cucumber/cli/options'

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/formatter/spec_helper'
 require 'cucumber/formatter/pretty'
 

--- a/spec/cucumber/glue/registry_and_more_spec.rb
+++ b/spec/cucumber/glue/registry_and_more_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/glue/registry_and_more'
 
 module Cucumber

--- a/spec/cucumber/glue/snippet_spec.rb
+++ b/spec/cucumber/glue/snippet_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/cucumber_expressions/parameter_type_registry'
 require 'cucumber/cucumber_expressions/parameter_type'
 require 'cucumber/cucumber_expressions/cucumber_expression_generator'

--- a/spec/cucumber/glue/step_definition_spec.rb
+++ b/spec/cucumber/glue/step_definition_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/glue/registry_and_more'
 
 module Cucumber

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/multiline_argument/data_table'
 
 module Cucumber

--- a/spec/cucumber/project_initializer_spec.rb
+++ b/spec/cucumber/project_initializer_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'tmpdir'
 
 module Cucumber

--- a/spec/cucumber/rake/forked_spec.rb
+++ b/spec/cucumber/rake/forked_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/rake/task'
 require 'rake'
 

--- a/spec/cucumber/rake/task_spec.rb
+++ b/spec/cucumber/rake/task_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/rake/task'
 require 'rake'
 

--- a/spec/cucumber/runtime/for_programming_languages_spec.rb
+++ b/spec/cucumber/runtime/for_programming_languages_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'spec_helper'
 
 module Cucumber
   describe Runtime::ForProgrammingLanguages do

--- a/spec/cucumber/runtime/support_code_spec.rb
+++ b/spec/cucumber/runtime/support_code_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 
 module Cucumber
   describe Runtime::SupportCode do

--- a/spec/cucumber/runtime_spec.rb
+++ b/spec/cucumber/runtime_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'spec_helper'
 
 module Cucumber
   describe Runtime do

--- a/spec/cucumber/step_argument_spec.rb
+++ b/spec/cucumber/step_argument_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/step_argument'
 
 module Cucumber

--- a/spec/cucumber/step_match_spec.rb
+++ b/spec/cucumber/step_match_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/glue/step_definition'
 require 'cucumber/glue/registry_and_more'
 

--- a/spec/cucumber/world/pending_spec.rb
+++ b/spec/cucumber/world/pending_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+
 require 'cucumber/glue/registry_and_more'
 require 'cucumber/configuration'
 


### PR DESCRIPTION
## Summary

This PR does one thing: uses the options file `.rspec` to _always_ include `spec_helper`. Also: removes the `require 'spec_helper'` from each spec file which has it.

## Details

I was asking myself: "Do we pay any special cost for having the spec helper in each file?" and "Can we have one `require` instead of 30?"

## Motivation and Context

"Can we have one `require` instead of 30?"

## How Has This Been Tested?

Ran the test suite locally.

## Types of changes

- [x] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

