### PR TITLE
Fix Layout/IndentHeredoc, Consistency, IndentationWidth, and new violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,13 +18,26 @@ AllCops:
     - 'lib/cucumber/formatter/legacy_api/*'
     - 'spec/cucumber/formatter/legacy_api/*'
 
-# Reviewed: please see PR-1022 for details on why this cop is disabled: https://github.com/cucumber/cucumber-ruby/pull/1022
+# Reviewed: please see PR-1022 for details on why this cop is disabled:
+# https://github.com/cucumber/cucumber-ruby/pull/1022
 Lint/AmbiguousOperator:
   Enabled: false
 
 # Disabling for appveyor
 Layout/EndOfLine:
   Enabled: false
+
+# Disabling this cop until the minimum Ruby version is >= 2.3 as squiggly
+# heredocs '<<~' were introduced them. The files below are the current ones
+# with offenses
+Layout/IndentHeredoc:
+  Exclude:
+    - 'features/lib/support/feature_factory.rb'
+    - 'lib/cucumber/cli/options.rb'
+    - 'lib/cucumber/cli/profile_loader.rb'
+    - 'spec/cucumber/cli/configuration_spec.rb'
+    - 'spec/cucumber/cli/profile_loader_spec.rb'
+    - 'spec/cucumber/formatter/pretty_spec.rb'
 
 # Reviewed: Formatters put trailing spaces after things like 'Feature: '
 #           In pretty_spec.rb, progress_spec.rb offences look false,

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -88,41 +88,6 @@ Layout/IndentArray:
 Layout/IndentHash:
   EnforcedStyle: consistent
 
-# Offense count: 12
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: auto_detection, squiggly, active_support, powerpack, unindent
-Layout/IndentHeredoc:
-  Exclude:
-    - 'features/lib/support/feature_factory.rb'
-    - 'lib/cucumber/cli/options.rb'
-    - 'lib/cucumber/cli/profile_loader.rb'
-    - 'spec/cucumber/cli/configuration_spec.rb'
-    - 'spec/cucumber/cli/profile_loader_spec.rb'
-    - 'spec/cucumber/formatter/pretty_spec.rb'
-
-# Offense count: 7
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: normal, rails
-Layout/IndentationConsistency:
-  Exclude:
-    - 'lib/cucumber/formatter/html.rb'
-    - 'spec/cucumber/cli/configuration_spec.rb'
-    - 'spec/cucumber/formatter/html_spec.rb'
-    - 'spec/cucumber/step_match_search_spec.rb'
-
-# Offense count: 6
-# Cop supports --auto-correct.
-# Configuration parameters: Width, IgnoredPatterns.
-Layout/IndentationWidth:
-  Exclude:
-    - 'lib/cucumber/gherkin/formatter/ansi_escapes.rb'
-    - 'lib/cucumber/gherkin/formatter/escaping.rb'
-    - 'spec/cucumber/cli/configuration_spec.rb'
-    - 'spec/cucumber/multiline_argument/data_table_spec.rb'
-    - 'spec/cucumber/step_match_search_spec.rb'
-
 # Offense count: 18
 # Cop supports --auto-correct.
 Layout/LeadingCommentSpace:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Changed
 
