### PR TITLE
Fix: Layout/EmptyLines, ...AroundAccessModifier, ...AroundArguments, ...AroundExceptionHandlingKeywords

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,32 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 9
-# Cop supports --auto-correct.
-Layout/EmptyLines:
-  Exclude:
-    - 'lib/cucumber/cli/main.rb'
-    - 'lib/cucumber/events/step_definition_registered.rb'
-    - 'lib/cucumber/formatter/backtrace_filter.rb'
-    - 'lib/cucumber/multiline_argument/data_table.rb'
-    - 'lib/cucumber/multiline_argument/data_table/diff_matrices.rb'
-    - 'lib/cucumber/term/ansicolor.rb'
-    - 'spec/cucumber/runtime/support_code_spec.rb'
-
-# Offense count: 3
-# Cop supports --auto-correct.
-Layout/EmptyLinesAroundAccessModifier:
-  Exclude:
-    - 'lib/cucumber/formatter/interceptor.rb'
-    - 'lib/cucumber/runtime/step_hooks.rb'
-    - 'lib/cucumber/step_match.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-Layout/EmptyLinesAroundArguments:
-  Exclude:
-    - 'spec/cucumber/formatter/junit_spec.rb'
-
 # Offense count: 33
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
@@ -45,12 +19,6 @@ Layout/EmptyLinesAroundBlockBody:
 # SupportedStyles: empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
 Layout/EmptyLinesAroundClassBody:
   Enabled: false
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/EmptyLinesAroundExceptionHandlingKeywords:
-  Exclude:
-    - 'scripts/invite-collaborator'
 
 # Offense count: 60
 # Cop supports --auto-correct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Improved
 
+* Fix: Layout/EmptyLines, ...AroundAccessModifier, ...AroundArguments, ...AroundExceptionHandlingKeywords ([#1262](https://github.com/cucumber/cucumber-ruby/pull/1262) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/EmptyLineAfterMagicComment ([#1255](https://github.com/cucumber/cucumber-ruby/pull/1255) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/DotPosition ([#1254](https://github.com/cucumber/cucumber-ruby/pull/1254) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/BlockEndNewline ([#1253](https://github.com/cucumber/cucumber-ruby/pull/1253) [@jaysonesmith](https://github.com/jaysonesmith))

--- a/lib/cucumber/cli/main.rb
+++ b/lib/cucumber/cli/main.rb
@@ -71,7 +71,6 @@ module Cucumber
 
       private
 
-
       def exit_ok
         @kernel.exit 0
       end

--- a/lib/cucumber/events/step_definition_registered.rb
+++ b/lib/cucumber/events/step_definition_registered.rb
@@ -8,7 +8,6 @@ module Cucumber
     # Event fired after each step definition has been registered
     class StepDefinitionRegistered < Core::Event.new(:step_definition)
 
-
       # The step definition that was just registered.
       #
       # @return [RbSupport::RbStepDefinition]

--- a/lib/cucumber/formatter/backtrace_filter.rb
+++ b/lib/cucumber/formatter/backtrace_filter.rb
@@ -2,7 +2,6 @@
 
 require 'cucumber/platform'
 
-
 module Cucumber
   module Formatter
     @backtrace_filters = %w(

--- a/lib/cucumber/formatter/interceptor.rb
+++ b/lib/cucumber/formatter/interceptor.rb
@@ -84,6 +84,7 @@ module Cucumber
         end
 
         private
+
         def lock
           @lock||=Mutex.new
         end

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -75,7 +75,6 @@ module Cucumber
         end
       end
 
-
       NULL_CONVERSIONS = Hash.new({ :strict => false, :proc => lambda{ |cell_value| cell_value } }).freeze
 
       # @param data [Core::Ast::DataTable] the data for the table

--- a/lib/cucumber/runtime/step_hooks.rb
+++ b/lib/cucumber/runtime/step_hooks.rb
@@ -14,6 +14,7 @@ module Cucumber
       end
 
       private
+
       def after_step_hooks(test_step)
         @hooks.map do |hook|
           action = ->(*args) { hook.invoke('AfterStep', [args, test_step]) }

--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -94,6 +94,7 @@ module Cucumber
     end
 
     private
+
     def deep_clone_args
       Marshal.load( Marshal.dump( args ) )
     end

--- a/lib/cucumber/term/ansicolor.rb
+++ b/lib/cucumber/term/ansicolor.rb
@@ -78,7 +78,6 @@ module Cucumber
       # uncoloring strings.
       COLORED_REGEXP = /\e\[(?:[34][0-7]|[0-9])?m/
 
-
       def self.included(klass)
         if klass == String
           ATTRIBUTES.delete(:clear)

--- a/scripts/invite-collaborator
+++ b/scripts/invite-collaborator
@@ -34,7 +34,6 @@ begin
   ].each do |team|
     team.add_member(login)
   end
-
 rescue StandardError => error
   abort error.message
 end

--- a/spec/cucumber/formatter/junit_spec.rb
+++ b/spec/cucumber/formatter/junit_spec.rb
@@ -57,12 +57,12 @@ module Cucumber
             end
           end
 
-          define_feature "
+          define_feature <<-FEATURE
               Feature: One passing scenario, one failing scenario
 
                 Scenario: Passing
                   Given a passing ctrl scenario
-            "
+            FEATURE
 
           it { expect(@doc.xpath('//testsuite/testcase/system-out').first.content).to match(/\s+boo boo\s+/) }
         end
@@ -113,12 +113,14 @@ module Cucumber
           end
 
           describe 'with a scenario in a subdirectory' do
+            # rubocop:disable Layout/EmptyLinesAroundArguments
             define_feature %{
               Feature: One passing scenario, one failing scenario
 
                 Scenario: Passing
                   Given a passing scenario
             }, File.join('features', 'some', 'path', 'spec.feature')
+            # rubocop:enable Layout/EmptyLinesAroundArguments
 
             it 'writes the filename with absolute path' do
               expect(@formatter.written_files.keys.first).to eq File.absolute_path('TEST-features-some-path-spec.xml')

--- a/spec/cucumber/runtime/support_code_spec.rb
+++ b/spec/cucumber/runtime/support_code_spec.rb
@@ -13,6 +13,5 @@ module Cucumber
       Object.new.extend(RbSupport::RbDsl)
     end
 
-
   end
 end


### PR DESCRIPTION
## Details

Fixed the following simple cops:
- Layout/EmptyLines
- Layout/EmptyLinesAroundAccessModifier
- Layout/EmptyLinesAroundArguments
- Layout/EmptyLinesAroundExceptionHandlingKeywords

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Rubocop style fixes
