### PR TITLE
Fix Layout/EmptyLineBetweenDefs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,13 +51,6 @@ Layout/DotPosition:
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: AllowAdjacentOneLineDefs, NumberOfEmptyLines.
-Layout/EmptyLineBetweenDefs:
-  Exclude:
-    - 'lib/cucumber/multiline_argument/data_table/diff_matrices.rb'
-
 # Offense count: 9
 # Cop supports --auto-correct.
 Layout/EmptyLines:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Changed
 
+* Fix Layout/EmptyLineBetweenDefs ([#1257](https://github.com/cucumber/cucumber-ruby/pull/1257) [@jaysonesmith](https://github.com/jaysonesmith))
 * N/A
 
 ### Deprecated

--- a/lib/cucumber/multiline_argument/data_table/diff_matrices.rb
+++ b/lib/cucumber/multiline_argument/data_table/diff_matrices.rb
@@ -68,7 +68,6 @@ module Cucumber
           array[0].is_a?(Array) ? array : [array]
         end
 
-
         def perform_diff
           inserted    = 0
           missing     = 0
@@ -109,7 +108,6 @@ module Cucumber
           end
         end
 
-
         def fill_in_missing_values
           other_table_cell_matrix.each_with_index do |other_row, i|
             row_index = row_indices.index(i)
@@ -133,7 +131,6 @@ module Cucumber
         def misplaced_col
           cell_matrix[0] != original_header
         end
-
 
         def raise_error
           table = DataTable.from([[]])


### PR DESCRIPTION
## Details

- Simple visibility change
- Fixed with the auto flag

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Rubocop style fixes
