### PR TITLE
Change to use the gherkin step location in the Json formatter.

### DIFF
--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   # Keep in sync with .circleci/config.yml & .rubocop.yml
   s.required_ruby_version = '>= 2.2'
   s.add_dependency 'builder', '>= 2.1.2'
-  s.add_dependency 'cucumber-core', '~> 3.1.0'
+  s.add_dependency 'cucumber-core', '~> 3.2.0'
   s.add_dependency 'cucumber-expressions', '~> 6.0.1'
   s.add_dependency 'cucumber-wire', '~> 0.0.1'
   s.add_dependency 'diff-lcs', '~> 1.3'

--- a/features/docs/formatters/json_formatter.feature
+++ b/features/docs/formatters/json_formatter.feature
@@ -420,7 +420,7 @@ Feature: JSON output formatter
               {
                 "keyword": "Given ",
                 "name": "this step passes",
-                "line": 8,
+                "line": 4,
                 "match": {
                   "location": "features/step_definitions/steps.rb:1"
                 },
@@ -442,7 +442,7 @@ Feature: JSON output formatter
               {
                 "keyword": "Given ",
                 "name": "this step fails",
-                "line": 9,
+                "line": 4,
                 "match": {
                   "location": "features/step_definitions/steps.rb:4"
                 },
@@ -465,7 +465,7 @@ Feature: JSON output formatter
               {
                 "keyword": "Given ",
                 "name": "this step passes",
-                "line": 13,
+                "line": 4,
                 "match": {
                   "location": "features/step_definitions/steps.rb:1"
                 },
@@ -566,7 +566,7 @@ Feature: JSON output formatter
               {
                 "keyword": "Given ",
                 "name": "this step passes",
-                "line": 8,
+                "line": 4,
                 "match": {
                   "location": "features/step_definitions/steps.rb:1"
                 },
@@ -588,7 +588,7 @@ Feature: JSON output formatter
               {
                 "keyword": "Given ",
                 "name": "this step fails",
-                "line": 9,
+                "line": 4,
                 "match": {
                   "location": "features/step_definitions/steps.rb:4"
                 },
@@ -611,7 +611,7 @@ Feature: JSON output formatter
               {
                 "keyword": "Given ",
                 "name": "this step passes",
-                "line": 13,
+                "line": 4,
                 "match": {
                   "location": "features/step_definitions/steps.rb:1"
                 },
@@ -680,7 +680,7 @@ Feature: JSON output formatter
               {
                 "keyword": "Given ",
                 "name": "I embed data directly",
-                "line": 11,
+                "line": 7,
                 "embeddings": [
                   {
                     "mime_type": "mime-type",
@@ -708,7 +708,7 @@ Feature: JSON output formatter
               {
                 "keyword": "Given ",
                 "name": "I embed data directly",
-                "line": 12,
+                "line": 7,
                 "embeddings": [
                   {
                     "mime_type": "mime-type",

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -163,7 +163,7 @@ module Cucumber
         step_hash = {
           keyword: step_source.keyword,
           name: step_source.to_s,
-          line: step_source.location.line
+          line: step_source.original_location.line
         }
         step_hash[:comments] = Formatter.create_comments_array(step_source.comments) unless step_source.comments.empty?
         step_hash[:doc_string] = create_doc_string_hash(step_source.multiline_arg) if step_source.multiline_arg.doc_string?

--- a/spec/cucumber/formatter/json_spec.rb
+++ b/spec/cucumber/formatter/json_spec.rb
@@ -198,7 +198,7 @@ module Cucumber
                    "steps":
                     [{"keyword": "Given ",
                       "name": "there are bananas",
-                      "line": 8,
+                      "line": 4,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:180"},
                       "result": {"status": "passed",
                                  "duration": 1}}]}]}]})
@@ -271,7 +271,7 @@ module Cucumber
                    "steps":
                     [{"keyword": "Given ",
                       "name": "there are bananas",
-                      "line": 15,
+                      "line": 10,
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:228"},
                       "result": {"status": "passed",
                                  "duration": 1}}]}]}]})
@@ -380,7 +380,7 @@ module Cucumber
                    "steps":
                     [{"keyword": "Then ",
                       "name": "the monkey eats bananas",
-                      "line": 22,
+                      "line": 16,
                       "comments": [{"value": "#step comment2",
                                     "line": 15}],
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:309"},


### PR DESCRIPTION
## Summary

Change to use the gherkin step location in the Json formatter.

## Details

For test steps from scenario outlines use the line of the outline step instead of line of the example table row.

## Motivation and Context

Fixes #1108 (a regression from v1.3.x).
Depends on cucumber/cucumber-ruby-core#150.

## How Has This Been Tested?

The automated test suite has been updated to verify this behavior.

## Types of changes

- [ ] Refactor (code change that does not change external functionality)
- [X] Bug fix (non-breaking change which fixes an issue) - regression from v1.3.x
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
