### PR TITLE
Fix Multiline Violations: Braces, Blocks, Method call work, etc.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,10 @@ Layout/TrailingWhitespace:
     - 'spec/cucumber/formatter/pretty_spec.rb'
     - 'spec/cucumber/formatter/progress_spec.rb'
 
+Metrics/ClassLength:
+  Exclude:
+    - 'lib/cucumber/cli/options.rb'
+
 # Rubocop doesn't like method names in other languages but as Cucumber supports 
 # languages, this cop needs to be disabled.
 Naming/AsciiIdentifiers:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -41,49 +41,6 @@ Layout/IndentationWidth:
     - 'spec/cucumber/multiline_argument/data_table_spec.rb'
     - 'spec/cucumber/step_match_search_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: symmetrical, new_line, same_line
-Layout/MultilineArrayBraceLayout:
-  Exclude:
-    - 'spec/cucumber/configuration_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/MultilineBlockLayout:
-  Exclude:
-    - 'lib/cucumber/formatter/junit.rb'
-
-# Offense count: 5
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: symmetrical, new_line, same_line
-Layout/MultilineMethodCallBraceLayout:
-  Exclude:
-    - 'lib/cucumber/cli/options.rb'
-    - 'lib/cucumber/formatter/junit.rb'
-    - 'lib/cucumber/runtime.rb'
-    - 'spec/cucumber/configuration_spec.rb'
-    - 'spec/cucumber/formatter/spec_helper.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: aligned, indented, indented_relative_to_receiver
-Layout/MultilineMethodCallIndentation:
-  Exclude:
-    - 'scripts/invite-collaborator'
-    - 'spec/cucumber/multiline_argument/data_table_spec.rb'
-
-# Offense count: 5
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: aligned, indented
-Layout/MultilineOperationIndentation:
-  Exclude:
-    - 'lib/cucumber/cli/options.rb'
-
 # Offense count: 24
 # Cop supports --auto-correct.
 # Configuration parameters: AllowForAlignment.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -140,49 +140,6 @@ Layout/LeadingCommentSpace:
     - 'lib/cucumber/formatter/html.rb'
     - 'spec/cucumber/formatter/json_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: symmetrical, new_line, same_line
-Layout/MultilineArrayBraceLayout:
-  Exclude:
-    - 'spec/cucumber/configuration_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/MultilineBlockLayout:
-  Exclude:
-    - 'lib/cucumber/formatter/junit.rb'
-
-# Offense count: 5
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: symmetrical, new_line, same_line
-Layout/MultilineMethodCallBraceLayout:
-  Exclude:
-    - 'lib/cucumber/cli/options.rb'
-    - 'lib/cucumber/formatter/junit.rb'
-    - 'lib/cucumber/runtime.rb'
-    - 'spec/cucumber/configuration_spec.rb'
-    - 'spec/cucumber/formatter/spec_helper.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: aligned, indented, indented_relative_to_receiver
-Layout/MultilineMethodCallIndentation:
-  Exclude:
-    - 'scripts/invite-collaborator'
-    - 'spec/cucumber/multiline_argument/data_table_spec.rb'
-
-# Offense count: 5
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: aligned, indented
-Layout/MultilineOperationIndentation:
-  Exclude:
-    - 'lib/cucumber/cli/options.rb'
-
 # Offense count: 89
 # Cop supports --auto-correct.
 Layout/SpaceAfterComma:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Improved
 
