### PR TITLE
CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
-          - v1-dependencies-
+          - bundle-{{ checksum "Gemfile.lock" }}
       - run:
           name: install dependencies
           command: |
@@ -22,7 +21,7 @@ jobs:
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+          key: bundle-{{ checksum "Gemfile.lock" }}
       - run:
           name: Run RSpec
           command: bundle exec rake spec
@@ -38,8 +37,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
-          - v1-dependencies-
+          - bundle-{{ checksum "Gemfile.lock" }}
       - run:
           name: install dependencies
           command: |
@@ -47,7 +45,7 @@ jobs:
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+          key: bundle-{{ checksum "Gemfile.lock" }}
       - run:
           name: Run RSpec
           command: bundle exec rake spec
@@ -63,8 +61,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
-          - v1-dependencies-
+          - bundle-{{ checksum "Gemfile.lock" }}
       - run:
           name: install dependencies
           command: |
@@ -72,7 +69,7 @@ jobs:
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+          key: bundle-{{ checksum "Gemfile.lock" }}
       - run:
           name: Run RSpec
           command: bundle exec rake spec
@@ -88,8 +85,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
-          - v1-dependencies-
+          - bundle-{{ checksum "Gemfile.lock" }}
       - run:
           name: install dependencies
           command: |
@@ -97,7 +93,7 @@ jobs:
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+          key: bundle-{{ checksum "Gemfile.lock" }}
       - run:
           name: Run RSpec
           command: bundle exec rake spec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,9 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      # Download and cache dependencies
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "Gemfile.lock" }}
-          # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
       - run:
           name: install dependencies
@@ -38,11 +36,59 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      # Download and cache dependencies
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "Gemfile.lock" }}
-          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Run RSpec
+          command: bundle exec rake spec
+      - run:
+          name: Run Cucumber
+          command: bundle exec rake cucumber
+
+  "ruby-2.2.8":
+    docker:
+       - image: circleci/ruby:2.2.8
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Run RSpec
+          command: bundle exec rake spec
+      - run:
+          name: Run Cucumber
+          command: bundle exec rake cucumber
+
+  "jruby-9.1.13.0":
+    docker:
+       - image: jruby:9.1.13.0-jdk-alpine
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
           - v1-dependencies-
       - run:
           name: install dependencies
@@ -65,3 +111,5 @@ workflows:
     jobs:
       - "ruby-2.4.1"
       - "ruby-2.3.5"
+      - "ruby-2.2.8"
+      - "jruby-9.1.13.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,38 @@ jobs:
             - ./vendor/bundle
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
-          name: Run Rake
-          command: bundle exec rake
+          name: Run RSpec
+          command: bundle exec rake spec
+      - run:
+          name: Run Cucumber
+          command: bundle exec rake cucumber
+
+  "ruby-2.3.5":
+    docker:
+       - image: circleci/ruby:2.3.5
+    working_directory: ~/repo
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Run RSpec
+          command: bundle exec rake spec
+      - run:
+          name: Run Cucumber
+          command: bundle exec rake cucumber
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,51 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  "2.4.1":
+    docker:
+       - image: circleci/ruby:2.4.1
+    working_directory: ~/repo
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            mkdir /tmp/test-results
+            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
+
+            bundle exec rspec --format progress \
+                            --format RspecJunitFormatter \
+                            --out /tmp/test-results/rspec.xml \
+                            --format progress \
+                            "${TEST_FILES}"
+
+            bundle exec cucumber --format progress \
+                            --format RspecJunitFormatter \
+                            --out /tmp/test-results/rspec.xml \
+                            --format progress \
+                            "${TEST_FILES}"
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,29 +29,3 @@ jobs:
           name: Run RSpec
           command: |
             bundle exec rake
-
-  "2.3.5":
-    docker:
-       - image: circleci/ruby:2.3.5
-    working_directory: ~/repo
-    steps:
-      - checkout
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
-      - run:
-          name: install dependencies
-          command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
-      - save_cache:
-          paths:
-            - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
-
-      - type: shell
-          name: Run RSpec
-          command: |
-            bundle exec rake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,23 +24,34 @@ jobs:
           paths:
             - ./vendor/bundle
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
-      # run tests!
-      - run:
-          name: run tests
+
+      - type: shell
+          name: Run RSpec
           command: |
