### PR TITLE
Remove Transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Breaking changes
 
-None so far...
+* `Transform` has been removed and replaced with `ParameterType`. See [upgrading instructions](https://cucumber.io/blog/2017/09/21/upgrading-to-cucumber-3). ([#1190](https://github.com/cucumber/cucumber-ruby/issues/1190) @aslakhellesoy)
+* Nested capture groups are not counted as parameters. See [upgrading instructions](https://cucumber.io/blog/2017/09/21/upgrading-to-cucumber-3). (@aslakhellesoy)
 
 ### Added
 

--- a/features/docs/writing_support_code/parameter_types.feature
+++ b/features/docs/writing_support_code/parameter_types.feature
@@ -51,20 +51,3 @@ Feature: Parameter Types
       """
     When I run `cucumber features/foo.feature`
     Then it should pass
-
-  Scenario: Parameter type defined with legacy Transform method
-    This is for backwards compatibility - works with regular expressions,
-    but not with Cucumber Expressions, because no name is specified for the
-    parameter type.
-
-    Given a file named "features/support/transforms.rb" with:
-      """
-      Transform(/[A-Z]\w+/) do |name|
-        Person.new(name)
-      end
-      """
-    When I run `cucumber features/foo.feature`
-    Then it should fail with:
-      """
-      Undefined parameter type {person}
-      """

--- a/lib/cucumber/glue/dsl.rb
+++ b/lib/cucumber/glue/dsl.rb
@@ -86,28 +86,6 @@ module Cucumber
         Dsl.register_rb_hook('after_step', tag_expressions, proc)
       end
 
-      # Registers a proc that will be called with a step definition argument if it
-      # matches the pattern passed as the first argument to Transform. Alternatively, if
-      # the pattern contains captures then they will be yielded as arguments to the
-      # provided proc. The return value of the proc is consequently yielded to the
-      # step definition.
-      def Transform(regexp, &proc)
-        Cucumber.deprecate(
-          'Use ParameterType(...) instead',
-          'Transform',
-          '3.0'
-        )
-        parameter_type = CucumberExpressions::ParameterType.new(
-          regexp.to_s,
-          regexp,
-          Object,
-          proc,
-          false,
-          true
-        )
-        Dsl.define_parameter_type(parameter_type)
-      end
-
       def ParameterType(options)
         type = options[:type] || Object
         use_for_snippets = true if options[:use_for_snippets].nil?

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -10,11 +10,6 @@ module Cucumber
     # make sense in your domain. For more on that, see {Cucumber::Glue::Dsl#World}
     module ProtoWorld
 
-      # Call a Transform with a string from another Transform definition
-      def Transform(arg)
-        super
-      end
-
       # Run a single Gherkin step
       # @example Call another step
       #   step "I am logged in"


### PR DESCRIPTION
As I've argued in https://github.com/cucumber/cucumber-ruby/issues/1190 we should remove `Transform` rather than deprecating it. My position is that deprecated functionality should satisfy all of the following:

* work as before deprecation
* provide users with an alternative API in the same version
* no longer issue warnings when the alternative API is used

We can't do all of these in a 2.x release, so we should remove in 3.0, and not deprecate in 2.x.