### PR TITLE
Fix Layout/SpaceAroundEqualsInParameterDefault & Layout/SpaceAroundKeyword

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -114,37 +114,6 @@ Layout/MultilineOperationIndentation:
 Layout/SpaceAfterComma:
   Enabled: false
 
-# Offense count: 32
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/SpaceAroundEqualsInParameterDefault:
-  Exclude:
-    - 'lib/cucumber/cli/main.rb'
-    - 'lib/cucumber/cli/options.rb'
-    - 'lib/cucumber/filters/broadcast_test_run_started_event.rb'
-    - 'lib/cucumber/filters/quit.rb'
-    - 'lib/cucumber/filters/randomizer.rb'
-    - 'lib/cucumber/filters/tag_limits.rb'
-    - 'lib/cucumber/formatter/html.rb'
-    - 'lib/cucumber/formatter/html_builder.rb'
-    - 'lib/cucumber/formatter/interceptor.rb'
-    - 'lib/cucumber/glue/proto_world.rb'
-    - 'lib/cucumber/multiline_argument.rb'
-    - 'lib/cucumber/multiline_argument/data_table.rb'
-    - 'lib/cucumber/platform.rb'
-    - 'lib/cucumber/runtime.rb'
-    - 'lib/cucumber/runtime/support_code.rb'
-
-# Offense count: 6
-# Cop supports --auto-correct.
-Layout/SpaceAroundKeyword:
-  Exclude:
-    - 'lib/cucumber/cli/options.rb'
-    - 'lib/cucumber/rake/task.rb'
-    - 'lib/cucumber/runtime/user_interface.rb'
-    - 'spec/cucumber/cli/profile_loader_spec.rb'
-
 # Offense count: 24
 # Cop supports --auto-correct.
 # Configuration parameters: AllowForAlignment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Improved
 
