### PR TITLE
Fix Layout/BlockEndNewline

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,12 +29,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'cucumber.gemspec'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Layout/BlockEndNewline:
-  Exclude:
-    - 'spec/cucumber/step_match_search_spec.rb'
-
 # Offense count: 8
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Changed
 
+* Fix Layout/BlockEndNewline ([#1253](https://github.com/cucumber/cucumber-ruby/pull/1253) [@jaysonesmith](https://github.com/jaysonesmith))
 * N/A
 
 ### Deprecated

--- a/spec/cucumber/step_match_search_spec.rb
+++ b/spec/cucumber/step_match_search_spec.rb
@@ -63,16 +63,14 @@ spec/cucumber/step_match_search_spec.rb:\\d+:in `/Three cute (.*)/'
           dsl.Given(/Three (.*) mice/) {|disability|}
           dsl.Given(/Three cute (.*)/) {|animal|}
 
-          expect(-> {
-            search.call('Three cute mice').first } ).to raise_error(Ambiguous, /#{expected_error}/)
+          expect(-> { search.call('Three cute mice').first } ).to raise_error(Ambiguous, /#{expected_error}/)
         end
 
         it 'does not raise Ambiguous error when multiple step definitions match' do
           dsl.Given(/Three (.*) mice/) {|disability|}
           dsl.Given(/Three (.*)/) {|animal|}
 
-          expect(-> {
-            search.call('Three blind mice').first } ).not_to raise_error
+          expect(-> { search.call('Three blind mice').first } ).not_to raise_error
         end
 
         it 'picks right step definition when an equal number of capture groups' do


### PR DESCRIPTION
## Details

- Looks like in the attempt at keeping line length shorter, a new line was used which Rubocop doesn't like.

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Rubocop style fixes