### PR TITLE
remove unneeded rubocop disabling

### DIFF
--- a/examples/i18n/ru/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/ru/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-# rubocop:disable VariableName
 
 Допустим(/ввожу число (\d+)/) do |число|
   calc.push число.to_i
@@ -18,5 +17,3 @@ end
   Допустим %{затем ввожу число #{слагаемое2}}
   Допустим %{я нажимаю "+"}
 end
-
-# rubocop:enable VariableName

--- a/examples/i18n/uk/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/uk/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-# rubocop:disable VariableName
 
 Припустимо(/ввожу число (\d+)/) do |число|
   calc.push число.to_i
@@ -18,5 +17,3 @@ end
   Припустимо %{потім ввожу число #{доданок2}}
   Припустимо %{я натискаю "+"}
 end
-
-# rubocop:enable VariableName

--- a/examples/i18n/uz/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/uz/features/step_definitions/calculator_steps.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-# rubocop:disable VariableName
 
 Агар(/(\d+) сонини киритсам/) do |сон|
   calc.push сон.to_i
@@ -18,5 +17,3 @@ end
   Агар %{ундан сунг #{кушилувчи2} сонини киритсам}
   Агар %{"+"ни боссам}
 end
-
-# rubocop:enable VariableName

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -148,7 +148,6 @@ module Cucumber
             runtime.invoke_dynamic_steps(steps_text, language, location)
           end
 
-          # rubocop:disable UnneededInterpolation
           define_method(:puts) do |*messages|
             # Even though they won't be output until later, converting the messages to
             # strings right away will protect them from modifications to their original
@@ -157,7 +156,6 @@ module Cucumber
 
             runtime.puts(*messages)
           end
-          # rubocop:enable UnneededInterpolation
 
           define_method(:ask) do |question, timeout_seconds=60|
             runtime.ask(question, timeout_seconds)

--- a/spec/cucumber/formatter/pretty_spec.rb
+++ b/spec/cucumber/formatter/pretty_spec.rb
@@ -39,7 +39,6 @@ module Cucumber
             end
           end
 
-          # rubocop:disable TrailingWhitespace
           describe 'with a background' do
             define_feature <<-FEATURE
 Feature: Banana party
@@ -63,7 +62,6 @@ Feature: Banana party
               expect(@out.string).to include 'Given there are bananas'
             end
           end
-          # rubocop:enable TrailingWhitespace
 
           describe 'with a scenario outline' do
             define_feature <<-FEATURE
@@ -295,7 +293,6 @@ OUTPUT
               Given('this step passes') {}
             end
 
-            # rubocop:disable TrailingWhitespace
             it 'displays hook output appropriately ' do
               expect( @out.string ).to include <<OUTPUT
 Feature: 
@@ -318,7 +315,6 @@ Feature:
 OUTPUT
             end
           end
-          # rubocop:enable TrailingWhitespace
 
           describe 'with background and output from hooks' do
             define_feature <<-FEATURE
@@ -342,7 +338,6 @@ OUTPUT
               Given('this step passes') {}
             end
 
-            # rubocop:disable TrailingWhitespace
             it 'displays hook output appropriately ' do
               expect( @out.string ).to include <<OUTPUT
 Feature: 
@@ -362,7 +357,6 @@ Feature:
 OUTPUT
             end
           end
-          # rubocop:enable TrailingWhitespace
 
           describe 'with tags on all levels' do
             define_feature <<-FEATURE
@@ -380,7 +374,6 @@ OUTPUT
               | dummy |
             FEATURE
 
-            # rubocop:disable TrailingWhitespace
             it 'includes the tags in the output ' do
               expect( @out.string ).to include <<OUTPUT
 @tag1
@@ -401,7 +394,6 @@ Feature:
 OUTPUT
             end
           end
-          # rubocop:enable TrailingWhitespace
 
           describe 'with comments on all levels' do
             define_feature <<-FEATURE
@@ -429,7 +421,6 @@ OUTPUT
                 | dummy |
             FEATURE
 
-            # rubocop:disable TrailingWhitespace
             it 'includes the all comments except for data table rows in the output ' do
               expect( @out.string ).to include <<OUTPUT
 #comment1
@@ -462,7 +453,6 @@ OUTPUT
           end
         end
       end
-      # rubocop:enable TrailingWhitespace
 
       context 'With --no-multiline passed as an option' do
         before(:each) do

--- a/spec/cucumber/formatter/progress_spec.rb
+++ b/spec/cucumber/formatter/progress_spec.rb
@@ -34,7 +34,6 @@ module Cucumber
           end
         end
 
-        # rubocop:disable TrailingWhitespace
         describe 'with a background' do
           define_feature <<-FEATURE
             Feature: Banana party
@@ -50,7 +49,6 @@ module Cucumber
             expect(@out.string).to include "UU\n"
           end
         end
-        # rubocop:enable TrailingWhitespace
 
         describe 'with a scenario outline' do
           define_feature <<-FEATURE


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Minor rubocop fixes

## Details

remove cops that we disabled but didn't need to be

## Motivation and Context

bored

## How Has This Been Tested?

ran rubocop and warning are gone.  Did not run tests :-)

## Screenshots (if appropriate):

n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
n/a
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