+* Fix Layout/IndentHeredoc, Consistency, IndentationWidth, and new violations ([#1269](https://github.com/cucumber/cucumber-ruby/pull/1269) [@jaysonesmith](https://github.com/jaysonesmith))
 * Add Rubocop to default Rake task ([#1256](https://github.com/cucumber/cucumber-ruby/pull/1256) [@jaysonesmith](https://github.com/jaysonesmith))
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Improved
 
+* Fix Layout/IndentHeredoc, Consistency, IndentationWidth, and new violations ([#1269](https://github.com/cucumber/cucumber-ruby/pull/1269) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/EmptyLineAfterMagicComment ([#1255](https://github.com/cucumber/cucumber-ruby/pull/1255) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/DotPosition ([#1254](https://github.com/cucumber/cucumber-ruby/pull/1254) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/BlockEndNewline ([#1253](https://github.com/cucumber/cucumber-ruby/pull/1253) [@jaysonesmith](https://github.com/jaysonesmith))

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -582,10 +582,10 @@ module Cucumber
         def lines_around(file, line)
           if File.file?(file)
             begin
-            lines = File.open(file).read.split("\n")
-          rescue ArgumentError
-            return "# Couldn't get snippet for #{file}"
-          end
+              lines = File.open(file).read.split("\n")
+            rescue ArgumentError
+              return "# Couldn't get snippet for #{file}"
+            end
             min = [0, line-3].max
             max = [line+1, lines.length-1].min
             selected_lines = []

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -366,12 +366,12 @@ module Cucumber
       def print_messages
         return if @delayed_messages.empty?
 
-          #builder.ol do
-          @delayed_messages.each do |ann|
-            builder.li(:class => 'step message') do
-              builder << ann
-            end
+        #builder.ol do
+        @delayed_messages.each do |ann|
+          builder.li(:class => 'step message') do
+            builder << ann
           end
+        end
         #end
         empty_messages
       end
@@ -590,7 +590,7 @@ module Cucumber
           rescue ArgumentError
             return "# Couldn't get snippet for #{file}"
           end
-          min = [0, line-3].max
+            min = [0, line-3].max
             max = [line+1, lines.length-1].min
             selected_lines = []
             selected_lines.join("\n")

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -359,19 +359,16 @@ module Cucumber
 
       def puts(message)
         @delayed_messages << message
-        # builder.pre(message, :class => 'message')
       end
 
       def print_messages
         return if @delayed_messages.empty?
 
-        #builder.ol do
         @delayed_messages.each do |ann|
           builder.li(:class => 'step message') do
             builder << ann
           end
         end
-        #end
         empty_messages
       end
 

--- a/lib/cucumber/gherkin/formatter/ansi_escapes.rb
+++ b/lib/cucumber/gherkin/formatter/ansi_escapes.rb
@@ -1,101 +1,101 @@
 # frozen_string_literal: true
 
 module Cucumber
-module Gherkin
-  module Formatter
-    # Defines aliases for ANSI coloured output. Default colours can be overridden by defining
-    # a <tt>GHERKIN_COLORS</tt> variable in your shell, very much like how you can
-    # tweak the familiar POSIX command <tt>ls</tt> with
-    # $LSCOLORS: http://linux-sxs.org/housekeeping/lscolors.html
-    #
-    # The colours that you can change are:
-    #
-    # <tt>undefined</tt>::     defaults to <tt>yellow</tt>
-    # <tt>pending</tt>::       defaults to <tt>yellow</tt>
-    # <tt>pending_arg</tt>::   defaults to <tt>yellow,bold</tt>
-    # <tt>executing</tt>::     defaults to <tt>grey</tt>
-    # <tt>executing_arg</tt>:: defaults to <tt>grey,bold</tt>
-    # <tt>failed</tt>::        defaults to <tt>red</tt>
-    # <tt>failed_arg</tt>::    defaults to <tt>red,bold</tt>
-    # <tt>passed</tt>::        defaults to <tt>green</tt>
-    # <tt>passed_arg</tt>::    defaults to <tt>green,bold</tt>
-    # <tt>outline</tt>::       defaults to <tt>cyan</tt>
-    # <tt>outline_arg</tt>::   defaults to <tt>cyan,bold</tt>
-    # <tt>skipped</tt>::       defaults to <tt>cyan</tt>
-    # <tt>skipped_arg</tt>::   defaults to <tt>cyan,bold</tt>
-    # <tt>comment</tt>::       defaults to <tt>grey</tt>
-    # <tt>tag</tt>::           defaults to <tt>cyan</tt>
-    #
-    # For instance, if your shell has a black background and a green font (like the
-    # "Homebrew" settings for OS X' Terminal.app), you may want to override passed
-    # steps to be white instead of green. Examples:
-    #
-    #   export GHERKIN_COLORS="passed=white"
-    #   export GHERKIN_COLORS="passed=white,bold:passed_arg=white,bold,underline"
-    #
-    # (If you're on Windows, use SET instead of export).
-    # To see what colours and effects are available, just run this in your shell:
-    #
-    #   ruby -e "require 'rubygems'; require 'term/ansicolor'; puts Term::ANSIColor.attributes"
-    #
-    # Although not listed, you can also use <tt>grey</tt>
-    module AnsiEscapes
-      COLORS = {
-        'black'   => "\e[30m",
-        'red'     => "\e[31m",
-        'green'   => "\e[32m",
-        'yellow'  => "\e[33m",
-        'blue'    => "\e[34m",
-        'magenta' => "\e[35m",
-        'cyan'    => "\e[36m",
-        'white'   => "\e[37m",
-        'grey'    => "\e[90m",
-        'bold'    => "\e[1m"
-      }
+  module Gherkin
+    module Formatter
+      # Defines aliases for ANSI coloured output. Default colours can be overridden by defining
+      # a <tt>GHERKIN_COLORS</tt> variable in your shell, very much like how you can
+      # tweak the familiar POSIX command <tt>ls</tt> with
+      # $LSCOLORS: http://linux-sxs.org/housekeeping/lscolors.html
+      #
+      # The colours that you can change are:
+      #
+      # <tt>undefined</tt>::     defaults to <tt>yellow</tt>
+      # <tt>pending</tt>::       defaults to <tt>yellow</tt>
+      # <tt>pending_arg</tt>::   defaults to <tt>yellow,bold</tt>
+      # <tt>executing</tt>::     defaults to <tt>grey</tt>
+      # <tt>executing_arg</tt>:: defaults to <tt>grey,bold</tt>
+      # <tt>failed</tt>::        defaults to <tt>red</tt>
+      # <tt>failed_arg</tt>::    defaults to <tt>red,bold</tt>
+      # <tt>passed</tt>::        defaults to <tt>green</tt>
+      # <tt>passed_arg</tt>::    defaults to <tt>green,bold</tt>
+      # <tt>outline</tt>::       defaults to <tt>cyan</tt>
+      # <tt>outline_arg</tt>::   defaults to <tt>cyan,bold</tt>
+      # <tt>skipped</tt>::       defaults to <tt>cyan</tt>
+      # <tt>skipped_arg</tt>::   defaults to <tt>cyan,bold</tt>
+      # <tt>comment</tt>::       defaults to <tt>grey</tt>
+      # <tt>tag</tt>::           defaults to <tt>cyan</tt>
+      #
+      # For instance, if your shell has a black background and a green font (like the
+      # "Homebrew" settings for OS X' Terminal.app), you may want to override passed
+      # steps to be white instead of green. Examples:
+      #
+      #   export GHERKIN_COLORS="passed=white"
+      #   export GHERKIN_COLORS="passed=white,bold:passed_arg=white,bold,underline"
+      #
+      # (If you're on Windows, use SET instead of export).
+      # To see what colours and effects are available, just run this in your shell:
+      #
+      #   ruby -e "require 'rubygems'; require 'term/ansicolor'; puts Term::ANSIColor.attributes"
+      #
+      # Although not listed, you can also use <tt>grey</tt>
+      module AnsiEscapes
+        COLORS = {
+          'black'   => "\e[30m",
+          'red'     => "\e[31m",
+          'green'   => "\e[32m",
+          'yellow'  => "\e[33m",
+          'blue'    => "\e[34m",
+          'magenta' => "\e[35m",
+          'cyan'    => "\e[36m",
+          'white'   => "\e[37m",
+          'grey'    => "\e[90m",
+          'bold'    => "\e[1m"
+        }
 
-      ALIASES = Hash.new do |h,k|
-        if k.to_s =~ /(.*)_arg/
-          h[$1] + ',bold'
-        end
-      end.merge({
-        'undefined' => 'yellow',
-        'pending'   => 'yellow',
-        'executing' => 'grey',
-        'failed'    => 'red',
-        'passed'    => 'green',
-        'outline'   => 'cyan',
-        'skipped'   => 'cyan',
-        'comments'  => 'grey',
-        'tag'       => 'cyan'
-      })
+        ALIASES = Hash.new do |h,k|
+          if k.to_s =~ /(.*)_arg/
+            h[$1] + ',bold'
+          end
+        end.merge({
+          'undefined' => 'yellow',
+          'pending'   => 'yellow',
+          'executing' => 'grey',
+          'failed'    => 'red',
+          'passed'    => 'green',
+          'outline'   => 'cyan',
+          'skipped'   => 'cyan',
+          'comments'  => 'grey',
+          'tag'       => 'cyan'
+        })
 
-      if ENV['GHERKIN_COLORS'] # Example: export GHERKIN_COLORS="passed=red:failed=yellow"
-        ENV['GHERKIN_COLORS'].split(':').each do |pair|
-          a = pair.split('=')
-          ALIASES[a[0]] = a[1]
-        end
-      end
-
-      ALIASES.keys.each do |key|
-        define_method(key) do
-          ALIASES[key].split(',').map{|color| COLORS[color]}.join('')
+        if ENV['GHERKIN_COLORS'] # Example: export GHERKIN_COLORS="passed=red:failed=yellow"
+          ENV['GHERKIN_COLORS'].split(':').each do |pair|
+            a = pair.split('=')
+            ALIASES[a[0]] = a[1]
+          end
         end
 
-        define_method("#{key}_arg") do
-          ALIASES["#{key}_arg"].split(',').map{|color| COLORS[color]}.join('')
+        ALIASES.keys.each do |key|
+          define_method(key) do
+            ALIASES[key].split(',').map{|color| COLORS[color]}.join('')
+          end
+
+          define_method("#{key}_arg") do
+            ALIASES["#{key}_arg"].split(',').map{|color| COLORS[color]}.join('')
+          end
         end
-      end
 
-      def reset
-        "\e[0m"
-      end
+        def reset
+          "\e[0m"
+        end
 
-      def up(n)
-        "\e[#{n}A"
-      end
+        def up(n)
+          "\e[#{n}A"
+        end
 
-      extend self
+        extend self
+      end
     end
   end
-end
 end

--- a/lib/cucumber/gherkin/formatter/escaping.rb
+++ b/lib/cucumber/gherkin/formatter/escaping.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 module Cucumber
-module Gherkin
-  module Formatter
-    module Escaping
-      # Escapes a pipes and backslashes:
-      #
-      # * | becomes \|
-      # * \ becomes \\
-      #
-      # This is used in the pretty formatter.
-      def escape_cell(s)
-        s.gsub(/\\(?!\|)/, '\\\\\\\\').gsub(/\n/, '\\n').gsub(/\|/, '\\|')
+  module Gherkin
+    module Formatter
+      module Escaping
+        # Escapes a pipes and backslashes:
+        #
+        # * | becomes \|
+        # * \ becomes \\
+        #
+        # This is used in the pretty formatter.
+        def escape_cell(s)
+          s.gsub(/\\(?!\|)/, '\\\\\\\\').gsub(/\n/, '\\n').gsub(/\|/, '\\|')
+        end
       end
     end
   end
-end
 end

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -107,7 +107,7 @@ ERB_YML
         end
 
         it 'provides a helpful error message when a specified profile does not exists in cucumber.yml' do
-          given_cucumber_yml_defined_as({'default' => '--require from/yml', 'html_report' =>  '--format html'})
+          given_cucumber_yml_defined_as({'default' => '--require from/yml', 'html_report' => '--format html'})
 
           expected_message = <<-END_OF_MESSAGE
 Could not find profile: 'i_do_not_exist'
@@ -121,7 +121,7 @@ END_OF_MESSAGE
         end
 
         it 'allows profiles to be defined in arrays' do
-          given_cucumber_yml_defined_as({'foo' => ['-f','progress']})
+          given_cucumber_yml_defined_as({'foo' => ['-f', 'progress']})
 
           config.parse!(%w{--profile foo})
 
@@ -178,7 +178,9 @@ END_OF_MESSAGE
 
           ['', 'sfsadfs', "--- \n- an\n- array\n", '---dddfd'].each do |bad_input|
             given_cucumber_yml_defined_as(bad_input)
+
             expect(-> { config.parse!([]) }).to raise_error(expected_error_message)
+
             reset_config
           end
         end
@@ -282,7 +284,7 @@ END_OF_MESSAGE
       end
 
       it 'does not accept multiple --out streams pointing to the same place (one from profile, one from command line)' do
-        given_cucumber_yml_defined_as({'default' => ['-f','progress', '--out', 'file1']})
+        given_cucumber_yml_defined_as({'default' => ['-f', 'progress', '--out', 'file1']})
         expect(-> { config.parse!(%w{--format pretty --out file1}) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
       end
 
@@ -373,7 +375,7 @@ END_OF_MESSAGE
         end
 
         it 'returns an expression when tags are specified' do
-          config.parse!(['--tags','@foo'])
+          config.parse!(['--tags', '@foo'])
 
           expect(config.tag_expressions).not_to be_empty
         end
@@ -387,7 +389,11 @@ END_OF_MESSAGE
         end
 
         it 'returns a hash of limits when limits are specified' do
-          config.parse!(['--tags','@foo:1'])
+          config.parse!(['--tags', '@foo:1'])
+
+          expect(config.tag_limits).to eq({ '@foo' => 1 })
+        end
+      end
 
       describe '#dry_run?' do
         it 'returns true when --dry-run was specified on in the arguments' do

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -4,112 +4,112 @@ require 'spec_helper'
 require 'yaml'
 
 module Cucumber
-module Cli
-  describe Configuration do
-    module ExposesOptions
-      attr_reader :options
-    end
-
-    def given_cucumber_yml_defined_as(hash_or_string)
-      allow(File).to receive(:exist?) { true }
-
-      cucumber_yml = hash_or_string.is_a?(Hash) ? hash_or_string.to_yaml : hash_or_string
-
-      allow(IO).to receive(:read).with('cucumber.yml') { cucumber_yml }
-    end
-
-    def given_the_following_files(*files)
-      allow(File).to receive(:directory?) { true }
-      allow(File).to receive(:file?) { true }
-      allow(Dir).to receive(:[]) { files }
-    end
-
-    before(:each) do
-      allow(File).to receive(:exist?) { false } # Meaning, no cucumber.yml exists
-      allow(Kernel).to receive(:exit)
-    end
-
-    def config
-      @config ||= Configuration.new(@out = StringIO.new, @error = StringIO.new).extend(ExposesOptions)
-    end
-
-    def reset_config
-      @config = nil
-    end
-
-    attr_reader :out, :error
-
-    it 'uses the default profile when no profile is defined' do
-      given_cucumber_yml_defined_as({'default' => '--require some_file'})
-
-      config.parse!(%w{--format progress})
-
-      expect(config.options[:require]).to include('some_file')
-    end
-
-    context '--profile' do
-      include RSpec::WorkInProgress
-
-      it 'expands args from profiles in the cucumber.yml file' do
-        given_cucumber_yml_defined_as({'bongo' => '--require from/yml'})
-
-        config.parse!(%w{--format progress --profile bongo})
-
-        expect(config.options[:formats]).to eq [['progress', {}, out]]
-        expect(config.options[:require]).to eq ['from/yml']
+  module Cli
+    describe Configuration do
+      module ExposesOptions
+        attr_reader :options
       end
 
-      it 'expands args from the default profile when no flags are provided' do
-        given_cucumber_yml_defined_as({'default' => '--require from/yml'})
+      def given_cucumber_yml_defined_as(hash_or_string)
+        allow(File).to receive(:exist?) { true }
 
-        config.parse!([])
+        cucumber_yml = hash_or_string.is_a?(Hash) ? hash_or_string.to_yaml : hash_or_string
 
-        expect(config.options[:require]).to eq ['from/yml']
+        allow(IO).to receive(:read).with('cucumber.yml') { cucumber_yml }
       end
 
-      it 'allows --strict to be set by a profile' do
-        given_cucumber_yml_defined_as({'bongo' => '--strict'})
-
-        config.parse!(%w{--profile bongo})
-
-        expect(config.options[:strict].strict?(:undefined)).to be true
-        expect(config.options[:strict].strict?(:pending)).to be true
-        expect(config.options[:strict].strict?(:flaky)).to be true
+      def given_the_following_files(*files)
+        allow(File).to receive(:directory?) { true }
+        allow(File).to receive(:file?) { true }
+        allow(Dir).to receive(:[]) { files }
       end
 
-      it 'allows --strict from a profile to be selectively overridden' do
-        given_cucumber_yml_defined_as({'bongo' => '--strict'})
-
-        config.parse!(%w{--profile bongo --no-strict-flaky})
-
-        expect(config.options[:strict].strict?(:undefined)).to be true
-        expect(config.options[:strict].strict?(:pending)).to be true
-        expect(config.options[:strict].strict?(:flaky)).to be false
+      before(:each) do
+        allow(File).to receive(:exist?) { false } # Meaning, no cucumber.yml exists
+        allow(Kernel).to receive(:exit)
       end
 
-      it 'parses ERB syntax in the cucumber.yml file' do
-        given_cucumber_yml_defined_as("---\ndefault: \"<%=\"--require some_file\"%>\"\n")
+      def config
+        @config ||= Configuration.new(@out = StringIO.new, @error = StringIO.new).extend(ExposesOptions)
+      end
 
-        config.parse!([])
+      def reset_config
+        @config = nil
+      end
+
+      attr_reader :out, :error
+
+      it 'uses the default profile when no profile is defined' do
+        given_cucumber_yml_defined_as({'default' => '--require some_file'})
+
+        config.parse!(%w{--format progress})
 
         expect(config.options[:require]).to include('some_file')
       end
 
-      it 'parses ERB in cucumber.yml that makes uses nested ERB sessions' do
-        given_cucumber_yml_defined_as(<<ERB_YML)
+      context '--profile' do
+        include RSpec::WorkInProgress
+
+        it 'expands args from profiles in the cucumber.yml file' do
+          given_cucumber_yml_defined_as({'bongo' => '--require from/yml'})
+
+          config.parse!(%w{--format progress --profile bongo})
+
+          expect(config.options[:formats]).to eq [['progress', {}, out]]
+          expect(config.options[:require]).to eq ['from/yml']
+        end
+
+        it 'expands args from the default profile when no flags are provided' do
+          given_cucumber_yml_defined_as({'default' => '--require from/yml'})
+
+          config.parse!([])
+
+          expect(config.options[:require]).to eq ['from/yml']
+        end
+
+        it 'allows --strict to be set by a profile' do
+          given_cucumber_yml_defined_as({'bongo' => '--strict'})
+
+          config.parse!(%w{--profile bongo})
+
+          expect(config.options[:strict].strict?(:undefined)).to be true
+          expect(config.options[:strict].strict?(:pending)).to be true
+          expect(config.options[:strict].strict?(:flaky)).to be true
+        end
+
+        it 'allows --strict from a profile to be selectively overridden' do
+          given_cucumber_yml_defined_as({'bongo' => '--strict'})
+
+          config.parse!(%w{--profile bongo --no-strict-flaky})
+
+          expect(config.options[:strict].strict?(:undefined)).to be true
+          expect(config.options[:strict].strict?(:pending)).to be true
+          expect(config.options[:strict].strict?(:flaky)).to be false
+        end
+
+        it 'parses ERB syntax in the cucumber.yml file' do
+          given_cucumber_yml_defined_as("---\ndefault: \"<%=\"--require some_file\"%>\"\n")
+
+          config.parse!([])
+
+          expect(config.options[:require]).to include('some_file')
+        end
+
+        it 'parses ERB in cucumber.yml that makes uses nested ERB sessions' do
+          given_cucumber_yml_defined_as(<<ERB_YML)
 <%= ERB.new({'standard' => '--require some_file'}.to_yaml).result %>
 <%= ERB.new({'enhanced' => '--require other_file'}.to_yaml).result %>
 ERB_YML
 
-        config.parse!(%w(-p standard))
+          config.parse!(%w(-p standard))
 
-        expect(config.options[:require]).to include('some_file')
-      end
+          expect(config.options[:require]).to include('some_file')
+        end
 
-      it 'provides a helpful error message when a specified profile does not exists in cucumber.yml' do
-        given_cucumber_yml_defined_as({'default' => '--require from/yml', 'html_report' =>  '--format html'})
+        it 'provides a helpful error message when a specified profile does not exists in cucumber.yml' do
+          given_cucumber_yml_defined_as({'default' => '--require from/yml', 'html_report' =>  '--format html'})
 
-        expected_message = <<-END_OF_MESSAGE
+          expected_message = <<-END_OF_MESSAGE
 Could not find profile: 'i_do_not_exist'
 
 Defined profiles in cucumber.yml:
@@ -117,331 +117,329 @@ Defined profiles in cucumber.yml:
   * html_report
 END_OF_MESSAGE
 
-        expect(-> { config.parse!(%w{--profile i_do_not_exist}) }).to raise_error(ProfileNotFound, expected_message)
-      end
+          expect(-> { config.parse!(%w{--profile i_do_not_exist}) }).to raise_error(ProfileNotFound, expected_message)
+        end
 
-      it 'allows profiles to be defined in arrays' do
-        given_cucumber_yml_defined_as({'foo' => ['-f','progress']})
+        it 'allows profiles to be defined in arrays' do
+          given_cucumber_yml_defined_as({'foo' => ['-f','progress']})
 
-        config.parse!(%w{--profile foo})
+          config.parse!(%w{--profile foo})
 
-        expect(config.options[:formats]).to eq [['progress', {}, out]]
-      end
+          expect(config.options[:formats]).to eq [['progress', {}, out]]
+        end
 
-      it 'disregards default STDOUT formatter defined in profile when another is passed in (via cmd line)' do
-        given_cucumber_yml_defined_as({'foo' => %w[--format pretty]})
-        config.parse!(%w{--format progress --profile foo})
+        it 'disregards default STDOUT formatter defined in profile when another is passed in (via cmd line)' do
+          given_cucumber_yml_defined_as({'foo' => %w[--format pretty]})
+          config.parse!(%w{--format progress --profile foo})
 
-        expect(config.options[:formats]).to eq [['progress', {}, out]]
-      end
+          expect(config.options[:formats]).to eq [['progress', {}, out]]
+        end
 
-      ['--no-profile', '-P'].each do |flag|
-        context 'when none is specified with #{flag}' do
-          it 'disables profiles' do
-            given_cucumber_yml_defined_as({'default' => '-v --require file_specified_in_default_profile.rb'})
+        ['--no-profile', '-P'].each do |flag|
+          context 'when none is specified with #{flag}' do
+            it 'disables profiles' do
+              given_cucumber_yml_defined_as({'default' => '-v --require file_specified_in_default_profile.rb'})
 
-            config.parse!("#{flag} --require some_file.rb".split(' '))
+              config.parse!("#{flag} --require some_file.rb".split(' '))
 
-            expect(config.options[:require]).to eq ['some_file.rb']
-          end
+              expect(config.options[:require]).to eq ['some_file.rb']
+            end
 
-          it 'notifies the user that the profiles are being disabled' do
-            given_cucumber_yml_defined_as({'default' => '-v'})
+            it 'notifies the user that the profiles are being disabled' do
+              given_cucumber_yml_defined_as({'default' => '-v'})
 
-            config.parse!("#{flag} --require some_file.rb".split(' '))
+              config.parse!("#{flag} --require some_file.rb".split(' '))
 
-            expect(out.string).to match(/Disabling profiles.../)
+              expect(out.string).to match(/Disabling profiles.../)
+            end
           end
         end
-      end
 
-      it 'issues a helpful error message when a specified profile exists but is nil or blank' do
-        [nil, '   '].each do |bad_input|
-          given_cucumber_yml_defined_as({'foo' => bad_input})
+        it 'issues a helpful error message when a specified profile exists but is nil or blank' do
+          [nil, '   '].each do |bad_input|
+            given_cucumber_yml_defined_as({'foo' => bad_input})
 
-          expected_error = /The 'foo' profile in cucumber.yml was blank.  Please define the command line arguments for the 'foo' profile in cucumber.yml./
+            expected_error = /The 'foo' profile in cucumber.yml was blank.  Please define the command line arguments for the 'foo' profile in cucumber.yml./
 
-          expect(-> { config.parse!(%w{--profile foo}) }).to raise_error(expected_error)
+            expect(-> { config.parse!(%w{--profile foo}) }).to raise_error(expected_error)
+          end
         end
-      end
 
-      it 'issues a helpful error message when no YAML file exists and a profile is specified' do
-        expect(File).to receive(:exist?).with('cucumber.yml') { false }
+        it 'issues a helpful error message when no YAML file exists and a profile is specified' do
+          expect(File).to receive(:exist?).with('cucumber.yml') { false }
 
-        expected_error = /cucumber\.yml was not found/
+          expected_error = /cucumber\.yml was not found/
 
-        expect(-> { config.parse!(%w{--profile i_do_not_exist}) }).to raise_error(expected_error)
-      end
+          expect(-> { config.parse!(%w{--profile i_do_not_exist}) }).to raise_error(expected_error)
+        end
 
-      it 'issues a helpful error message when cucumber.yml is blank or malformed' do
+        it 'issues a helpful error message when cucumber.yml is blank or malformed' do
           expected_error_message = /cucumber\.yml was found, but was blank or malformed. Please refer to cucumber's documentation on correct profile usage./
 
-        ['', 'sfsadfs', "--- \n- an\n- array\n", '---dddfd'].each do |bad_input|
-          given_cucumber_yml_defined_as(bad_input)
+          ['', 'sfsadfs', "--- \n- an\n- array\n", '---dddfd'].each do |bad_input|
+            given_cucumber_yml_defined_as(bad_input)
+            expect(-> { config.parse!([]) }).to raise_error(expected_error_message)
+            reset_config
+          end
+        end
+
+        it 'issues a helpful error message when cucumber.yml can not be parsed' do
+          expected_error_message = /cucumber.yml was found, but could not be parsed. Please refer to cucumber's documentation on correct profile usage./
+
+          given_cucumber_yml_defined_as('input that causes an exception in YAML loading')
+
+          expect(YAML).to receive(:load).and_raise(ArgumentError)
+          expect(-> { config.parse!([]) }).to raise_error(expected_error_message)
+        end
+
+        it 'issues a helpful error message when cucumber.yml can not be parsed by ERB' do
+          expected_error_message = /cucumber.yml was found, but could not be parsed with ERB.  Please refer to cucumber's documentation on correct profile usage./
+          given_cucumber_yml_defined_as('<% this_fails %>')
 
           expect(-> { config.parse!([]) }).to raise_error(expected_error_message)
-
-          reset_config
         end
       end
 
-      it 'issues a helpful error message when cucumber.yml can not be parsed' do
-        expected_error_message = /cucumber.yml was found, but could not be parsed. Please refer to cucumber's documentation on correct profile usage./
+      it 'accepts --dry-run option' do
+        config.parse!(%w{--dry-run})
 
-        given_cucumber_yml_defined_as('input that causes an exception in YAML loading')
-
-        expect(YAML).to receive(:load).and_raise(ArgumentError)
-        expect(-> { config.parse!([]) }).to raise_error(expected_error_message)
+        expect(config.options[:dry_run]).to be true
       end
 
-      it 'issues a helpful error message when cucumber.yml can not be parsed by ERB' do
-        expected_error_message = /cucumber.yml was found, but could not be parsed with ERB.  Please refer to cucumber's documentation on correct profile usage./
-        given_cucumber_yml_defined_as('<% this_fails %>')
+      it 'implies --no-duration with --dry-run option' do
+        config.parse!(%w{--dry-run})
 
-        expect(-> { config.parse!([]) }).to raise_error(expected_error_message)
-      end
-    end
-
-    it 'accepts --dry-run option' do
-      config.parse!(%w{--dry-run})
-
-      expect(config.options[:dry_run]).to be true
-    end
-
-    it 'implies --no-duration with --dry-run option' do
-      config.parse!(%w{--dry-run})
-
-      expect(config.options[:duration]).to be false
-    end
-
-    it 'accepts --no-source option' do
-      config.parse!(%w{--no-source})
-
-      expect(config.options[:source]).to be false
-    end
-
-    it 'accepts --no-snippets option' do
-      config.parse!(%w{--no-snippets})
-
-      expect(config.options[:snippets]).to be false
-    end
-
-    it 'sets snippets and source and duration to false with --quiet option' do
-      config.parse!(%w{--quiet})
-
-      expect(config.options[:snippets]).to be false
-      expect(config.options[:source]).to be false
-      expect(config.options[:duration]).to be false
-    end
-
-    it 'sets duration to false with --no-duration' do
-      config.parse!(%w{--no-duration})
-
-      expect(config.options[:duration]).to be false
-    end
-
-    it 'accepts --verbose option' do
-      config.parse!(%w{--verbose})
-
-      expect(config.options[:verbose]).to be true
-    end
-
-    it 'accepts --out option' do
-      config.parse!(%w{--out jalla.txt})
-
-      expect(config.formats).to eq [['pretty', {}, 'jalla.txt']]
-    end
-
-    it 'accepts multiple --out options' do
-      config.parse!(%w{--format progress --out file1 --out file2})
-
-      expect(config.formats).to eq [['progress', {}, 'file2']]
-    end
-
-    it 'accepts multiple --format options and put the STDOUT one first so progress is seen' do
-      config.parse!(%w{--format pretty --out pretty.txt --format progress})
-
-      expect(config.formats).to eq [['progress', {}, out], ['pretty', {}, 'pretty.txt']]
-    end
-
-    it 'does not accept multiple --format options when both use implicit STDOUT' do
-      expect(-> { config.parse!(%w{--format pretty --format progress}) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
-    end
-
-    it 'does not accept multiple --format options when both use implicit STDOUT (using profile with no formatters)' do
-      given_cucumber_yml_defined_as({'default' => ['-q']})
-      expect(-> { config.parse!(%w{--format pretty --format progress}) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
-    end
-
-    it 'accepts same --format options with implicit STDOUT, and keep only one' do
-      config.parse!(%w{--format pretty --format pretty})
-
-      expect(config.formats).to eq [['pretty', {}, out]]
-    end
-
-    it 'does not accept multiple --out streams pointing to the same place' do
-      expect(-> { config.parse!(%w{--format pretty --out file1 --format progress --out file1}) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
-    end
-
-    it 'does not accept multiple --out streams pointing to the same place (one from profile, one from command line)' do
-      given_cucumber_yml_defined_as({'default' => ['-f','progress', '--out', 'file1']})
-      expect(-> { config.parse!(%w{--format pretty --out file1}) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
-    end
-
-    it 'associates --out to previous --format' do
-      config.parse!(%w{--format progress --out file1 --format profile --out file2})
-
-      expect(config.formats).to match_array([['progress', {}, 'file1'], ['profile', {}, 'file2']])
-    end
-
-    it 'accepts same --format options with same --out streams and keep only one' do
-      config.parse!(%w{--format html --out file --format pretty --format html --out file})
-
-      expect(config.formats).to eq [['pretty', {}, out], ['html', {}, 'file']]
-    end
-
-    it 'accepts same --format options with different --out streams' do
-      config.parse!(%w{--format html --out file1 --format html --out file2})
-
-      expect(config.formats).to match_array([['html', {}, 'file1'], ['html', {}, 'file2']])
-    end
-
-    it 'accepts --color option' do
-      expect(Cucumber::Term::ANSIColor).to receive(:coloring=).with(true)
-
-      config.parse!(['--color'])
-    end
-
-    it 'accepts --no-color option' do
-      expect(Cucumber::Term::ANSIColor).to receive(:coloring=).with(false)
-
-      config = Configuration.new(StringIO.new)
-      config.parse!(['--no-color'])
-    end
-
-    describe '--backtrace' do
-      before do
-        Cucumber.use_full_backtrace = false
+        expect(config.options[:duration]).to be false
       end
 
-      it 'shows full backtrace when --backtrace is present' do
-        Main.new(['--backtrace'])
-        begin
-          expect('x').to eq 'y'
-        rescue RSpec::Expectations::ExpectationNotMetError => e
-          expect(e.backtrace[0]).not_to eq "#{__FILE__}:#{__LINE__ - 2}"
+      it 'accepts --no-source option' do
+        config.parse!(%w{--no-source})
+
+        expect(config.options[:source]).to be false
+      end
+
+      it 'accepts --no-snippets option' do
+        config.parse!(%w{--no-snippets})
+
+        expect(config.options[:snippets]).to be false
+      end
+
+      it 'sets snippets and source and duration to false with --quiet option' do
+        config.parse!(%w{--quiet})
+
+        expect(config.options[:snippets]).to be false
+        expect(config.options[:source]).to be false
+        expect(config.options[:duration]).to be false
+      end
+
+      it 'sets duration to false with --no-duration' do
+        config.parse!(%w{--no-duration})
+
+        expect(config.options[:duration]).to be false
+      end
+
+      it 'accepts --verbose option' do
+        config.parse!(%w{--verbose})
+
+        expect(config.options[:verbose]).to be true
+      end
+
+      it 'accepts --out option' do
+        config.parse!(%w{--out jalla.txt})
+
+        expect(config.formats).to eq [['pretty', {}, 'jalla.txt']]
+      end
+
+      it 'accepts multiple --out options' do
+        config.parse!(%w{--format progress --out file1 --out file2})
+
+        expect(config.formats).to eq [['progress', {}, 'file2']]
+      end
+
+      it 'accepts multiple --format options and put the STDOUT one first so progress is seen' do
+        config.parse!(%w{--format pretty --out pretty.txt --format progress})
+
+        expect(config.formats).to eq [['progress', {}, out], ['pretty', {}, 'pretty.txt']]
+      end
+
+      it 'does not accept multiple --format options when both use implicit STDOUT' do
+        expect(-> { config.parse!(%w{--format pretty --format progress}) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
+      end
+
+      it 'does not accept multiple --format options when both use implicit STDOUT (using profile with no formatters)' do
+        given_cucumber_yml_defined_as({'default' => ['-q']})
+        expect(-> { config.parse!(%w{--format pretty --format progress}) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
+      end
+
+      it 'accepts same --format options with implicit STDOUT, and keep only one' do
+        config.parse!(%w{--format pretty --format pretty})
+
+        expect(config.formats).to eq [['pretty', {}, out]]
+      end
+
+      it 'does not accept multiple --out streams pointing to the same place' do
+        expect(-> { config.parse!(%w{--format pretty --out file1 --format progress --out file1}) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
+      end
+
+      it 'does not accept multiple --out streams pointing to the same place (one from profile, one from command line)' do
+        given_cucumber_yml_defined_as({'default' => ['-f','progress', '--out', 'file1']})
+        expect(-> { config.parse!(%w{--format pretty --out file1}) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
+      end
+
+      it 'associates --out to previous --format' do
+        config.parse!(%w{--format progress --out file1 --format profile --out file2})
+
+        expect(config.formats).to match_array([['progress', {}, 'file1'], ['profile', {}, 'file2']])
+      end
+
+      it 'accepts same --format options with same --out streams and keep only one' do
+        config.parse!(%w{--format html --out file --format pretty --format html --out file})
+
+        expect(config.formats).to eq [['pretty', {}, out], ['html', {}, 'file']]
+      end
+
+      it 'accepts same --format options with different --out streams' do
+        config.parse!(%w{--format html --out file1 --format html --out file2})
+
+        expect(config.formats).to match_array([['html', {}, 'file1'], ['html', {}, 'file2']])
+      end
+
+      it 'accepts --color option' do
+        expect(Cucumber::Term::ANSIColor).to receive(:coloring=).with(true)
+
+        config.parse!(['--color'])
+      end
+
+      it 'accepts --no-color option' do
+        expect(Cucumber::Term::ANSIColor).to receive(:coloring=).with(false)
+
+        config = Configuration.new(StringIO.new)
+        config.parse!(['--no-color'])
+      end
+
+      describe '--backtrace' do
+        before do
+          Cucumber.use_full_backtrace = false
+        end
+
+        it 'shows full backtrace when --backtrace is present' do
+          Main.new(['--backtrace'])
+          begin
+            expect('x').to eq 'y'
+          rescue RSpec::Expectations::ExpectationNotMetError => e
+            expect(e.backtrace[0]).not_to eq "#{__FILE__}:#{__LINE__ - 2}"
+          end
+        end
+
+        after do
+          Cucumber.use_full_backtrace = false
         end
       end
 
-      after do
-        Cucumber.use_full_backtrace = false
-      end
-    end
+      it 'accepts multiple --name options' do
+        config.parse!(['--name', 'User logs in', '--name', 'User signs up'])
 
-    it 'accepts multiple --name options' do
-      config.parse!(['--name', 'User logs in', '--name', 'User signs up'])
-
-      expect(config.options[:name_regexps]).to include(/User logs in/)
-      expect(config.options[:name_regexps]).to include(/User signs up/)
-    end
-
-    it 'accepts multiple -n options' do
-      config.parse!(['-n', 'User logs in', '-n', 'User signs up'])
-
-      expect(config.options[:name_regexps]).to include(/User logs in/)
-      expect(config.options[:name_regexps]).to include(/User signs up/)
-    end
-
-    it 'should allow specifying environment variables on the command line' do
-      config.parse!(['foo=bar'])
-
-      expect(ENV['foo']).to eq 'bar'
-      expect(config.paths).not_to include('foo=bar')
-    end
-
-    it 'allows specifying environment variables in profiles' do
-      given_cucumber_yml_defined_as({'selenium' => 'RAILS_ENV=selenium'})
-      config.parse!(['--profile', 'selenium'])
-
-      expect(ENV['RAILS_ENV']).to eq 'selenium'
-      expect(config.paths).not_to include('RAILS_ENV=selenium')
-    end
-
-    describe '#tag_expressions' do
-      it 'returns an empty expression when no tags are specified' do
-        config.parse!([])
-
-        expect(config.tag_expressions).to be_empty
+        expect(config.options[:name_regexps]).to include(/User logs in/)
+        expect(config.options[:name_regexps]).to include(/User signs up/)
       end
 
-      it 'returns an expression when tags are specified' do
-        config.parse!(['--tags','@foo'])
+      it 'accepts multiple -n options' do
+        config.parse!(['-n', 'User logs in', '-n', 'User signs up'])
 
-        expect(config.tag_expressions).not_to be_empty
-      end
-    end
-
-    describe '#tag_limits' do
-      it 'returns an empty hash when no limits are specified' do
-        config.parse!([])
-
-        expect(config.tag_limits).to eq({ })
+        expect(config.options[:name_regexps]).to include(/User logs in/)
+        expect(config.options[:name_regexps]).to include(/User signs up/)
       end
 
-      it 'returns a hash of limits when limits are specified' do
-        config.parse!(['--tags','@foo:1'])
+      it 'should allow specifying environment variables on the command line' do
+        config.parse!(['foo=bar'])
 
-        expect(config.tag_limits).to eq({ '@foo' => 1 })
-      end
-    end
-
-    describe '#dry_run?' do
-      it 'returns true when --dry-run was specified on in the arguments' do
-        config.parse!(['--dry-run'])
-
-        expect(config.dry_run?).to be true
+        expect(ENV['foo']).to eq 'bar'
+        expect(config.paths).not_to include('foo=bar')
       end
 
-      it 'returns true when --dry-run was specified in yaml file' do
-        given_cucumber_yml_defined_as({'default' => '--dry-run'})
-        config.parse!([])
+      it 'allows specifying environment variables in profiles' do
+        given_cucumber_yml_defined_as({'selenium' => 'RAILS_ENV=selenium'})
+        config.parse!(['--profile', 'selenium'])
 
-        expect(config.dry_run?).to be true
+        expect(ENV['RAILS_ENV']).to eq 'selenium'
+        expect(config.paths).not_to include('RAILS_ENV=selenium')
       end
 
-      it 'returns false by default' do
-        config.parse!([])
+      describe '#tag_expressions' do
+        it 'returns an empty expression when no tags are specified' do
+          config.parse!([])
 
-        expect(config.dry_run?).to be false
-      end
-    end
+          expect(config.tag_expressions).to be_empty
+        end
 
-    describe '#snippet_type' do
-      it 'returns the snippet type when it was set' do
-        config.parse!(['--snippet-type', 'classic'])
+        it 'returns an expression when tags are specified' do
+          config.parse!(['--tags','@foo'])
 
-        expect(config.snippet_type).to eq :classic
-      end
-
-      it 'returns the snippet type when it was set with shorthand option' do
-        config.parse!(['-I', 'classic'])
-
-        expect(config.snippet_type).to eq :classic
+          expect(config.tag_expressions).not_to be_empty
+        end
       end
 
-      it 'returns the default snippet type if it was not set' do
-        config.parse!([])
+      describe '#tag_limits' do
+        it 'returns an empty hash when no limits are specified' do
+          config.parse!([])
 
-        expect(config.snippet_type).to eq :cucumber_expression
+          expect(config.tag_limits).to eq({ })
+        end
+
+        it 'returns a hash of limits when limits are specified' do
+          config.parse!(['--tags','@foo:1'])
+
+          expect(config.tag_limits).to eq({ '@foo' => 1 })
+        end
       end
-    end
 
-    describe '#retry_attempts' do
-      it 'returns the specified number of retries' do
-        config.parse!(['--retry=3'])
-        expect(config.retry_attempts).to eql 3
+      describe '#dry_run?' do
+        it 'returns true when --dry-run was specified on in the arguments' do
+          config.parse!(['--dry-run'])
+
+          expect(config.dry_run?).to be true
+        end
+
+        it 'returns true when --dry-run was specified in yaml file' do
+          given_cucumber_yml_defined_as({'default' => '--dry-run'})
+          config.parse!([])
+
+          expect(config.dry_run?).to be true
+        end
+
+        it 'returns false by default' do
+          config.parse!([])
+
+          expect(config.dry_run?).to be false
+        end
+      end
+
+      describe '#snippet_type' do
+        it 'returns the snippet type when it was set' do
+          config.parse!(['--snippet-type', 'classic'])
+
+          expect(config.snippet_type).to eq :classic
+        end
+
+        it 'returns the snippet type when it was set with shorthand option' do
+          config.parse!(['-I', 'classic'])
+
+          expect(config.snippet_type).to eq :classic
+        end
+
+        it 'returns the default snippet type if it was not set' do
+          config.parse!([])
+
+          expect(config.snippet_type).to eq :cucumber_expression
+        end
+      end
+
+      describe '#retry_attempts' do
+        it 'returns the specified number of retries' do
+          config.parse!(['--retry=3'])
+          expect(config.retry_attempts).to eql 3
+        end
       end
     end
   end
-end
 end

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -539,9 +539,9 @@ module Cucumber
               | undefined |
             FEATURE
 
-            define_steps do
-              Given(/^this step passes$/) {}
-            end
+          define_steps do
+            Given(/^this step passes$/) {}
+          end
 
           it { expect(@doc.css('pre').map { |pre| /^(Given|Then|When)/.match(pre.text)[1] }).to eq %w(Given Given) }
         end

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -254,10 +254,10 @@ module Cucumber
 
       describe '#map_headers' do
         let(:table) do
-           DataTable.from([
-          %w{HELLO WORLD},
-          %w{4444 55555}
-          ])
+          DataTable.from([
+         %w{HELLO WORLD},
+         %w{4444 55555}
+         ])
         end
 
         it 'renames the columns to the specified values in the provided hash' do

--- a/spec/cucumber/step_match_search_spec.rb
+++ b/spec/cucumber/step_match_search_spec.rb
@@ -55,7 +55,7 @@ You can run again with --guess to make Cucumber be more smart about it
         let(:options) { {:guess => true} }
 
         it 'does not show --guess hint' do
-        expected_error = %{Ambiguous match of "Three cute mice":
+          expected_error = %{Ambiguous match of "Three cute mice":
 
 spec/cucumber/step_match_search_spec.rb:\\d+:in `/Three (.*) mice/'
 spec/cucumber/step_match_search_spec.rb:\\d+:in `/Three cute (.*)/'


### PR DESCRIPTION
## Details

Fixed
- Layout/IndentHeredoc
- Layout/IndentConsistency
- Layout/IndentIndentationWidth
- New violations from above fixes

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Rubocop style fixes
