### PR TITLE
Fix Junit formatter when Around hook throws an exception

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - gem install bundler
   - bundle install
 
 build: off

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -103,7 +103,7 @@ module Cucumber
       def create_output_string(test_case, scenario, result, row_name)
         output = "#{test_case.keyword}: #{scenario}\n\n"
         return output if result.ok?(@config.strict)
-        if test_case.keyword == 'Scenario'
+        if test_case.keyword == 'Scenario' && @failing_step_source
           output += @failing_step_source.keyword.to_s unless hook?(@failing_step_source)
           output += "#{@failing_step_source}\n"
         else

--- a/spec/cucumber/formatter/junit_spec.rb
+++ b/spec/cucumber/formatter/junit_spec.rb
@@ -153,6 +153,30 @@ module Cucumber
             it { expect(@doc.to_s).not_to match(/type="skipped"/)}
           end
 
+          describe 'with a scenario and failing after hook' do
+            define_steps do
+              Around do |_scenario, block|
+                block.call
+                raise 'Around hook made a boo-boo'
+              end
+              Given(/.*/) {  }
+            end
+
+            define_feature <<-FEATURE
+              Feature: One passing scenario, one failing scenario
+
+                Scenario: Passing
+                  Given a passing scenario
+            FEATURE
+
+            it { expect(@doc.to_s).to match(/One passing scenario, one failing scenario/) }
+            it do
+              expect(@doc.at_css('testsuite').attr('failures')).to eq '1'
+              expect(@doc.at_css('testsuite').attr('errors')).to eq '0'
+            end
+            it { expect(@doc.to_s).to include('Around hook made a boo-boo (RuntimeError)') }
+          end
+
           describe 'scenario with skipped test in junit report' do
             define_feature <<-FEATURE
               Feature: junit report with skipped test


### PR DESCRIPTION
## Summary

`Junit` formatter doesn't handle correctly cases when exceptions are thrown from `Around` hook.

## Details

Junit formatter incorrectly assumes that failing scenario always has a
failing step, while failure can come from a hook and all steps would be
successful.

Let's use the information from `@failing_step_source` only if it exists.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
