### PR TITLE
Fix Layout/EmptyLinesAroundModuleBody

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -52,13 +52,6 @@ Layout/EmptyLinesAroundExceptionHandlingKeywords:
   Exclude:
     - 'scripts/invite-collaborator'
 
-# Offense count: 60
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
-Layout/EmptyLinesAroundModuleBody:
-  Enabled: false
-
 # Offense count: 8
 # Cop supports --auto-correct.
 # Configuration parameters: AllowForAlignment, ForceEqualSignAlignment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Improved
 
+* Fix Layout/EmptyLinesAroundModuleBody ([#1266](https://github.com/cucumber/cucumber-ruby/pull/1266) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/EmptyLineAfterMagicComment ([#1255](https://github.com/cucumber/cucumber-ruby/pull/1255) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/DotPosition ([#1254](https://github.com/cucumber/cucumber-ruby/pull/1254) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/BlockEndNewline ([#1253](https://github.com/cucumber/cucumber-ruby/pull/1253) [@jaysonesmith](https://github.com/jaysonesmith))

--- a/features/lib/support/normalise_output.rb
+++ b/features/lib/support/normalise_output.rb
@@ -47,7 +47,6 @@ module NormaliseArubaOutput
     expect(step_or_hook['result']['duration']).to be >= 0
     step_or_hook['result']['duration'] = 1
   end
-
 end
 
 World(NormaliseArubaOutput)

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -8,7 +8,6 @@ require 'cucumber/core/test/result'
 
 module Cucumber
   module Cli
-
     class Options
       INDENT = ' ' * 53
       BUILTIN_FORMATS = {
@@ -586,6 +585,5 @@ TEXT
         }
       end
     end
-
   end
 end

--- a/lib/cucumber/cli/profile_loader.rb
+++ b/lib/cucumber/cli/profile_loader.rb
@@ -4,7 +4,6 @@ require 'yaml'
 
 module Cucumber
   module Cli
-
     class ProfileLoader
 
       def initialize

--- a/lib/cucumber/deprecate.rb
+++ b/lib/cucumber/deprecate.rb
@@ -27,5 +27,4 @@ module Cucumber
   def self.deprecate(*args)
     Deprecate::STRATEGY.call(*args)
   end
-
 end

--- a/lib/cucumber/events.rb
+++ b/lib/cucumber/events.rb
@@ -3,7 +3,6 @@
 Dir[File.dirname(__FILE__) + '/events/*.rb'].map(&method(:require))
 
 module Cucumber
-
   # Events tell you what's happening while Cucumber runs your features.
   #
   # They're designed to be read-only, appropriate for writing formatters and other

--- a/lib/cucumber/events/gherkin_source_read.rb
+++ b/lib/cucumber/events/gherkin_source_read.rb
@@ -2,7 +2,6 @@ require 'cucumber/core/events'
 
 module Cucumber
   module Events
-
     # Fired after we've read in the contents of a feature file
     class GherkinSourceRead < Core::Event.new(:path, :body)
 
@@ -12,6 +11,5 @@ module Cucumber
       # The raw Gherkin source
       attr_reader :body
     end
-
   end
 end

--- a/lib/cucumber/events/step_activated.rb
+++ b/lib/cucumber/events/step_activated.rb
@@ -4,7 +4,6 @@ require 'cucumber/core/events'
 
 module Cucumber
   module Events
-
     # Event fired when a step is activated
     class StepActivated < Core::Event.new(:test_step, :step_match)
 

--- a/lib/cucumber/events/step_definition_registered.rb
+++ b/lib/cucumber/events/step_definition_registered.rb
@@ -4,7 +4,6 @@ require 'cucumber/core/events'
 
 module Cucumber
   module Events
-
     # Event fired after each step definition has been registered
     class StepDefinitionRegistered < Core::Event.new(:step_definition)
 
@@ -20,6 +19,5 @@ module Cucumber
       end
 
     end
-
   end
 end

--- a/lib/cucumber/events/test_case_finished.rb
+++ b/lib/cucumber/events/test_case_finished.rb
@@ -2,7 +2,6 @@ require 'cucumber/core/events'
 
 module Cucumber
   module Events
-
     # Signals that a {Cucumber::Core::Test::Case} has finished executing
     class TestCaseFinished < Core::Events::TestCaseFinished
 
@@ -13,6 +12,5 @@ module Cucumber
       attr_reader :result
 
     end
-
   end
 end

--- a/lib/cucumber/events/test_case_started.rb
+++ b/lib/cucumber/events/test_case_started.rb
@@ -2,7 +2,6 @@ require 'cucumber/core/events'
 
 module Cucumber
   module Events
-
     # Signals that a {Cucumber::Core::Test::Case} is about to be executed
     class TestCaseStarted < Core::Events::TestCaseStarted
 
@@ -10,6 +9,5 @@ module Cucumber
       attr_reader :test_case
 
     end
-
   end
 end

--- a/lib/cucumber/events/test_run_finished.rb
+++ b/lib/cucumber/events/test_run_finished.rb
@@ -4,10 +4,8 @@ require 'cucumber/core/events'
 
 module Cucumber
   module Events
-
     # Event fired after all test cases have finished executing
     class TestRunFinished < Core::Event.new
     end
-
   end
 end

--- a/lib/cucumber/events/test_run_started.rb
+++ b/lib/cucumber/events/test_run_started.rb
@@ -4,7 +4,6 @@ require 'cucumber/core/events'
 
 module Cucumber
   module Events
-
     # Event fired once all test cases have been filtered before
     # the first one is executed.
     class TestRunStarted < Core::Event.new(:test_cases)
@@ -12,6 +11,5 @@ module Cucumber
       # @return [Array<Cucumber::Core::Test::Case>] the test cases to be executed
       attr_reader :test_cases
     end
-
   end
 end

--- a/lib/cucumber/events/test_step_finished.rb
+++ b/lib/cucumber/events/test_step_finished.rb
@@ -2,7 +2,6 @@ require 'cucumber/core/events'
 
 module Cucumber
   module Events
-
     # Signals that a {Cucumber::Core::Test::Step} has finished executing
     class TestStepFinished < Core::Events::TestStepFinished
 
@@ -13,6 +12,5 @@ module Cucumber
       attr_reader :result
 
     end
-
   end
 end

--- a/lib/cucumber/events/test_step_started.rb
+++ b/lib/cucumber/events/test_step_started.rb
@@ -2,7 +2,6 @@ require 'cucumber/core/events'
 
 module Cucumber
   module Events
-
     # Signals that a {Cucumber::Core::Test::Step} is about to be executed
     class TestStepStarted < Core::Events::TestStepStarted
 
@@ -10,6 +9,5 @@ module Cucumber
       attr_reader :test_step
 
     end
-
   end
 end

--- a/lib/cucumber/filters/gated_receiver.rb
+++ b/lib/cucumber/filters/gated_receiver.rb
@@ -2,7 +2,6 @@
 
 module Cucumber
   module Filters
-
     class GatedReceiver
       def initialize(receiver)
         @receiver = receiver
@@ -22,6 +21,5 @@ module Cucumber
         self
       end
     end
-
   end
 end

--- a/lib/cucumber/filters/prepare_world.rb
+++ b/lib/cucumber/filters/prepare_world.rb
@@ -6,7 +6,6 @@ require 'cucumber/running_test_case'
 
 module Cucumber
   module Filters
-
     class PrepareWorld < Core::Filter.new(:runtime)
 
       def test_case(test_case)
@@ -42,6 +41,5 @@ module Cucumber
       end
 
     end
-
   end
 end

--- a/lib/cucumber/filters/quit.rb
+++ b/lib/cucumber/filters/quit.rb
@@ -2,7 +2,6 @@
 
 module Cucumber
   module Filters
-
     class Quit
       def initialize(receiver=nil)
         @receiver = receiver
@@ -24,6 +23,5 @@ module Cucumber
         self.class.new(receiver)
       end
     end
-
   end
 end

--- a/lib/cucumber/filters/randomizer.rb
+++ b/lib/cucumber/filters/randomizer.rb
@@ -4,7 +4,6 @@ require 'digest/sha2'
 
 module Cucumber
   module Filters
-
     # Batches up all test cases, randomizes them, and then sends them on
     class Randomizer
       def initialize(seed, receiver=nil)
@@ -42,6 +41,5 @@ module Cucumber
       attr_reader :seed
       private :seed
     end
-
   end
 end

--- a/lib/cucumber/filters/tag_limits.rb
+++ b/lib/cucumber/filters/tag_limits.rb
@@ -42,6 +42,5 @@ module Cucumber
       attr_reader :test_case_index
       attr_reader :verifier
     end
-
   end
 end

--- a/lib/cucumber/formatter/backtrace_filter.rb
+++ b/lib/cucumber/formatter/backtrace_filter.rb
@@ -50,6 +50,5 @@ module Cucumber
         @exception
       end
     end
-
   end
 end

--- a/lib/cucumber/formatter/console.rb
+++ b/lib/cucumber/formatter/console.rb
@@ -6,7 +6,6 @@ require 'cucumber/gherkin/i18n'
 
 module Cucumber
   module Formatter
-
     # This module contains helper methods that are used by formatters that
     # print output to the terminal.
     #
@@ -253,7 +252,6 @@ module Cucumber
           @actual_keyword, @step = actual_keyword, step
         end
       end
-
     end
   end
 end

--- a/lib/cucumber/formatter/duration_extractor.rb
+++ b/lib/cucumber/formatter/duration_extractor.rb
@@ -2,7 +2,6 @@
 
 module Cucumber
   module Formatter
-
     class DurationExtractor
       attr_reader :result_duration
       def initialize(result)

--- a/lib/cucumber/formatter/fail_fast.rb
+++ b/lib/cucumber/formatter/fail_fast.rb
@@ -5,7 +5,6 @@ require 'cucumber/formatter/console'
 
 module Cucumber
   module Formatter
-
     class FailFast
 
       def initialize(configuration)
@@ -16,6 +15,5 @@ module Cucumber
       end
 
     end
-
   end
 end

--- a/lib/cucumber/formatter/fanout.rb
+++ b/lib/cucumber/formatter/fanout.rb
@@ -2,7 +2,6 @@
 
 module Cucumber
   module Formatter
-
     # Forwards any messages sent to this object to all recipients
     # that respond to that message.
     class Fanout < BasicObject
@@ -24,6 +23,5 @@ module Cucumber
       end
 
     end
-
   end
 end

--- a/lib/cucumber/formatter/ignore_missing_messages.rb
+++ b/lib/cucumber/formatter/ignore_missing_messages.rb
@@ -2,7 +2,6 @@
 
 module Cucumber
   module Formatter
-
     class IgnoreMissingMessages < BasicObject
       def initialize(receiver)
         @receiver = receiver
@@ -16,6 +15,5 @@ module Cucumber
         @receiver.respond_to?(name, include_private)
       end
     end
-
   end
 end

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -241,6 +241,5 @@ module Cucumber
         duration.tap { |duration| @test_case_duration = duration.nanoseconds / 10**9.0 }
       end
     end
-
   end
 end

--- a/lib/cucumber/formatter/summary.rb
+++ b/lib/cucumber/formatter/summary.rb
@@ -8,7 +8,6 @@ require 'cucumber/core/test/result'
 
 module Cucumber
   module Formatter
-
     # Summary formatter, outputting only feature / scenario titles
     class Summary
       include Io

--- a/lib/cucumber/glue/invoke_in_world.rb
+++ b/lib/cucumber/glue/invoke_in_world.rb
@@ -66,6 +66,5 @@ module Cucumber
     # is different from the number of Proc arguments.
     class ArityMismatchError < StandardError
     end
-
   end
 end

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -10,7 +10,6 @@ module Cucumber
     # You can, and probably should, extend this API with your own methods that
     # make sense in your domain. For more on that, see {Cucumber::Glue::Dsl#World}
     module ProtoWorld
-
       # Run a single Gherkin step
       # @example Call another step
       #   step "I am logged in"

--- a/lib/cucumber/glue/snippet.rb
+++ b/lib/cucumber/glue/snippet.rb
@@ -3,7 +3,6 @@
 module Cucumber
   module Glue
     module Snippet
-
       ARGUMENT_PATTERNS = ['"([^"]*)"', '(\d+)']
 
       class Generator
@@ -151,7 +150,6 @@ module Cucumber
       }
 
       module MultilineArgumentSnippet
-
         def self.new(multiline_argument)
           builder = Builder.new
           multiline_argument.describe_to(builder)

--- a/lib/cucumber/glue/world_factory.rb
+++ b/lib/cucumber/glue/world_factory.rb
@@ -1,6 +1,5 @@
 module Cucumber
   module Glue
-
     class WorldFactory
       def initialize(proc)
         @proc = proc || -> { Object.new }
@@ -18,6 +17,5 @@ module Cucumber
         raise e
       end
     end
-
   end
 end

--- a/lib/cucumber/hooks.rb
+++ b/lib/cucumber/hooks.rb
@@ -5,11 +5,9 @@ require 'cucumber/core/ast/location'
 require 'cucumber/core/test/around_hook'
 
 module Cucumber
-
   # Hooks quack enough like `Cucumber::Core::Ast` source nodes that we can use them as
   # source for test steps
   module Hooks
-
     class << self
       def before_hook(source, location, &block)
         build_hook_step(source, location, block, BeforeHook, Core::Test::UnskippableAction)
@@ -108,6 +106,5 @@ module Cucumber
         visitor.after_step_hook(self, *args)
       end
     end
-
   end
 end

--- a/lib/cucumber/multiline_argument.rb
+++ b/lib/cucumber/multiline_argument.rb
@@ -6,7 +6,6 @@ require 'cucumber/multiline_argument/doc_string'
 
 module Cucumber
   module MultilineArgument
-
     class << self
       def from_core(node)
         builder.wrap(node)

--- a/lib/cucumber/project_initializer.rb
+++ b/lib/cucumber/project_initializer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module Cucumber
-
   # Generates generic file structure for a cucumber project
   class ProjectInitializer
     def run

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -280,5 +280,4 @@ module Cucumber
     end
 
   end
-
 end

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -9,7 +9,6 @@ require 'cucumber/gherkin/steps_parser'
 require 'cucumber/step_match_search'
 
 module Cucumber
-
   class Runtime
 
     class SupportCode

--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -3,7 +3,6 @@
 require 'cucumber/multiline_argument'
 
 module Cucumber
-
   # Represents the match found between a Test Step and its activation
   class StepMatch #:nodoc:
     attr_reader :step_definition, :step_arguments
@@ -156,5 +155,4 @@ module Cucumber
     end
 
   end
-
 end

--- a/lib/cucumber/step_match_search.rb
+++ b/lib/cucumber/step_match_search.rb
@@ -63,6 +63,5 @@ module Cucumber
         @match_cache[step_name] = super(step_name)
       end
     end
-
   end
 end


### PR DESCRIPTION
## Details

- (more) Empty lines removed with the auto flag

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Rubocop style fixes
