### PR TITLE
Fix Lint/IneffectiveAccessModifier

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,12 +18,6 @@ Lint/HandleExceptions:
     - 'features/lib/step_definitions/wire_steps.rb'
     - 'lib/cucumber/rake/task.rb'
 
-# Offense count: 2
-Lint/IneffectiveAccessModifier:
-  Exclude:
-    - 'lib/cucumber/glue/registry_and_more.rb'
-    - 'lib/cucumber/glue/snippet.rb'
-
 # Offense count: 1
 Lint/Loop:
   Exclude:

--- a/lib/cucumber/glue/registry_and_more.rb
+++ b/lib/cucumber/glue/registry_and_more.rb
@@ -155,6 +155,14 @@ module Cucumber
         raise ArgumentError.new('Expression must be a String or Regexp')
       end
 
+      def self.cli_snippet_type_options
+        registry = CucumberExpressions::ParameterTypeRegistry.new
+        cucumber_expression_generator = CucumberExpressions::CucumberExpressionGenerator.new(registry)
+        Snippet::SNIPPET_TYPES.keys.sort_by(&:to_s).map do |type|
+          Snippet::SNIPPET_TYPES[type].cli_option_string(type, cucumber_expression_generator)
+        end
+      end
+
       private
 
       def available_step_definition_hash
@@ -167,14 +175,6 @@ module Cucumber
 
       def hooks
         @hooks ||= Hash.new{|h,k| h[k] = []}
-      end
-
-      def self.cli_snippet_type_options
-        registry = CucumberExpressions::ParameterTypeRegistry.new
-        cucumber_expression_generator = CucumberExpressions::CucumberExpressionGenerator.new(registry)
-        Snippet::SNIPPET_TYPES.keys.sort_by(&:to_s).map do |type|
-          Snippet::SNIPPET_TYPES[type].cli_option_string(type, cucumber_expression_generator)
-        end
       end
     end
 

--- a/lib/cucumber/glue/snippet.rb
+++ b/lib/cucumber/glue/snippet.rb
@@ -81,6 +81,8 @@ module Cucumber
           new(cucumber_expression_generator, 'Given', 'I have 2 cukes', MultilineArgument::None.new).step
         end
 
+        private_class_method :example
+
       end
 
       class CucumberExpression < BaseSnippet


### PR DESCRIPTION
## Details

Rubocop pointed out that we had two points in our code where we had methods under the private designation that actually weren't private. It seems that for one instance we actually want it to be private and another we don't. I'll make comments below to explain some.

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Rubocop style fixes