### PR TITLE
RuboCop: skip vendor directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,4 @@ AllCops:
   DisplayStyleGuide: true
   Exclude:
     - 'tmp/**/*'
+    - 'vendor/**/*'


### PR DESCRIPTION
~This PR changes the Travis CI configuration to:~

 - ~**skip** `gem update --system`. This is now done by the `rvm` package manager, built-in.~
 - ~cache bundler~
- **skip** vendor directories in `rubocop` (now that they're cached)

The goal is: quicker builds.

~Travis is~ now 💚 