### PR TITLE
Fix html reporter with more than one embedded screenshot

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -399,7 +399,7 @@ module Cucumber
       def next_id(type)
         @indices ||= Hash.new { 0 }
         @indices[type] += 1
-        "#{type}_#{@indices[:type]}"
+        "#{type}_#{@indices[type]}"
       end
 
       def build_exception_detail(exception)

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -33,12 +33,15 @@ module Cucumber
       describe 'when writing the report to a file' do
         before(:each) do
           allow(@out).to receive(:respond_to?).with(:path).and_return(true)
-          expect(@out).to receive(:path).and_return('out/file.html')
-          run_defined_feature
-          @doc = Nokogiri.HTML(@out.string)
         end
 
         describe 'with a step that embeds a snapshot' do
+          before(:each) do
+            expect(@out).to receive(:path).and_return('out/file.html')
+            run_defined_feature
+            @doc = Nokogiri.HTML(@out.string)
+          end
+
           define_steps do
             Given(/snap/) {
               RSpec::Mocks.allow_message(File, :file?) { true }
@@ -54,6 +57,33 @@ module Cucumber
 
           it 'converts the snapshot path to a relative path' do
             expect(@doc.css('.embed img').first.attributes['src'].to_s).to eq 'snapshot.jpeg'
+          end
+        end
+
+        describe 'with more than one step that embeds snapshot' do
+          before(:each) do
+            expect(@out).to receive(:path).twice.and_return('out/file.html')
+            run_defined_feature
+            @doc = Nokogiri.HTML(@out.string)
+          end
+
+          define_steps do
+            Given(/snap/) {
+              RSpec::Mocks.allow_message(File, :file?) { true }
+              embed('out/snapshot.jpeg', 'image/jpeg')
+            }
+          end
+
+          define_feature(<<-FEATURE)
+          Feature:
+            Scenario:
+              Given snap
+              And snap
+            FEATURE
+
+          it 'specifies id for img incrementally' do
+            ids = @doc.css('img').map { |element| element.attributes['id'].to_s }
+            expect(ids).to match %w(img_1 img_2)
           end
         end
       end
@@ -364,7 +394,7 @@ module Cucumber
               Given log
             FEATURE
 
-          it { expect(@doc.at('a#text_0')['href'].to_s).to eq 'log.txt' }
+          it { expect(@doc.at('a#text_1')['href'].to_s).to eq 'log.txt' }
         end
 
         describe 'with a step that embeds a snapshot content manually' do


### PR DESCRIPTION
## Summary

There was typo in `#next_id` method: `@indices` used incorrect key for incrementing screenshot number (_:type_ as a symbol instead of _type_ as a variable). It was lead to confusion when every screenshot in reporter pointed to the same image id.

## How Has This Been Tested?

`formatter/html_spec.rb` has been extended to cover a case with more than one screenshot in html-report.

## Screenshots (if appropriate):

![](https://d1ro8r1rbfn3jf.cloudfront.net/ms_44580/MKItLi5pyWFS3P4LuTW0Qt87kOXdxU/Cucumber%2B%25F0%259F%2594%2587%2B2017-10-11%2B19-01-22.png?Expires=1507860138&Signature=k1Jat5MBkbAh098crIclkE61G7-WFKIoIeEAveABCBnB9RNxUkbzyzCD-esN6NtvZVfXzYaGDIP9iL4e4JxptwQOrP1omUQqkAqlkEigO112YuCNKThKguKFho5XDD7sQT-xrQgyDAm6pwAycrs44tdYqVnj0tykDttmFRAsOFljjObLc-WNxU2w7kGi9Ln3FUHQJKViDoI671jVPpuq~qnlqRrK0UZ9VinWLQM5ybvuduOivRcZ7GBJ5B9zIH~c6h2-P7mSqtm4FeNORu-J6m~QUn1VLUlUunfx8EzDxJJvqGEeG98kMt0cfd9jKdzv5ht~VEVrKt9R50Ix2U38lQ__&Key-Pair-Id=APKAJHEJJBIZWFB73RSA)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
