### PR TITLE
Add Rubocop to default Rake task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,10 @@ AllCops:
 Lint/AmbiguousOperator:
   Enabled: false
 
+# Disabling for appveyor
+Layout/EndOfLine:
+  Enabled: false
+
 # Reviewed: Formatters put trailing spaces after things like 'Feature: '
 #           In pretty_spec.rb, progress_spec.rb offences look false,
 #           as the trailing spaces are in multiline string literals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Changed
 
+* Add Rubocop to default Rake task ([#1256](https://github.com/cucumber/cucumber-ruby/pull/1256) [@jaysonesmith](https://github.com/jaysonesmith))
 * N/A
 
 ### Deprecated

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ Cucumber::Rake::Task.new do |t|
   t.profile = 'ruby' if Cucumber::RUBY
 end
 
-default_tasks = [:spec, :cucumber]
+default_tasks = [:spec, :cucumber, :rubocop]
 
 task :default => default_tasks
 

--- a/lib/cucumber/formatter/interceptor.rb
+++ b/lib/cucumber/formatter/interceptor.rb
@@ -24,7 +24,8 @@ module Cucumber
           Cucumber.deprecate(
             'Use Cucumber::Formatter::Interceptor::Pipe#buffer_string instead',
             'Cucumber::Formatter::Interceptor::Pipe#buffer',
-            '3.99')
+            '3.99'
+          )
           lock.synchronize do
             return @buffer.string.lines
           end

--- a/spec/cucumber/formatter/junit_spec.rb
+++ b/spec/cucumber/formatter/junit_spec.rb
@@ -74,8 +74,8 @@ module Cucumber
 
           define_steps do
             Given(/a passing ctrl scenario/) do
-              Kernel.puts "encoding"
-              Kernel.puts "pickle".encode("UTF-16")
+              Kernel.puts 'encoding'
+              Kernel.puts 'pickle'.encode('UTF-16')
             end
           end
 


### PR DESCRIPTION
## Details

- Added Rubocop to the default Rake task 
- This way folks contributing to the project are forced to follow the style guidelines we're moving toward and don't add new violations that need to be fixed.

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021) and keep it solved!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Test enhancement