### PR TITLE
Fixes rubocop violation Lint/AmbiguousOperator

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,15 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 8
-Lint/AmbiguousOperator:
-  Exclude:
-    - 'lib/cucumber/formatter/legacy_api/adapter.rb'
-    - 'lib/cucumber/multiline_argument/data_table.rb'
-    - 'lib/cucumber/running_test_case.rb'
-    - 'spec/cucumber/formatter/legacy_api/adapter_spec.rb'
-    - 'spec/cucumber/formatter/spec_helper.rb'
-
 # Offense count: 2
 Lint/Eval:
   Exclude:

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -303,7 +303,7 @@ module Cucumber
           end
 
           def puts(messages)
-            @delayed_messages.push *messages
+            @delayed_messages.push(*messages)
           end
 
           def embed(src, mime_type, label)
@@ -329,7 +329,7 @@ module Cucumber
           private :before_hook_results
 
           def any_test_steps_failed?
-            @test_step_results.any? &:failed?
+            @test_step_results.any?(&:failed?)
           end
 
           def switch_step_container(source = current_test_step_source)

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -205,7 +205,7 @@ module Cucumber
 
       def rows
         hashes.map do |hash|
-          hash.values_at *headers
+          hash.values_at(*headers)
         end
       end
 

--- a/lib/cucumber/running_test_case.rb
+++ b/lib/cucumber/running_test_case.rb
@@ -81,7 +81,7 @@ module Cucumber
       end
 
       def source_tag_names
-        tags.map &:name
+        tags.map(&:name)
       end
 
       def outline?

--- a/spec/cucumber/formatter/legacy_api/adapter_spec.rb
+++ b/spec/cucumber/formatter/legacy_api/adapter_spec.rb
@@ -28,7 +28,7 @@ module Cucumber
         end
 
         def activate(test_step)
-          test_step.with_action &@block
+          test_step.with_action(&@block)
         end
       end
 

--- a/spec/cucumber/formatter/spec_helper.rb
+++ b/spec/cucumber/formatter/spec_helper.rb
@@ -73,7 +73,7 @@ module Cucumber
         return unless step_defs
         dsl = Object.new
         dsl.extend Glue::Dsl
-        dsl.instance_exec &step_defs
+        dsl.instance_exec(&step_defs)
       end
 
       def options


### PR DESCRIPTION
## Summary
Fixes rubocop violation Lint/AmbiguousOperator.

## Details
Method arguments have been parenthesised when using block operators or splat operators.

## Motivation and Context
This change is required to satisfy the ruboxop requirement related to Lint/AmbiguousOperator.
Refs #1021 

## How Has This Been Tested?
No new tests. Existing tests are green (with bundle exec rake). Rubocop is happy.

## Screenshots (if appropriate):
N/A.

## Types of changes
- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Rubocop fix.

## Checklist:
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