+* Fix Multiline Violations: Braces, Blocks, Method call work, etc. ([#1271](https://github.com/cucumber/cucumber-ruby/pull/1271) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/EmptyLineAfterMagicComment ([#1255](https://github.com/cucumber/cucumber-ruby/pull/1255) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/DotPosition ([#1254](https://github.com/cucumber/cucumber-ruby/pull/1254) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/BlockEndNewline ([#1253](https://github.com/cucumber/cucumber-ruby/pull/1253) [@jaysonesmith](https://github.com/jaysonesmith))

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -11,6 +11,7 @@ module Cucumber
 
     class Options
       INDENT = ' ' * 53
+      # rubocop:disable Layout/MultilineOperationIndentation
       BUILTIN_FORMATS = {
         'html'        => ['Cucumber::Formatter::Html',        'Generates a nice looking HTML report.'],
         'pretty'      => ['Cucumber::Formatter::Pretty',      'Prints the feature as is - in colours.'],
@@ -28,6 +29,7 @@ module Cucumber
         'json_pretty' => ['Cucumber::Formatter::JsonPretty',  'Prints the feature as prettified JSON'],
         'summary'     => ['Cucumber::Formatter::Summary',     'Summary output of feature and scenarios']
       }
+      # rubocop:enable Layout/MultilineOperationIndentation
       max = BUILTIN_FORMATS.keys.map(&:length).max
       FORMAT_HELP_MSG = [
                           'Use --format rerun --out rerun.txt to write out failing',
@@ -554,7 +556,8 @@ TEXT
         data = Cucumber::MultilineArgument::DataTable.from(
           ::Gherkin::DIALECTS.keys.map do |key|
             [key, ::Gherkin::DIALECTS[key].fetch('name'), ::Gherkin::DIALECTS[key].fetch('native')]
-          end)
+          end
+        )
         @out_stream.write(data.to_s({ color: false, prefixes: Hash.new('') }))
         Kernel.exit(0)
       end

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -26,15 +26,16 @@ module Cucumber
         config.on_event :test_run_finished, &method(:on_test_run_finished)
         @reportdir = ensure_dir(config.out_stream, 'junit')
         @config = config
-        @features_data = Hash.new do |h, k| h[k] = {
-          feature: nil,
-          failures: 0,
-          errors: 0,
-          tests: 0,
-          skipped: 0,
-          time: 0,
-          builder: Builder::XmlMarkup.new(:indent => 2)
-        }
+        @features_data = Hash.new do |h, k|
+          h[k] = {
+            feature: nil,
+            failures: 0,
+            errors: 0,
+            tests: 0,
+            skipped: 0,
+            time: 0,
+            builder: Builder::XmlMarkup.new(:indent => 2)
+          }
         end
       end
 
@@ -95,7 +96,8 @@ module Cucumber
           :skipped => feature_data[:skipped],
           :tests => feature_data[:tests],
           :time => format('%.6f', feature_data[:time]),
-          :name => feature_data[:feature].name ) do
+          :name => feature_data[:feature].name
+        ) do
           @testsuite << feature_data[:builder].target!
         end
 

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -215,7 +215,8 @@ module Cucumber
       formatter = factory.new(runtime_facade, path_or_io, cli_options)
       Formatter::LegacyApi::Adapter.new(
         Formatter::IgnoreMissingMessages.new(formatter),
-        results, @configuration)
+        results, @configuration
+      )
     end
 
     def accept_options?(factory)

--- a/scripts/invite-collaborator
+++ b/scripts/invite-collaborator
@@ -19,7 +19,7 @@ class Team
 
   def team
     @team ||= gh.organization_teams('cucumber')
-      .find { |team| team['name'] == name } || raise("Unable to find a team named #{name}")
+                .find { |team| team['name'] == name } || raise("Unable to find a team named #{name}")
   end
 end
 

--- a/scripts/invite-collaborator
+++ b/scripts/invite-collaborator
@@ -18,8 +18,9 @@ class Team
   end
 
   def team
-    @team ||= gh.organization_teams('cucumber')
-                .find { |team| team['name'] == name } || raise("Unable to find a team named #{name}")
+    @team ||=
+      gh.organization_teams('cucumber')
+        .find { |team| team['name'] == name } || raise("Unable to find a team named #{name}")
   end
 end
 

--- a/spec/cucumber/configuration_spec.rb
+++ b/spec/cucumber/configuration_spec.rb
@@ -121,7 +121,8 @@ module Cucumber
         allow(IO).to receive(:read).and_return(
           "cucumber.feature:1:3\ncucumber.feature:5 cucumber.feature:10\n"\
           "domain folder/different cuke.feature:134 domain folder/cuke.feature:1\n"\
-          'domain folder/different cuke.feature:4:5 bar.feature')
+          'domain folder/different cuke.feature:4:5 bar.feature'
+        )
 
         configuration = Configuration.new(paths: %w{@rerun.txt})
 
@@ -132,7 +133,8 @@ module Cucumber
           'domain folder/different cuke.feature:134',
           'domain folder/cuke.feature:1',
           'domain folder/different cuke.feature:4:5',
-          'bar.feature']
+          'bar.feature'
+        ]
       end
     end
 

--- a/spec/cucumber/formatter/spec_helper.rb
+++ b/spec/cucumber/formatter/spec_helper.rb
@@ -44,7 +44,8 @@ module Cucumber
         @report ||= LegacyApi::Adapter.new(
           Fanout.new([@formatter]),
           actual_runtime.results,
-          actual_runtime.configuration)
+          actual_runtime.configuration
+        )
       end
 
       require 'cucumber/core/gherkin/document'


### PR DESCRIPTION
## Details

- Layout/MultilineArrayBraceLayout
- Layout/MultilineBlockLayout
- Layout/MultilineMethodCallBraceLayout
- Layout/MultilineMethodCallIndentation
- Layout/MultilineOperationIndentation
- Metrics/ClassLength exclusion for the CLI's options also.

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Rubocop style fixes