+* Fix Layout/SpaceAroundEqualsInParameterDefault & Layout/SpaceAroundKeyword ([#1273](https://github.com/cucumber/cucumber-ruby/pull/1273) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/EmptyLinesAroundModuleBody ([#1266](https://github.com/cucumber/cucumber-ruby/pull/1266) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/EmptyLinesAroundBlockBody ([#1263](https://github.com/cucumber/cucumber-ruby/pull/1263) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix: Layout/EmptyLines, ...AroundAccessModifier, ...AroundArguments, ...AroundExceptionHandlingKeywords ([#1262](https://github.com/cucumber/cucumber-ruby/pull/1262) [@jaysonesmith](https://github.com/jaysonesmith))

--- a/lib/cucumber/cli/main.rb
+++ b/lib/cucumber/cli/main.rb
@@ -14,7 +14,7 @@ module Cucumber
         end
       end
 
-      def initialize(args, _=nil, out=STDOUT, err=STDERR, kernel=Kernel)
+      def initialize(args, _ = nil, out = STDOUT, err = STDERR, kernel = Kernel)
         @args   = args
         @out    = out
         @err    = err

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -95,7 +95,7 @@ module Cucumber
           opts.banner = banner
           opts.on('-r LIBRARY|DIR', '--require LIBRARY|DIR', *require_files_msg) {|lib| require_files(lib) }
 
-          if(Cucumber::JRUBY)
+          if Cucumber::JRUBY
             opts.on('-j DIR', '--jars DIR', 'Load all the jars under DIR') {|jars| load_jars(jars) }
           end
 
@@ -403,7 +403,7 @@ TEXT
         @profiles << p
       end
 
-      def set_option(option, value=nil)
+      def set_option(option, value = nil)
         @options[option] = value.nil? ? true : value
       end
 

--- a/lib/cucumber/filters/broadcast_test_run_started_event.rb
+++ b/lib/cucumber/filters/broadcast_test_run_started_event.rb
@@ -5,7 +5,7 @@ module Cucumber
     # Added at the end of the filter chain to broadcast a list of
     # all of the test cases that have made it through the filters.
     class BroadcastTestRunStartedEvent < Core::Filter.new(:config)
-      def initialize(config, receiver=nil)
+      def initialize(config, receiver = nil)
         super
         @test_cases = []
       end

--- a/lib/cucumber/filters/quit.rb
+++ b/lib/cucumber/filters/quit.rb
@@ -3,7 +3,7 @@
 module Cucumber
   module Filters
     class Quit
-      def initialize(receiver=nil)
+      def initialize(receiver = nil)
         @receiver = receiver
       end
 

--- a/lib/cucumber/filters/randomizer.rb
+++ b/lib/cucumber/filters/randomizer.rb
@@ -6,7 +6,7 @@ module Cucumber
   module Filters
     # Batches up all test cases, randomizes them, and then sends them on
     class Randomizer
-      def initialize(seed, receiver=nil)
+      def initialize(seed, receiver = nil)
         @receiver = receiver
         @test_cases = []
         @seed = seed

--- a/lib/cucumber/filters/tag_limits.rb
+++ b/lib/cucumber/filters/tag_limits.rb
@@ -13,7 +13,7 @@ module Cucumber
     end
 
     class TagLimits
-      def initialize(tag_limits, receiver=nil)
+      def initialize(tag_limits, receiver = nil)
         @tag_limits = tag_limits
         @gated_receiver = GatedReceiver.new(receiver)
         @test_case_index = TestCaseIndex.new

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -548,7 +548,7 @@ module Cucumber
         return " (#{counts.join(', ')})" if counts.any?
       end
 
-      def dump_count(count, what, state=nil)
+      def dump_count(count, what, state = nil)
         [count, state, "#{what}#{count == 1 ? '' : 's'}"].compact.join(' ')
       end
 

--- a/lib/cucumber/formatter/html_builder.rb
+++ b/lib/cucumber/formatter/html_builder.rb
@@ -11,7 +11,7 @@ module Cucumber
       class InvalidEmbedTypeError < ::StandardError
         MESSAGE = 'Invalid embed type. Valid types are :text and :image.'.freeze
 
-        def initialize(message=MESSAGE)
+        def initialize(message = MESSAGE)
           super(message)
         end
       end

--- a/lib/cucumber/formatter/interceptor.rb
+++ b/lib/cucumber/formatter/interceptor.rb
@@ -46,7 +46,7 @@ module Cucumber
           @pipe.send(method, *args, &blk)
         end
 
-        def respond_to?(method, include_private=false)
+        def respond_to?(method, include_private = false)
           super || @pipe.respond_to?(method, include_private)
         end
 

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -25,7 +25,7 @@ module Cucumber
       #   step "the email should contain:", "Dear sir,\nYou've won a prize!\n"
       # @param [String] name The name of the step
       # @param [String,Cucumber::Ast::DocString,Cucumber::Ast::Table] multiline_argument
-      def step(name, raw_multiline_arg=nil)
+      def step(name, raw_multiline_arg = nil)
         super
       end
 
@@ -67,7 +67,7 @@ module Cucumber
       #     %w{ CUC-101 Peeler      22     }
       #   ])
       #
-      def table(text_or_table, file=nil, line=0)
+      def table(text_or_table, file = nil, line = 0)
         location = !file ? Core::Ast::Location.of_caller : Core::Ast::Location.new(file, line)
         MultilineArgument::DataTable.from(text_or_table, location)
       end
@@ -84,12 +84,12 @@ module Cucumber
       end
 
       # Pause the tests and ask the operator for input
-      def ask(question, timeout_seconds=60)
+      def ask(question, timeout_seconds = 60)
         super
       end
 
       # Embed an image in the output
-      def embed(file, mime_type, label='Screenshot')
+      def embed(file, mime_type, label = 'Screenshot')
         super
       end
 
@@ -138,7 +138,7 @@ module Cucumber
             add_namespaced_modules!(namespaced_world_modules)
           end
 
-          define_method(:step) do |name, raw_multiline_arg=nil|
+          define_method(:step) do |name, raw_multiline_arg = nil|
             location = Core::Ast::Location.of_caller
             runtime.invoke_dynamic_step(name, MultilineArgument.from(raw_multiline_arg, location))
           end
@@ -159,11 +159,11 @@ module Cucumber
           end
           # rubocop:enable UnneededInterpolation
 
-          define_method(:ask) do |question, timeout_seconds=60|
+          define_method(:ask) do |question, timeout_seconds = 60|
             runtime.ask(question, timeout_seconds)
           end
 
-          define_method(:embed) do |file, mime_type, label='Screenshot'|
+          define_method(:embed) do |file, mime_type, label = 'Screenshot'|
             runtime.embed(file, mime_type, label)
           end
 

--- a/lib/cucumber/multiline_argument.rb
+++ b/lib/cucumber/multiline_argument.rb
@@ -11,7 +11,7 @@ module Cucumber
         builder.wrap(node)
       end
 
-      def from(argument, location=nil, content_type=nil)
+      def from(argument, location = nil, content_type = nil)
         location ||= Core::Ast::Location.of_caller
         case argument
         when String

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -260,7 +260,7 @@ module Cucumber
       #   table.hashes.keys
       #   # => ['phone number', 'ADDRESS']
       #
-      def map_headers!(mappings={}, &block)
+      def map_headers!(mappings = {}, &block)
         # TODO: Remove this method for 2.0
         clear_cache!
         @header_mappings = mappings
@@ -268,7 +268,7 @@ module Cucumber
       end
 
       # Returns a new Table where the headers are redefined. See #map_headers!
-      def map_headers(mappings={}, &block)
+      def map_headers(mappings = {}, &block)
         self.class.new(Core::Ast::DataTable.new(raw, location), @conversion_procs.dup, mappings, block)
       end
 
@@ -284,14 +284,14 @@ module Cucumber
       #     end
       #   end
       #
-      def map_column!(column_name, strict=true, &conversion_proc)
+      def map_column!(column_name, strict = true, &conversion_proc)
         # TODO: Remove this method for 2.0
         @conversion_procs[column_name.to_s] = { :strict => strict, :proc => conversion_proc }
         self
       end
 
       # Returns a new Table with an additional column mapping. See #map_column!
-      def map_column(column_name, strict=true, &conversion_proc)
+      def map_column(column_name, strict = true, &conversion_proc)
         conversion_procs = @conversion_procs.dup
         conversion_procs[column_name.to_s] = { :strict => strict, :proc => conversion_proc }
         self.class.new(Core::Ast::DataTable.new(raw, location), conversion_procs, @header_mappings.dup, @header_conversion_proc)
@@ -333,7 +333,7 @@ module Cucumber
       # Calling this method is particularly useful in <tt>Then</tt> steps that take
       # a Table argument, if you want to compare that table to some actual values.
       #
-      def diff!(other_table, options={})
+      def diff!(other_table, options = {})
         other_table = ensure_table(other_table)
         other_table.convert_headers!
         other_table.convert_columns!

--- a/lib/cucumber/platform.rb
+++ b/lib/cucumber/platform.rb
@@ -18,7 +18,7 @@ module Cucumber
       attr_accessor :use_full_backtrace
 
       # @private
-      def file_mode(m, encoding='UTF-8')
+      def file_mode(m, encoding = 'UTF-8')
         "#{m}:#{encoding}"
       end
     end

--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -154,7 +154,7 @@ module Cucumber
 
       def runner(_task_args = nil) #:nodoc:
         cucumber_opts = [(ENV['CUCUMBER_OPTS'] ? ENV['CUCUMBER_OPTS'].split(/\s+/) : nil) || cucumber_opts_with_profile]
-        if(@fork)
+        if @fork
           return ForkedCucumberRunner.new(libs, binary, cucumber_opts, bundler, feature_files)
         end
         InProcessCucumberRunner.new(libs, cucumber_opts, feature_files)

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -106,7 +106,7 @@ module Cucumber
 
     # Returns Ast::DocString for +string_without_triple_quotes+.
     #
-    def doc_string(string_without_triple_quotes, content_type='', _line_offset=0)
+    def doc_string(string_without_triple_quotes, content_type = '', _line_offset = 0)
       location = Core::Ast::Location.of_caller
       Core::Ast::DocString.new(string_without_triple_quotes, content_type, location)
     end

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -48,7 +48,7 @@ module Cucumber
 
       attr_reader :registry
 
-      def initialize(user_interface, configuration=Configuration.default)
+      def initialize(user_interface, configuration = Configuration.default)
         @configuration = configuration
         # TODO: needs a better name, or inlining its methods
         @runtime_facade = Runtime::ForProgrammingLanguages.new(self, user_interface)
@@ -76,7 +76,7 @@ module Cucumber
       # steps which are compiled into test steps before execution.
       #
       # These are commonly called nested steps.
-      def invoke_dynamic_step(step_name, multiline_argument, _location=nil)
+      def invoke_dynamic_step(step_name, multiline_argument, _location = nil)
         matches = step_matches(step_name)
         raise UndefinedDynamicStep, step_name if matches.empty?
         matches.first.invoke(multiline_argument)

--- a/lib/cucumber/runtime/user_interface.rb
+++ b/lib/cucumber/runtime/user_interface.rb
@@ -34,7 +34,7 @@ module Cucumber
         STDOUT.flush
         puts(question)
 
-        answer = if(Cucumber::JRUBY)
+        answer = if Cucumber::JRUBY
                    jruby_gets(timeout_seconds)
                  else
                    mri_gets(timeout_seconds)

--- a/spec/cucumber/cli/profile_loader_spec.rb
+++ b/spec/cucumber/cli/profile_loader_spec.rb
@@ -21,7 +21,7 @@ module Cucumber
 
       it 'treats backslashes as literals in rerun.txt when on Windows (JRuby or MRI)' do
         given_cucumber_yml_defined_as('default' => '--format "pretty" features\sync_imap_mailbox.feature:16:22')
-        if(Cucumber::WINDOWS)
+        if Cucumber::WINDOWS
           expect(loader.args_from('default')).to eq ['--format','pretty','features\sync_imap_mailbox.feature:16:22']
         else
           expect(loader.args_from('default')).to eq ['--format','pretty','featuressync_imap_mailbox.feature:16:22']
@@ -46,7 +46,7 @@ default: <%= x %>
 
       it 'correctly parses a profile that uses tag expressions (with double quotes)' do
         given_cucumber_yml_defined_as('default' => '--format "pretty" features\sync_imap_mailbox.feature:16:22 --tags "not @jruby"')
-        if(Cucumber::WINDOWS)
+        if Cucumber::WINDOWS
           expect(loader.args_from('default')).to eq ['--format','pretty','features\sync_imap_mailbox.feature:16:22','--tags','not @jruby']
         else
           expect(loader.args_from('default')).to eq ['--format','pretty','featuressync_imap_mailbox.feature:16:22','--tags','not @jruby']
@@ -55,7 +55,7 @@ default: <%= x %>
 
       it 'correctly parses a profile that uses tag expressions (with single quotes)' do
         given_cucumber_yml_defined_as('default' => "--format 'pretty' features\\sync_imap_mailbox.feature:16:22 --tags 'not @jruby'")
-        if(Cucumber::WINDOWS)
+        if Cucumber::WINDOWS
           expect(loader.args_from('default')).to eq ['--format','pretty','features\sync_imap_mailbox.feature:16:22','--tags','not @jruby']
         else
           expect(loader.args_from('default')).to eq ['--format','pretty','featuressync_imap_mailbox.feature:16:22','--tags','not @jruby']


### PR DESCRIPTION
## Details

- The [space between](http://www.metrolyrics.com/the-space-between-lyrics-dave-matthews-band.html) things is to be updated.

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Rubocop style fixes
