### PR TITLE
Fix incompatible encodings error in Junit formatter

### DIFF
--- a/lib/cucumber/formatter/interceptor.rb
+++ b/lib/cucumber/formatter/interceptor.rb
@@ -8,7 +8,7 @@ module Cucumber
         attr_reader :pipe
         def initialize(pipe)
           @pipe = pipe
-          @buffer = []
+          @buffer = StringIO.new
           @wrapped = true
         end
 
@@ -19,9 +19,16 @@ module Cucumber
           end
         end
 
+        # @deprecated use #buffer_string
         def buffer
           lock.synchronize do
-            return @buffer.dup
+            return @buffer.string.lines
+          end
+        end
+
+        def buffer_string
+          lock.synchronize do
+            return @buffer.string.dup
           end
         end
 

--- a/lib/cucumber/formatter/interceptor.rb
+++ b/lib/cucumber/formatter/interceptor.rb
@@ -21,6 +21,11 @@ module Cucumber
 
         # @deprecated use #buffer_string
         def buffer
+          require 'cucumber/deprecate.rb'
+          Cucumber.deprecate(
+            'Use Cucumber::Formatter::Interceptor::Pipe#buffer_string instead',
+            'Cucumber::Formatter::Interceptor::Pipe#buffer',
+            '3.99')
           lock.synchronize do
             return @buffer.string.lines
           end

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -140,10 +140,10 @@ module Cucumber
             @current_feature_data[:failures] += 1
           end
           @current_feature_data[:builder].tag!('system-out') do
-            @current_feature_data[:builder].cdata! strip_control_chars(@interceptedout.buffer.join)
+            @current_feature_data[:builder].cdata! strip_control_chars(@interceptedout.buffer_string)
           end
           @current_feature_data[:builder].tag!('system-err') do
-            @current_feature_data[:builder].cdata! strip_control_chars(@interceptederr.buffer.join)
+            @current_feature_data[:builder].cdata! strip_control_chars(@interceptederr.buffer_string)
           end
         end
         @current_feature_data[:tests] += 1

--- a/spec/cucumber/formatter/interceptor_spec.rb
+++ b/spec/cucumber/formatter/interceptor_spec.rb
@@ -114,6 +114,7 @@ module Cucumber::Formatter
 
         expect(pi.buffer).not_to be_empty
         expect(pi.buffer.first).to eq buffer
+        expect(pi.buffer_string).to eq buffer
       end
     end
 

--- a/spec/cucumber/formatter/junit_spec.rb
+++ b/spec/cucumber/formatter/junit_spec.rb
@@ -66,6 +66,29 @@ module Cucumber
           it { expect(@doc.xpath('//testsuite/testcase/system-out').first.content).to match(/\s+boo boo\s+/) }
         end
 
+        describe 'is able to handle multiple encodings in pipe' do
+          before(:each) do
+            run_defined_feature
+            @doc = Nokogiri.XML(@formatter.written_files.values.first)
+          end
+
+          define_steps do
+            Given(/a passing ctrl scenario/) do
+              Kernel.puts "encoding"
+              Kernel.puts "pickle".encode("UTF-16")
+            end
+          end
+
+          define_feature "
+              Feature: One passing scenario, one failing scenario
+
+                Scenario: Passing
+                  Given a passing ctrl scenario
+            "
+
+          it { expect(@doc.xpath('//testsuite/testcase/system-out').first.content).to match(/\s+encoding\npickle\s+/) }
+        end
+
         describe 'a feature with no name' do
           define_feature <<-FEATURE
             Feature:


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Fix  incompatible character encodings error in Junit formatter which occurs if strings with incompatible encodings were written to pipe.

## Details

Replaced array buffer in Interceptor::Pipe with StringIO to prevent  incompatible character encodings error. This also elements need to join array in Junit formatter and reduces exposure of internals of pipe interceptor. Although #buffer method was kept and is backward compatible in case any end user code is using it.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes issues of cucumber failing to generate junit report for test cases that had non UTF strings in different languages logged during test run.

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Add test case for junit formatter to write output in case of incompatible strings being logged during test run.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.