### PR TITLE
Fix Layout/EmptyLinesAroundClassBody

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,13 +39,6 @@ Layout/EmptyLinesAroundArguments:
 Layout/EmptyLinesAroundBlockBody:
   Enabled: false
 
-# Offense count: 52
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
-Layout/EmptyLinesAroundClassBody:
-  Enabled: false
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Layout/EmptyLinesAroundExceptionHandlingKeywords:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Improved
 
+* Fix Layout/EmptyLinesAroundClassBody ([#1264](https://github.com/cucumber/cucumber-ruby/pull/1264) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/EmptyLineAfterMagicComment ([#1255](https://github.com/cucumber/cucumber-ruby/pull/1255) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/DotPosition ([#1254](https://github.com/cucumber/cucumber-ruby/pull/1254) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/BlockEndNewline ([#1253](https://github.com/cucumber/cucumber-ruby/pull/1253) [@jaysonesmith](https://github.com/jaysonesmith))

--- a/examples/i18n/ca/lib/calculadora.rb
+++ b/examples/i18n/ca/lib/calculadora.rb
@@ -1,5 +1,4 @@
 class Calculadora
-
   def push(n)
     @args ||= []
     @args << n
@@ -12,5 +11,4 @@ class Calculadora
   def divide
     @args[0].to_f / @args[1].to_f
   end
-
 end

--- a/examples/i18n/sr-Cyrl/lib/calculator.rb
+++ b/examples/i18n/sr-Cyrl/lib/calculator.rb
@@ -1,5 +1,4 @@
 class Calculator
-
   def push(n)
     @args ||= []
     @args << n
@@ -8,5 +7,4 @@ class Calculator
   def add
     @args.inject(0){|n,sum| sum + n}
   end
-
 end

--- a/examples/i18n/sr-Latn/lib/calculator.rb
+++ b/examples/i18n/sr-Latn/lib/calculator.rb
@@ -1,5 +1,4 @@
 class Calculator
-
   def push(n)
     @args ||= []
     @args << n
@@ -8,5 +7,4 @@ class Calculator
   def add
     @args.inject(0){|n,sum| sum + n}
   end
-
 end

--- a/lib/cucumber/cli/profile_loader.rb
+++ b/lib/cucumber/cli/profile_loader.rb
@@ -6,7 +6,6 @@ module Cucumber
   module Cli
 
     class ProfileLoader
-
       def initialize
         @cucumber_yml = nil
       end
@@ -91,7 +90,6 @@ Defined profiles in cucumber.yml:
       def cucumber_file
         @cucumber_file ||= Dir.glob('{,.config/,config/}cucumber{.yml,.yaml}').first
       end
-
     end
   end
 end

--- a/lib/cucumber/events/gherkin_source_read.rb
+++ b/lib/cucumber/events/gherkin_source_read.rb
@@ -5,7 +5,6 @@ module Cucumber
 
     # Fired after we've read in the contents of a feature file
     class GherkinSourceRead < Core::Event.new(:path, :body)
-
       # The path to the file
       attr_reader :path
 

--- a/lib/cucumber/events/step_activated.rb
+++ b/lib/cucumber/events/step_activated.rb
@@ -7,7 +7,6 @@ module Cucumber
 
     # Event fired when a step is activated
     class StepActivated < Core::Event.new(:test_step, :step_match)
-
       # The test step that was matched.
       #
       # @return [Cucumber::Core::Test::Step]

--- a/lib/cucumber/events/step_definition_registered.rb
+++ b/lib/cucumber/events/step_definition_registered.rb
@@ -7,8 +7,6 @@ module Cucumber
 
     # Event fired after each step definition has been registered
     class StepDefinitionRegistered < Core::Event.new(:step_definition)
-
-
       # The step definition that was just registered.
       #
       # @return [RbSupport::RbStepDefinition]
@@ -18,7 +16,6 @@ module Cucumber
       def initialize(step_definition)
         @step_definition = step_definition
       end
-
     end
 
   end

--- a/lib/cucumber/events/test_case_finished.rb
+++ b/lib/cucumber/events/test_case_finished.rb
@@ -5,13 +5,11 @@ module Cucumber
 
     # Signals that a {Cucumber::Core::Test::Case} has finished executing
     class TestCaseFinished < Core::Events::TestCaseFinished
-
       # @return [Cucumber::Core::Test::Case] that was executed
       attr_reader :test_case
 
       # @return [Cucumber::Core::Test::Result] the result of running the {Cucumber::Core::Test::Case}
       attr_reader :result
-
     end
 
   end

--- a/lib/cucumber/events/test_case_started.rb
+++ b/lib/cucumber/events/test_case_started.rb
@@ -5,10 +5,8 @@ module Cucumber
 
     # Signals that a {Cucumber::Core::Test::Case} is about to be executed
     class TestCaseStarted < Core::Events::TestCaseStarted
-
       # @return [Cucumber::Core::Test::Case] the test case to be executed
       attr_reader :test_case
-
     end
 
   end

--- a/lib/cucumber/events/test_run_started.rb
+++ b/lib/cucumber/events/test_run_started.rb
@@ -8,7 +8,6 @@ module Cucumber
     # Event fired once all test cases have been filtered before
     # the first one is executed.
     class TestRunStarted < Core::Event.new(:test_cases)
-
       # @return [Array<Cucumber::Core::Test::Case>] the test cases to be executed
       attr_reader :test_cases
     end

--- a/lib/cucumber/events/test_step_finished.rb
+++ b/lib/cucumber/events/test_step_finished.rb
@@ -5,13 +5,11 @@ module Cucumber
 
     # Signals that a {Cucumber::Core::Test::Step} has finished executing
     class TestStepFinished < Core::Events::TestStepFinished
-
       # @return [Cucumber::Core::Test::Step] the test step that was executed
       attr_reader :test_step
 
       # @return [Cucumber::Core::Test::Result] the result of running the {Cucumber::Core::Test::Step}
       attr_reader :result
-
     end
 
   end

--- a/lib/cucumber/events/test_step_started.rb
+++ b/lib/cucumber/events/test_step_started.rb
@@ -5,10 +5,8 @@ module Cucumber
 
     # Signals that a {Cucumber::Core::Test::Step} is about to be executed
     class TestStepStarted < Core::Events::TestStepStarted
-
       # @return [Cucumber::Core::Test::Step] the test step to be executed
       attr_reader :test_step
-
     end
 
   end

--- a/lib/cucumber/filters/activate_steps.rb
+++ b/lib/cucumber/filters/activate_steps.rb
@@ -8,7 +8,6 @@ require 'cucumber/errors'
 module Cucumber
   module Filters
     class ActivateSteps < Core::Filter.new(:step_match_search, :configuration)
-
       def test_case(test_case)
         CaseFilter.new(test_case, step_match_search, configuration).test_case.describe_to receiver
       end

--- a/lib/cucumber/filters/prepare_world.rb
+++ b/lib/cucumber/filters/prepare_world.rb
@@ -8,7 +8,6 @@ module Cucumber
   module Filters
 
     class PrepareWorld < Core::Filter.new(:runtime)
-
       def test_case(test_case)
         CaseFilter.new(runtime, test_case).test_case.describe_to receiver
       end
@@ -40,7 +39,6 @@ module Cucumber
           @scenario ||= RunningTestCase.new(test_case)
         end
       end
-
     end
 
   end

--- a/lib/cucumber/filters/retry.rb
+++ b/lib/cucumber/filters/retry.rb
@@ -7,7 +7,6 @@ require 'cucumber/events'
 module Cucumber
   module Filters
     class Retry < Core::Filter.new(:configuration)
-
       def test_case(test_case)
         configuration.on_event(:test_case_finished) do |event|
           next unless retry_required?(test_case, event)

--- a/lib/cucumber/filters/tag_limits/test_case_index.rb
+++ b/lib/cucumber/filters/tag_limits/test_case_index.rb
@@ -3,7 +3,6 @@
 module Cucumber
   module Filters
     class TagLimits
-
       class TestCaseIndex
         def initialize
           @index = Hash.new { |hash, key| hash[key] = [] }
@@ -27,7 +26,6 @@ module Cucumber
 
         attr_accessor :index
       end
-
     end
   end
 end

--- a/lib/cucumber/filters/tag_limits/verifier.rb
+++ b/lib/cucumber/filters/tag_limits/verifier.rb
@@ -3,7 +3,6 @@
 module Cucumber
   module Filters
     class TagLimits
-
       class Verifier
         def initialize(tag_limits)
           @tag_limits = tag_limits
@@ -54,7 +53,6 @@ module Cucumber
           attr_reader :limit
           attr_reader :locations
         end
-
       end
     end
   end

--- a/lib/cucumber/formatter/fail_fast.rb
+++ b/lib/cucumber/formatter/fail_fast.rb
@@ -7,14 +7,12 @@ module Cucumber
   module Formatter
 
     class FailFast
-
       def initialize(configuration)
         configuration.on_event :test_case_finished do |event|
           _test_case, result = *event.attributes
           Cucumber.wants_to_quit = true unless result.ok?(configuration.strict)
         end
       end
-
     end
 
   end

--- a/lib/cucumber/formatter/fanout.rb
+++ b/lib/cucumber/formatter/fanout.rb
@@ -22,7 +22,6 @@ module Cucumber
       def respond_to_missing?(name, include_private = false)
         recipients.any? { |recipient| recipient.respond_to?(name, include_private) }
       end
-
     end
 
   end

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -9,7 +9,6 @@ require 'pathname'
 module Cucumber
   module Formatter
     class Html
-
       # TODO: remove coupling to types
       AST_CLASSES = {
         Cucumber::Core::Ast::Scenario        => 'scenario',
@@ -609,7 +608,6 @@ module Cucumber
           end
           new_lines.join("\n")
         end
-
       end
     end
   end

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -10,7 +10,6 @@ module Cucumber
   module Formatter
     # The formatter used for <tt>--format junit</tt>
     class Junit
-
       include Io
 
       class UnNamedFeatureError < StandardError
@@ -181,7 +180,6 @@ module Cucumber
       def strip_control_chars(cdata)
         cdata.scan(/[[:print:]\t\n\r]/).join
       end
-
     end
 
     class NameBuilder

--- a/lib/cucumber/formatter/steps.rb
+++ b/lib/cucumber/formatter/steps.rb
@@ -4,7 +4,6 @@ module Cucumber
   module Formatter
     # The formatter used for <tt>--format steps</tt>
     class Steps
-
       def initialize(runtime, path_or_io, options)
         @io = ensure_io(path_or_io)
         @options = options

--- a/lib/cucumber/formatter/usage.rb
+++ b/lib/cucumber/formatter/usage.rb
@@ -6,7 +6,6 @@ require 'cucumber/step_definition_light'
 module Cucumber
   module Formatter
     class Usage < Progress
-
       class StepDefKey < StepDefinitionLight
         attr_accessor :mean_duration, :status
       end
@@ -136,7 +135,6 @@ module Cucumber
           statuses.include?(status)
         end
       end
-
     end
   end
 end

--- a/lib/cucumber/glue/snippet.rb
+++ b/lib/cucumber/glue/snippet.rb
@@ -26,7 +26,6 @@ module Cucumber
       end
 
       class BaseSnippet
-
         def initialize(cucumber_expression_generator, code_keyword, step_name, multiline_argument)
           @number_of_arguments = 0
           @code_keyword = code_keyword
@@ -80,7 +79,6 @@ module Cucumber
         def self.example(cucumber_expression_generator)
           new(cucumber_expression_generator, 'Given', 'I have 2 cukes', MultilineArgument::None.new).step
         end
-
       end
 
       class CucumberExpression < BaseSnippet

--- a/lib/cucumber/glue/step_definition.rb
+++ b/lib/cucumber/glue/step_definition.rb
@@ -18,7 +18,6 @@ module Cucumber
     #   end
     #
     class StepDefinition
-
       class MissingProc < StandardError
         def message
           'Step definitions must always have a proc or symbol'

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -278,7 +278,6 @@ module Cucumber
     def log
       Cucumber.logger
     end
-
   end
 
 end

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -11,12 +11,9 @@ require 'cucumber/step_match_search'
 module Cucumber
 
   class Runtime
-
     class SupportCode
-
       require 'forwardable'
       class StepInvoker
-
         def initialize(support_code)
           @support_code = support_code
         end
@@ -151,7 +148,6 @@ module Cucumber
       def log
         Cucumber.logger
       end
-
     end
   end
 end

--- a/lib/cucumber/runtime/user_interface.rb
+++ b/lib/cucumber/runtime/user_interface.rb
@@ -4,7 +4,6 @@ require 'timeout'
 
 module Cucumber
   class Runtime
-
     module UserInterface
       attr_writer :visitor
 
@@ -75,6 +74,5 @@ module Cucumber
         answer
       end
     end
-
   end
 end

--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -146,7 +146,6 @@ module Cucumber
   end
 
   class AmbiguousStepMatch
-
     def initialize(error)
       @error = error
     end
@@ -154,7 +153,6 @@ module Cucumber
     def activate(test_step)
       return test_step.with_action { raise @error }
     end
-
   end
 
 end

--- a/lib/cucumber/step_match_search.rb
+++ b/lib/cucumber/step_match_search.rb
@@ -49,7 +49,6 @@ module Cucumber
           top_groups
         end
       end
-
     end
 
     require 'delegate'


### PR DESCRIPTION
## Details

- Empty lines removed with the auto flag

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Rubocop style fixes
