### PR TITLE
make failure details expandable

### DIFF
--- a/lib/cucumber/formatter/inline-js.js
+++ b/lib/cucumber/formatter/inline-js.js
@@ -15,6 +15,24 @@ $(document).ready(function() {
   $("#expander").click(function() {
     $(SCENARIOS).siblings().show();
   });
+
+  // Close failures, right at the beginning
+  $('li.failed .message').slideToggle();
+  $('li.failed .backtrace').slideToggle();
+  $('li.failed .ruby').slideToggle();
+  $('tr.step').next('tr').children('td.failed').parent().slideToggle();
+
+  // Register to re-open failing Scenario messages
+  $('li.failed').click(function() {
+    $('.message', this).slideToggle();
+    $('.backtrace', this).slideToggle();
+    $('.ruby', this).slideToggle();
+  });
+
+  // Register to re-open failing Scenario Outline messages
+  $('tr.step').click(function() {
+    $(this).next('tr').children('td.failed').parent().slideToggle();
+  });
 })
 
 function moveProgressBar(percentDone) {


### PR DESCRIPTION
## Summary
Make failure details expandable; collapsed by default.

## Details
To the event handler for `document.ready`, I've added some code to `slideToggle()` those page elements which contain the details of a failure.

To the event handlers for `click` for failure rows (whether *Scenario* or *Scenario Outline*), I've added some code which will `slideToggle()` open or closed those page elements which contain the details of that failure.

## Motivation and Context

Cucumber HTML reports are a great way to demonstrate functional test coverage to non-technical stakeholders. However, my stakeholders were complaining that test failures included too much technical information, which they were not equipped to consume. I wanted to address this concern while not squelching my callstacks and other output, so I wrote this as a monkey-patch in the `support/` section of a  project. As an improvement, it made a lot of product managers happy. Now I'm just sharing-back!

## How Has This Been Tested?

1. I made these changes to a local clone of the `cucumber-ruby` project.
2. I changed my own project's `Gemfile` to refer to that local gem.
3. I deleted the monkey-patched code from my project to eliminate false positives.
4. I ran `bundle install` and confirmed that the local code was used to install the `cucumber` gem.
5. I ran `cucumber` against my project with the HTML formatter & evaluated the results. The code is present in the HTML report, and performs as expected in a modern version of Google Chrome.

NOTE: I did not add any automated tests to the codebase, as I could find no existing tests for JavaScript for the HTML formatter.

## Screenshots (if appropriate):

## Types of changes

- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
