### PR TITLE
Change test expectation to handle Ruby's unstable sorting

### DIFF
--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -290,7 +290,7 @@ END_OF_MESSAGE
     it 'associates --out to previous --format' do
       config.parse!(%w{--format progress --out file1 --format profile --out file2})
 
-      expect(config.formats).to eq [['progress', {}, 'file1'], ['profile', {}, 'file2']]
+      expect(config.formats).to match_array([['progress', {}, 'file1'], ['profile', {}, 'file2']])
     end
 
     it 'accepts same --format options with same --out streams and keep only one' do
@@ -302,7 +302,7 @@ END_OF_MESSAGE
     it 'accepts same --format options with different --out streams' do
       config.parse!(%w{--format html --out file1 --format html --out file2})
 
-      expect(config.formats).to eq [['html', {}, 'file1'], ['html', {}, 'file2']]
+      expect(config.formats).to match_array([['html', {}, 'file1'], ['html', {}, 'file2']])
     end
 
     it 'accepts --color option' do


### PR DESCRIPTION
## Summary

Paraphrasing @enkessler who helped me pin down what was going on here (thanks!): Ruby doesn't guarantee the sort order of `sort` or `sort_by` if the objects have the same comparison value.

## Details

Unfortunately, the test data we were using falls under the scenario above and it was causing a couple tests to fail on my machine. `[['progress', {}, 'file1'], ['profile', {}, 'file2']]` was going through a sort_by that should not have changed the output order of the arrays, but instead the following was being returned: `[['profile', {}, 'file2'], ['progress', {}, 'file1']]`

Instead of using rspec's `eq` check, I've changed the tests to use `match_array.`

## Motivation and Context

Fixing this primarily to allow me to dev on my Windows machine at home, but could also be extended to helping prevent this type of error from happening in the future.

## How Has This Been Tested?

`bundle exec rake` passes with no errors! :+1: 

## Screenshots (if appropriate):

## Types of changes

- [x] Refactor (code change that does not change external functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