-            mkdir /tmp/test-results
-            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
+            bundle exec rake
 
-            bundle exec rspec --format progress \
-                            --format RspecJunitFormatter \
-                            --out /tmp/test-results/rspec.xml \
-                            "${TEST_FILES}"
+  "2.3.5":
+    docker:
+       - image: circleci/ruby:2.3.5
+    working_directory: ~/repo
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
 
-            bundle exec cucumber
-
-      # collect reports
-      - store_test_results:
-          path: /tmp/test-results
-      - store_artifacts:
-          path: /tmp/test-results
-          destination: test-results
+      - type: shell
+          name: Run RSpec
+          command: |
+            bundle exec rake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,14 +34,9 @@ jobs:
             bundle exec rspec --format progress \
                             --format RspecJunitFormatter \
                             --out /tmp/test-results/rspec.xml \
-                            --format progress \
                             "${TEST_FILES}"
 
-            bundle exec cucumber --format progress \
-                            --format RspecJunitFormatter \
-                            --out /tmp/test-results/rspec.xml \
-                            --format progress \
-                            "${TEST_FILES}"
+            bundle exec cucumber
 
       # collect reports
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  "2.4.1":
+  "ruby-2.4.1":
     docker:
        - image: circleci/ruby:2.4.1
     working_directory: ~/repo
@@ -29,3 +29,37 @@ jobs:
           name: Run RSpec
           command: |
             bundle exec rake
+
+  "ruby-2.3.5":
+    docker:
+       - image: circleci/ruby:2.3.5
+    working_directory: ~/repo
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+
+      - type: shell
+          name: Run RSpec
+          command: |
+            bundle exec rake
+
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - "ruby-2.4.1"
+      - "ruby-2.3.5"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.0
+
 jobs:
   "ruby-2.4.1":
     docker:
@@ -24,38 +25,9 @@ jobs:
           paths:
             - ./vendor/bundle
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
-
-      - type: shell
-          name: Run RSpec
-          command: |
-            bundle exec rake
-
-  "ruby-2.3.5":
-    docker:
-       - image: circleci/ruby:2.3.5
-    working_directory: ~/repo
-    steps:
-      - checkout
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
       - run:
-          name: install dependencies
-          command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
-      - save_cache:
-          paths:
-            - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
-
-      - type: shell
-          name: Run RSpec
-          command: |
-            bundle exec rake
-
+          name: Run Rake
+          command: bundle exec rake
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ rerun.txt
 .sass-cache
 doc/
 *.tgz
-Gemfile.lock
 tags
 .ruby-version
 .project

--- a/Gemfile
+++ b/Gemfile
@@ -1,28 +1,20 @@
-gem 'cucumber-pro', '0.0.13', :group => :test
 source 'https://rubygems.org'
 gemspec
-load File.expand_path('../Gemfile.local', __FILE__) if File.file? File.expand_path('../Gemfile.local', __FILE__)
 
-unless ENV['CUCUMBER_USE_RELEASED_CORE']
-  core_path = File.expand_path('../../cucumber-ruby-core', __FILE__)
-  wire_path = File.expand_path('../../cucumber-ruby-wire', __FILE__)
-  if File.exist?(core_path) && !ENV['CUCUMBER_USE_GIT_CORE']
-    gem 'cucumber-core', :path => core_path
-  else
-    gem 'cucumber-core', :git => 'https://github.com/cucumber/cucumber-ruby-core.git'
-  end
-
-  if File.exist?(wire_path) && !ENV['CUCUMBER_USE_GIT_WIRE']
-    gem 'cucumber-wire', :path => wire_path
-  else
-    gem 'cucumber-wire', :git => 'https://github.com/cucumber/cucumber-ruby-wire.git'
-  end
-
-  if ENV['CUCUMBER_EXPRESSIONS']
-    gem 'cucumber-expressions', :path => ENV['CUCUMBER_EXPRESSIONS']
-  else
-    gem 'cucumber-expressions', :git => 'https://github.com/cucumber/cucumber-expressions-ruby.git'
-  end
+if ENV['CUCUMBER_RUBY_WIRE']
+  gem 'cucumber-core', :path => ENV['CUCUMBER_RUBY_WIRE']
+else
+  gem 'cucumber-core', :git => 'https://github.com/cucumber/cucumber-ruby-core.git'
 end
 
