### PR TITLE
Add force to push for pro publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - checkout
       - run: git remote add cucumber-pro git@git.cucumber.pro:cucumber-ruby.git
-      - run: git push cucumber-pro $CIRCLE_BRANCH
+      - run: git push -f cucumber-pro $CIRCLE_BRANCH
   "ruby-2.4.1":
     docker:
        - image: circleci/ruby:2.4.1


### PR DESCRIPTION
## Summary

Solves #1248  - Issue with pushing to cucumberpro by adding a force to the publish job in circle.

## Details

Super simple change.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
