### PR TITLE
Fix Layout/DotPosition

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,17 +35,6 @@ Layout/BlockEndNewline:
   Exclude:
     - 'spec/cucumber/step_match_search_spec.rb'
 
-# Offense count: 8
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: leading, trailing
-Layout/DotPosition:
-  Exclude:
-    - 'lib/cucumber/constantize.rb'
-    - 'lib/cucumber/filters/randomizer.rb'
-    - 'scripts/invite-collaborator'
-    - 'spec/cucumber/multiline_argument/data_table_spec.rb'
-
 # Offense count: 217
 # Cop supports --auto-correct.
 Layout/EmptyLineAfterMagicComment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Changed
 
+* Fix Layout/DotPosition ([#1254](https://github.com/cucumber/cucumber-ruby/pull/1254) [@jaysonesmith](https://github.com/jaysonesmith))
 * N/A
 
 ### Deprecated

--- a/lib/cucumber/constantize.rb
+++ b/lib/cucumber/constantize.rb
@@ -26,11 +26,11 @@ module Cucumber
 
     # Snagged from active_support
     def underscore(camel_cased_word)
-      camel_cased_word.to_s.gsub(/::/, '/').
-        gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
-        gsub(/([a-z\d])([A-Z])/,'\1_\2').
-        tr('-', '_').
-        downcase
+      camel_cased_word.to_s.gsub(/::/, '/')
+                      .gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
+                      .gsub(/([a-z\d])([A-Z])/,'\1_\2')
+                      .tr('-', '_')
+                      .downcase
     end
 
     private

--- a/lib/cucumber/filters/randomizer.rb
+++ b/lib/cucumber/filters/randomizer.rb
@@ -33,9 +33,9 @@ module Cucumber
 
       def shuffled_test_cases
         digester = Digest::SHA2.new(256)
-        @test_cases.map.with_index.
-          sort_by { |_, index| digester.digest((@seed + index).to_s) }.
-          map { |test_case, _| test_case }
+        @test_cases.map.with_index
+                   .sort_by { |_, index| digester.digest((@seed + index).to_s) }
+                   .map { |test_case, _| test_case }
       end
 
       attr_reader :seed

--- a/scripts/invite-collaborator
+++ b/scripts/invite-collaborator
@@ -18,8 +18,8 @@ class Team
   end
 
   def team
-    @team ||= gh.organization_teams('cucumber').
-      find { |team| team['name'] == name } || raise("Unable to find a team named #{name}")
+    @team ||= gh.organization_teams('cucumber')
+      .find { |team| team['name'] == name } || raise("Unable to find a team named #{name}")
   end
 end
 

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -209,8 +209,8 @@ module Cucumber
             %w{one 1111},
             %w{two 22222}
           ])
-          t2 = table.map_headers({ 'two' => 'Two' }, &:upcase).
-                     map_column('two', false, &:to_i)
+          t2 = table.map_headers({ 'two' => 'Two' }, &:upcase)
+                    .map_column('two', false, &:to_i)
           expect( t2.rows_hash ).to eq( 'ONE' => '1111', 'Two' => 22222 )
         end
       end


### PR DESCRIPTION
## Details

- This cop supports leading OR trailing dots for chained lines.

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Rubocop style fixes