-gem 'mime-types', '~>2.99'
+if ENV['CUCUMBER_RUBY_WIRE']
+  gem 'cucumber-wire', :path => ENV['CUCUMBER_RUBY_WIRE']
+else
+  gem 'cucumber-wire', :git => 'https://github.com/cucumber/cucumber-ruby-wire.git'
+end
+
+if ENV['CUCUMBER_EXPRESSIONS_RUBY']
+  gem 'cucumber-expressions', :path => ENV['CUCUMBER_EXPRESSIONS_RUBY']
+else
+  gem 'cucumber-expressions', :git => 'https://github.com/cucumber/cucumber-expressions-ruby.git'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -3,18 +3,12 @@ gemspec
 
 if ENV['CUCUMBER_RUBY_CORE']
   gem 'cucumber-core', :path => ENV['CUCUMBER_RUBY_CORE']
-else
-  gem 'cucumber-core', :git => 'https://github.com/cucumber/cucumber-ruby-core.git'
 end
 
 if ENV['CUCUMBER_RUBY_WIRE']
   gem 'cucumber-wire', :path => ENV['CUCUMBER_RUBY_WIRE']
-else
-  gem 'cucumber-wire', :git => 'https://github.com/cucumber/cucumber-ruby-wire.git'
 end
 
 if ENV['CUCUMBER_EXPRESSIONS_RUBY']
   gem 'cucumber-expressions', :path => ENV['CUCUMBER_EXPRESSIONS_RUBY']
-else
-  gem 'cucumber-expressions', :git => 'https://github.com/cucumber/cucumber-expressions-ruby.git'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 gemspec
 
-if ENV['CUCUMBER_RUBY_WIRE']
-  gem 'cucumber-core', :path => ENV['CUCUMBER_RUBY_WIRE']
+if ENV['CUCUMBER_RUBY_CORE']
+  gem 'cucumber-core', :path => ENV['CUCUMBER_RUBY_CORE']
 else
   gem 'cucumber-core', :git => 'https://github.com/cucumber/cucumber-ruby-core.git'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,169 @@
