### PR TITLE
Fix Gemspec/RequiredRubyVersion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ workflows:
   version: 2
   build:
     jobs:
-      # Keep lowest ruby-* version in sync with .cucumber.gemspec
+      # Keep lowest ruby-* version in sync with .cucumber.gemspec & .rubocop.yml
       - "ruby-2.4.1"
       - "ruby-2.3.5"
       - "ruby-2.2.8"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
+  # Keep this inline with the lowest ruby-* version in circleci/config.yml and
+  # the version in the gemspec
+  TargetRubyVersion: 2.2
   # Cop names are not displayed in offense messages by default. Change behavior
   # by overriding DisplayCopNames, or by giving the `-D/--display-cop-names`
   # option.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,13 +22,6 @@ Gemspec/OrderedDependencies:
   Exclude:
     - 'cucumber.gemspec'
 
-# Offense count: 1
-# Configuration parameters: Include.
-# Include: **/*.gemspec
-Gemspec/RequiredRubyVersion:
-  Exclude:
-    - 'cucumber.gemspec'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Layout/BlockEndNewline:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Changed
 
+* Fix Gemspec/RequiredRubyVersion ([#1252](https://github.com/cucumber/cucumber-ruby/pull/1252) [@jaysonesmith](https://github.com/jaysonesmith))
 * N/A
 
 ### Deprecated

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -9,7 +9,8 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.homepage    = 'https://cucumber.io/'
   s.platform    = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.2' # Keep in sync with .circleci/config.yml
+  # Keep in sync with .circleci/config.yml & .rubocop.yml
+  s.required_ruby_version = '>= 2.2'
   s.add_dependency 'cucumber-core', '~> 3.1.0'
   s.add_dependency 'builder', '>= 2.1.2'
   s.add_dependency 'diff-lcs', '~> 1.3'

--- a/lib/cucumber/formatter/interceptor.rb
+++ b/lib/cucumber/formatter/interceptor.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'thread'
 
 module Cucumber
   module Formatter


### PR DESCRIPTION
## Details

- Rubocop likes the ruby version specified to be the same between .rubocop.yml and the required version in the gemspec. Since we hadn't specified a version in the rubocop file, it defaulted to the 2.1 which doesn't equal 2.2. :)

Update the versions and the comments for each. Also had a Lint/UnneededRequireStatement violation pop up that I handled.

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Rubocop style fixes