+GIT
+  remote: https://github.com/cucumber/cucumber-expressions-ruby.git
+  revision: b8b250c098e18a56181cc1e1a17405964e9b3120
+  specs:
+    cucumber-expressions (4.0.3)
+
+GIT
+  remote: https://github.com/cucumber/cucumber-ruby-core.git
+  revision: 852a133cd565ebf73c256c2001767b899b30b8f0
+  specs:
+    cucumber-core (3.0.0)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (>= 1.0.1)
+      gherkin (>= 4.1.3)
+
+GIT
+  remote: https://github.com/cucumber/cucumber-ruby-wire.git
+  revision: 6395397df9558e6edbb129ebb4cda755ae5d7440
+  specs:
+    cucumber-wire (0.0.1)
+
+PATH
+  remote: .
+  specs:
+    cucumber (3.0.1)
+      builder (>= 2.1.2)
+      cucumber-core (~> 3.0.0)
+      cucumber-expressions (~> 4.0.3)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (~> 1.3)
+      gherkin (~> 4.0)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    aruba (0.6.2)
+      childprocess (>= 0.3.6)
+      cucumber (>= 1.1.1)
+      rspec-expectations (>= 2.7.0)
+    ast (2.3.0)
+    backports (3.8.0)
+    bcat (0.6.2)
+      rack (~> 1.0)
+    builder (3.2.3)
+    capybara (2.15.1)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    childprocess (0.8.0)
+      ffi (~> 1.0, >= 1.0.11)
+    coderay (1.1.2)
+    coveralls (0.8.21)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.14.1)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.4)
+      tins (~> 1.6)
+    cucumber-tag_expressions (1.0.1)
+    diff-lcs (1.3)
+    docile (1.1.5)
+    faraday (0.13.1)
+      multipart-post (>= 1.2, < 3)
+    ffi (1.9.18)
+    gherkin (4.1.3)
+    json (1.8.6)
+    kramdown (0.14.2)
+    method_source (0.9.0)
+    mini_mime (0.1.4)
+    mini_portile2 (2.3.0)
+    multi_json (1.12.2)
+    multi_test (0.1.2)
+    multipart-post (2.0.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
+    octokit (4.7.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    parser (2.4.0.0)
+      ast (~> 2.2)
+    powerpack (0.1.1)
+    pry (0.11.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    public_suffix (3.0.0)
+    rack (1.6.8)
+    rack-protection (1.5.3)
+      rack
+    rack-test (0.7.0)
+      rack (>= 1.0, < 3)
+    rainbow (2.2.2)
+      rake
+    rake (12.1.0)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
+    rubocop (0.40.0)
+      parser (>= 2.3.1.0, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    simplecov (0.14.1)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    syntax (1.2.2)
+    term-ansicolor (1.6.0)
+      tins (~> 1.0)
+    thor (0.19.4)
+    tilt (2.0.8)
+    tins (1.15.0)
+    unicode-display_width (1.3.0)
+    xpath (2.1.0)
+      nokogiri (~> 1.3)
+    yard (0.8.7.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  aruba (~> 0.6.1)
+  bcat (~> 0.6.2)
+  capybara (>= 2.1)
+  coveralls (~> 0.7)
+  cucumber!
+  cucumber-core!
+  cucumber-expressions!
+  cucumber-wire!
+  json (~> 1.8.6)
+  kramdown (~> 0.14)
+  nokogiri (~> 1.8.1)
+  octokit
+  pry
+  rack-test (>= 0.6.1)
+  rake (>= 0.9.2)
+  rspec (>= 3.6)
+  rubocop (~> 0.40.0)
+  simplecov (>= 0.6.2)
+  sinatra (>= 1.3.2)
+  syntax (>= 1.0.0)
+  yard (~> 0.8.0)
+
+BUNDLED WITH
+   1.15.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,7 @@ PLATFORMS
 DEPENDENCIES
   aruba (~> 0.6.1)
   bcat (~> 0.6.2)
+  bundler (~> 1.15.4)
   capybara (>= 2.1)
   coveralls (~> 0.7)
   cucumber!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,3 @@
-GIT
-  remote: https://github.com/cucumber/cucumber-expressions-ruby.git
-  revision: b8b250c098e18a56181cc1e1a17405964e9b3120
-  specs:
-    cucumber-expressions (4.0.3)
-
-GIT
-  remote: https://github.com/cucumber/cucumber-ruby-core.git
-  revision: 852a133cd565ebf73c256c2001767b899b30b8f0
-  specs:
-    cucumber-core (3.0.0)
-      backports (>= 3.8.0)
-      cucumber-tag_expressions (>= 1.0.1)
-      gherkin (>= 4.1.3)
-
-GIT
-  remote: https://github.com/cucumber/cucumber-ruby-wire.git
-  revision: 6395397df9558e6edbb129ebb4cda755ae5d7440
-  specs:
-    cucumber-wire (0.0.1)
-
 PATH
   remote: .
   specs:
@@ -62,7 +41,13 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.4)
       tins (~> 1.6)
+    cucumber-core (3.0.0)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (>= 1.0.1)
+      gherkin (>= 4.1.3)
+    cucumber-expressions (4.0.3)
     cucumber-tag_expressions (1.0.1)
+    cucumber-wire (0.0.1)
     diff-lcs (1.3)
     docile (1.1.5)
     faraday (0.13.1)
@@ -148,9 +133,6 @@ DEPENDENCIES
   capybara (>= 2.1)
   coveralls (~> 0.7)
   cucumber!
-  cucumber-core!
-  cucumber-expressions!
-  cucumber-wire!
   json (~> 1.8.6)
   kramdown (~> 0.14)
   nokogiri (~> 1.8.1)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Join the chat at https://gitter.im/cucumber/cucumber-ruby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/cucumber/cucumber-ruby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 [![CircleCI](https://circleci.com/gh/cucumber/cucumber-ruby.svg?style=svg)](https://circleci.com/gh/cucumber/cucumber-ruby)
 [![Build Status](https://travis-ci.org/cucumber/cucumber-ruby.svg?branch=master)](https://travis-ci.org/cucumber/cucumber-ruby)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/ncqhcevrv93hhu5j?svg=true)](https://ci.appveyor.com/project/cucumberbdd/cucumber-ruby)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Join the chat at https://gitter.im/cucumber/cucumber-ruby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/cucumber/cucumber-ruby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![CircleCI](https://circleci.com/gh/cucumber/cucumber-ruby.svg?style=svg)](https://circleci.com/gh/cucumber/cucumber-ruby)
 [![Build Status](https://travis-ci.org/cucumber/cucumber-ruby.svg?branch=master)](https://travis-ci.org/cucumber/cucumber-ruby)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/ncqhcevrv93hhu5j?svg=true)](https://ci.appveyor.com/project/cucumberbdd/cucumber-ruby)
 
@@ -9,7 +10,7 @@
 # Cucumber
 
 Cucumber is a tool for running automated tests written in plain language. Because they're
-written in plain language, they can be read by anyone on your team. Because they can be 
+written in plain language, they can be read by anyone on your team. Because they can be
 read by anyone, you can use them to help improve communication, collaboration and trust on
 your team.
 

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |s|
     'LICENSE',
     'lib/**/*'
   ]
-  s.executables      = ['bin/cucumber']
+  s.executables      = ['cucumber']
   s.rdoc_options     = ['--charset=UTF-8']
   s.require_path     = 'lib'
 end

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -44,11 +44,14 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sinatra', '>= 1.3.2'
 
   s.rubygems_version = '>= 1.6.1'
-  s.files            = `git ls-files`.split("\n").reject do |path|
-    path =~ /\.gitignore$/ || path =~ /Gemfile\.lock/
-  end
-  s.test_files       = `git ls-files -- {spec,features}/*`.split("\n")
-  s.executables      = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files            = Dir[
+    'CHANGELOG.md',
+    'CONTRIBUTING.md',
+    'README.md',
+    'LICENSE',
+    'lib/**/*'
+  ]
+  s.executables      = ['bin/cucumber']
   s.rdoc_options     = ['--charset=UTF-8']
   s.require_path     = 'lib'
 end

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'aruba', '~> 0.6.1'
   s.add_development_dependency 'json', '~> 1.8.6'
-  s.add_development_dependency 'nokogiri', '~> 1.5'
+  s.add_development_dependency 'nokogiri', '~> 1.8.1'
   s.add_development_dependency 'rake', '>= 0.9.2'
-  s.add_development_dependency 'rspec', '>= 3.0'
+  s.add_development_dependency 'rspec', '>= 3.6'
   s.add_development_dependency 'simplecov', '>= 0.6.2'
   s.add_development_dependency 'coveralls', '~> 0.7'
   s.add_development_dependency 'syntax', '>= 1.0.0'

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cucumber-wire', '~> 0.0.1'
   s.add_dependency 'cucumber-expressions', '~> 4.0.3'
 
+  s.add_development_dependency 'bundler', '~> 1.15.4'
   s.add_development_dependency 'aruba', '~> 0.6.1'
   s.add_development_dependency 'json', '~> 1.8.6'
   s.add_development_dependency 'nokogiri', '~> 1.8.1'

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -44,7 +44,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sinatra', '>= 1.3.2'
 
   s.rubygems_version = '>= 1.6.1'
-  s.files            = `git ls-files`.split("\n").reject {|path| path =~ /\.gitignore$/ }
+  s.files            = `git ls-files`.split("\n").reject do |path|
+    path =~ /\.gitignore$/ || path =~ /Gemfile\.lock/
+  end
   s.test_files       = `git ls-files -- {spec,features}/*`.split("\n")
   s.executables      = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.rdoc_options     = ['--charset=UTF-8']


### PR DESCRIPTION
The travis build currently takes over 40 minutes to give us feedback.

I set up [CircleCI](https://circleci.com/gh/cucumber/cucumber-ruby) and feedback time is now down to a couple of minutes.

As part of doing this I also simplified the `Gemfile` (changed the mechanism for using local dependencies).

The `Gemfile.lock` is now checked in, which allows CircleCI to cache gems and speed up the build. It's excluded from the built gem.

The `cucumber.gemspec` no longer runs git to list all files. The jruby docker image doesn't have git, and we shouldn't assume anyone has git. Not running git is also faster.