### PR TITLE
Fix Layout/Space cops: around operators and before block braces

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -41,35 +41,6 @@ Layout/IndentationWidth:
     - 'spec/cucumber/multiline_argument/data_table_spec.rb'
     - 'spec/cucumber/step_match_search_spec.rb'
 
-# Offense count: 24
-# Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment.
-Layout/SpaceAroundOperators:
-  Exclude:
-    - 'examples/i18n/Rakefile'
-    - 'examples/i18n/pt/lib/calculadora.rb'
-    - 'lib/cucumber/cli/options.rb'
-    - 'lib/cucumber/formatter/ansicolor.rb'
-    - 'lib/cucumber/formatter/console.rb'
-    - 'lib/cucumber/formatter/html.rb'
-    - 'lib/cucumber/formatter/interceptor.rb'
-    - 'lib/cucumber/formatter/json.rb'
-    - 'lib/cucumber/formatter/pretty.rb'
-    - 'lib/cucumber/glue/invoke_in_world.rb'
-    - 'lib/cucumber/glue/snippet.rb'
-    - 'lib/cucumber/step_definition_light.rb'
-    - 'spec/cucumber/cli/configuration_spec.rb'
-    - 'spec/cucumber/glue/step_definition_spec.rb'
-    - 'spec/cucumber/multiline_argument/data_table_spec.rb'
-
-# Offense count: 80
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceBeforeBlockBraces:
-  Enabled: false
-
 # Offense count: 27
 # Cop supports --auto-correct.
 Layout/SpaceBeforeComma:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Improved
 
+* Fix Layout/Space cops: around operators and before block braces ([#1276](https://github.com/cucumber/cucumber-ruby/pull/1276) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Multiline Violations: Braces, Blocks, Method call work, etc. ([#1271](https://github.com/cucumber/cucumber-ruby/pull/1271) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/EmptyLinesAroundClassBody ([#1264](https://github.com/cucumber/cucumber-ruby/pull/1264) [@jaysonesmith](https://github.com/jaysonesmith))
 * Fix Layout/SpaceAfterComma ([#1272](https://github.com/cucumber/cucumber-ruby/pull/1272) [@jaysonesmith](https://github.com/jaysonesmith))

--- a/examples/i18n/Rakefile
+++ b/examples/i18n/Rakefile
@@ -3,7 +3,7 @@ task :cucumber do
   dir = File.dirname(__FILE__)
   Dir["#{dir}/*"].each do |f|
     if File.directory?(f)
-      lang = f[dir.length+1..-1]
+      lang = f[dir.length + 1..-1]
       if examples_working?(lang)
         Dir.chdir(f) do
           puts "DIR: #{f}"

--- a/examples/i18n/ar/lib/calculator.rb
+++ b/examples/i18n/ar/lib/calculator.rb
@@ -7,6 +7,6 @@ class Calculator
   end
 
   def جمع
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 end

--- a/examples/i18n/ca/lib/calculadora.rb
+++ b/examples/i18n/ca/lib/calculadora.rb
@@ -5,7 +5,7 @@ class Calculadora
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/cs/lib/calculator.rb
+++ b/examples/i18n/cs/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/da/lib/lommeregner.rb
+++ b/examples/i18n/da/lib/lommeregner.rb
@@ -6,6 +6,6 @@ class Lommeregner
 
   def add
     # @args[0] + @args[1]
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 end

--- a/examples/i18n/de/lib/calculator.rb
+++ b/examples/i18n/de/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/el/lib/calculator.rb
+++ b/examples/i18n/el/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/en/lib/calculator.rb
+++ b/examples/i18n/en/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/eo/lib/calculator.rb
+++ b/examples/i18n/eo/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/es/lib/calculador.rb
+++ b/examples/i18n/es/lib/calculador.rb
@@ -5,7 +5,7 @@ class Calculador
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/et/lib/kalkulaator.rb
+++ b/examples/i18n/et/lib/kalkulaator.rb
@@ -5,7 +5,7 @@ class Kalkulaator
   end
 
   def liida
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def jaga

--- a/examples/i18n/fi/lib/laskin.rb
+++ b/examples/i18n/fi/lib/laskin.rb
@@ -5,7 +5,7 @@ class Laskin
   end
 
   def summaa
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def jaa

--- a/examples/i18n/fr/lib/calculatrice.rb
+++ b/examples/i18n/fr/lib/calculatrice.rb
@@ -5,6 +5,6 @@ class Calculatrice
   end
 
   def additionner
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 end

--- a/examples/i18n/he/lib/calculator.rb
+++ b/examples/i18n/he/lib/calculator.rb
@@ -7,7 +7,7 @@ class Calculator
   end
 
   def חבר
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def חלק

--- a/examples/i18n/hi/lib/calculator.rb
+++ b/examples/i18n/hi/lib/calculator.rb
@@ -7,7 +7,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/ht/lib/kalkilatris.rb
+++ b/examples/i18n/ht/lib/kalkilatris.rb
@@ -5,7 +5,7 @@ class Kalkilatris
   end
 
   def ajoute
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divize

--- a/examples/i18n/hu/lib/calculator.rb
+++ b/examples/i18n/hu/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/id/lib/calculator.rb
+++ b/examples/i18n/id/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/it/lib/calcolatrice.rb
+++ b/examples/i18n/it/lib/calcolatrice.rb
@@ -6,6 +6,6 @@ class Calcolatrice
 
   def add
     # @args[0] + @args[1]
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 end

--- a/examples/i18n/ja/lib/calculator.rb
+++ b/examples/i18n/ja/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/ko/lib/calculator.rb
+++ b/examples/i18n/ko/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/lt/lib/calculator.rb
+++ b/examples/i18n/lt/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/lv/lib/calculator.rb
+++ b/examples/i18n/lv/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/no/lib/kalkulator.rb
+++ b/examples/i18n/no/lib/kalkulator.rb
@@ -6,6 +6,6 @@ class Kalkulator
 
   def add
     # @args[0] + @args[1]
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 end

--- a/examples/i18n/pl/lib/calculator.rb
+++ b/examples/i18n/pl/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def dodaj
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def podziel

--- a/examples/i18n/pt/lib/calculadora.rb
+++ b/examples/i18n/pt/lib/calculadora.rb
@@ -5,6 +5,6 @@ class Calculadora
   end
 
   def soma
-    @args.inject(0) {|n, sum| sum+n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 end

--- a/examples/i18n/ro/lib/calculator.rb
+++ b/examples/i18n/ro/lib/calculator.rb
@@ -6,6 +6,6 @@ class Calculator
 
   def add
     # @args[0] + @args[1]
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 end

--- a/examples/i18n/sk/lib/calculator.rb
+++ b/examples/i18n/sk/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/examples/i18n/sr-Cyrl/lib/calculator.rb
+++ b/examples/i18n/sr-Cyrl/lib/calculator.rb
@@ -5,6 +5,6 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 end

--- a/examples/i18n/sr-Latn/lib/calculator.rb
+++ b/examples/i18n/sr-Latn/lib/calculator.rb
@@ -5,6 +5,6 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 end

--- a/examples/i18n/sv/lib/kalkulator.rb
+++ b/examples/i18n/sv/lib/kalkulator.rb
@@ -6,6 +6,6 @@ class Kalkulator
 
   def add
     # @args[0] + @args[1]
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 end

--- a/examples/i18n/tr/lib/hesap_makinesi.rb
+++ b/examples/i18n/tr/lib/hesap_makinesi.rb
@@ -7,7 +7,7 @@ class HesapMakinesi
   end
 
   def topla
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def böl

--- a/examples/i18n/zh-CN/lib/calculator.rb
+++ b/examples/i18n/zh-CN/lib/calculator.rb
@@ -5,6 +5,6 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 end

--- a/examples/i18n/zh-TW/lib/calculator.rb
+++ b/examples/i18n/zh-TW/lib/calculator.rb
@@ -5,7 +5,7 @@ class Calculator
   end
 
   def add
-    @args.inject(0){|n, sum| sum + n}
+    @args.inject(0) {|n, sum| sum + n}
   end
 
   def divide

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -576,7 +576,7 @@ TEXT
           :dry_run      => false,
           :formats      => [],
           :excludes     => [],
-          :tag_expressions  => [],
+          :tag_expressions => [],
           :tag_limits   => {},
           :name_regexps => [],
           :env_vars     => {},

--- a/lib/cucumber/formatter/ansicolor.rb
+++ b/lib/cucumber/formatter/ansicolor.rb
@@ -96,7 +96,7 @@ module Cucumber
           end
           # This resets the colour to the non-param colour
           def #{method_name}_param(string=nil, &proc)
-            #{ALIASES[method_name+'_param'].split(",").join("(") + "(string, &proc" + ")" * ALIASES[method_name+'_param'].split(",").length} + #{ALIASES[method_name].split(",").join(' + ')}
+            #{ALIASES[method_name + '_param'].split(",").join("(") + "(string, &proc" + ")" * ALIASES[method_name + '_param'].split(",").length} + #{ALIASES[method_name].split(",").join(' + ')}
           end
           EOF
           eval(code)

--- a/lib/cucumber/formatter/console.rb
+++ b/lib/cucumber/formatter/console.rb
@@ -111,7 +111,7 @@ module Cucumber
       # http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/10655
       def linebreaks(s, max)
         return s unless max && max > 0
-        s.gsub(/.{1,#{max}}(?:\s|\Z)/){($& + 5.chr).gsub(/\n\005/, "\n").gsub(/\005/, "\n")}.rstrip
+        s.gsub(/.{1,#{max}}(?:\s|\Z)/) {($& + 5.chr).gsub(/\n\005/, "\n").gsub(/\005/, "\n")}.rstrip
       end
 
       def collect_snippet_data(test_step, result)
@@ -211,12 +211,12 @@ module Cucumber
         profiles_sentence = profiles.size == 1 ? profiles.first :
           "#{profiles[0...-1].join(', ')} and #{profiles.last}"
 
-        @io.puts "Using the #{profiles_sentence} profile#{'s' if profiles.size> 1}..."
+        @io.puts "Using the #{profiles_sentence} profile#{'s' if profiles.size > 1}..."
       end
 
       private
 
-      FORMATS = Hash.new{ |hash, format| hash[format] = method(format).to_proc }
+      FORMATS = Hash.new { |hash, format| hash[format] = method(format).to_proc }
 
       def format_for(*keys)
         key = keys.join('_').to_sym

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -153,7 +153,7 @@ module Cucumber
       end
 
       def before_feature_element(feature_element)
-        @scenario_number+=1
+        @scenario_number += 1
         @scenario_red = false
         css_class = AST_CLASSES[feature_element.class]
         builder << "<div class='#{css_class}'>"
@@ -467,7 +467,7 @@ module Cucumber
       end
 
       def build_step(keyword, step_match, _status)
-        step_name = step_match.format_args(lambda{|param| %{<span class="param">#{param}</span>}})
+        step_name = step_match.format_args(lambda {|param| %{<span class="param">#{param}</span>}})
         builder.div(:class => 'step_name') do |div|
           builder.span(keyword, :class => 'keyword')
           builder.span(:class => 'step val') do |name|
@@ -531,11 +531,11 @@ module Cucumber
       def print_stat_string(_features)
         string = String.new
         string << dump_count(@runtime.scenarios.length, 'scenario')
-        scenario_count = print_status_counts{|status| @runtime.scenarios(status)}
+        scenario_count = print_status_counts {|status| @runtime.scenarios(status)}
         string << scenario_count if scenario_count
         string << '<br />'
         string << dump_count(@runtime.steps.length, 'step')
-        step_count = print_status_counts{|status| @runtime.steps(status)}
+        step_count = print_status_counts {|status| @runtime.steps(status)}
         string << step_count if step_count
       end
 
@@ -589,8 +589,8 @@ module Cucumber
           rescue ArgumentError
             return "# Couldn't get snippet for #{file}"
           end
-          min = [0, line-3].max
-            max = [line+1, lines.length-1].min
+          min = [0, line - 3].max
+            max = [line + 1, lines.length - 1].min
             selected_lines = []
             selected_lines.join("\n")
             lines[min..max].join("\n")
@@ -602,7 +602,7 @@ module Cucumber
         def post_process(highlighted, offending_line)
           new_lines = []
           highlighted.split("\n").each_with_index do |line, i|
-            new_line = "<span class=\"linenum\">#{offending_line+i-2}</span>#{line}"
+            new_line = "<span class=\"linenum\">#{offending_line + i - 2}</span>#{line}"
             new_line = "<span class=\"offending\">#{new_line}</span>" if i == 2
             new_lines << new_line
           end

--- a/lib/cucumber/formatter/interceptor.rb
+++ b/lib/cucumber/formatter/interceptor.rb
@@ -86,7 +86,7 @@ module Cucumber
         private
 
         def lock
-          @lock||=Mutex.new
+          @lock ||= Mutex.new
         end
       end
     end

--- a/lib/cucumber/formatter/pretty.rb
+++ b/lib/cucumber/formatter/pretty.rb
@@ -164,7 +164,7 @@ module Cucumber
       def doc_string(string)
         return if @options[:no_multiline] || @hide_this_step
         s = %{"""\n#{string}\n"""}.indent(@indent)
-        s = s.split("\n").map{|l| l =~ /^\s+$/ ? '' : l}.join("\n")
+        s = s.split("\n").map {|l| l =~ /^\s+$/ ? '' : l}.join("\n")
         @io.puts(format_string(s, @current_step.status))
         @io.flush
       end
@@ -188,7 +188,7 @@ module Cucumber
       def before_table_row(_table_row)
         return if !@table || @hide_this_step
         @col_index = 0
-        @io.print '  |'.indent(@indent-2)
+        @io.print '  |'.indent(@indent - 2)
       end
 
       def after_table_row(table_row)

--- a/lib/cucumber/formatter/unicode.rb
+++ b/lib/cucumber/formatter/unicode.rb
@@ -27,7 +27,7 @@ if Cucumber::WINDOWS
         o.instance_eval do
           def cucumber_preprocess_output(*a)
             begin
-              a.map{|arg| arg.to_s.encode(Encoding.default_external)}
+              a.map {|arg| arg.to_s.encode(Encoding.default_external)}
             rescue Encoding::UndefinedConversionError => e
               STDERR.cucumber_puts("WARNING: #{e.message}")
               a

--- a/lib/cucumber/formatter/usage.rb
+++ b/lib/cucumber/formatter/usage.rb
@@ -108,7 +108,7 @@ module Cucumber
       end
 
       def max_stepdef_length
-        @stepdef_to_match.keys.flatten.map{|key| key.regexp_source.unpack('U*').length}.max
+        @stepdef_to_match.keys.flatten.map {|key| key.regexp_source.unpack('U*').length}.max
       end
 
       def max_step_length
@@ -123,7 +123,7 @@ module Cucumber
             key.status = :skipped
             key.mean_duration = 0
           else
-            key.status = worst_status(steps.map{ |step| step[:status] })
+            key.status = worst_status(steps.map { |step| step[:status] })
             total_duration = steps.inject(0) {|sum, step| step[:duration] + sum}
             key.mean_duration = total_duration / steps.length
           end

--- a/lib/cucumber/gherkin/formatter/ansi_escapes.rb
+++ b/lib/cucumber/gherkin/formatter/ansi_escapes.rb
@@ -78,11 +78,11 @@ module Gherkin
 
       ALIASES.keys.each do |key|
         define_method(key) do
-          ALIASES[key].split(',').map{|color| COLORS[color]}.join('')
+          ALIASES[key].split(',').map {|color| COLORS[color]}.join('')
         end
 
         define_method("#{key}_arg") do
-          ALIASES["#{key}_arg"].split(',').map{|color| COLORS[color]}.join('')
+          ALIASES["#{key}_arg"].split(',').map {|color| COLORS[color]}.join('')
         end
       end
 

--- a/lib/cucumber/glue/invoke_in_world.rb
+++ b/lib/cucumber/glue/invoke_in_world.rb
@@ -18,7 +18,7 @@ module Cucumber
           depth = backtrace.count { |line| line == instance_exec_invocation_line }
           end_pos = depth > 1 ? instance_exec_pos : -1
 
-          backtrace[replacement_line+1..end_pos] = nil
+          backtrace[replacement_line + 1..end_pos] = nil
           backtrace.compact!
         end
       end
@@ -28,7 +28,7 @@ module Cucumber
           if check_arity && !cucumber_compatible_arity?(args, block)
             world.instance_exec do
               ari = block.arity
-              ari = ari < 0 ? (ari.abs-1).to_s+'+' : ari
+              ari = ari < 0 ? (ari.abs - 1).to_s + '+' : ari
               s1 = ari == 1 ? '' : 's'
               s2 = args.length == 1 ? '' : 's'
               raise ArityMismatchError.new(

--- a/lib/cucumber/glue/registry_and_more.rb
+++ b/lib/cucumber/glue/registry_and_more.rb
@@ -135,7 +135,7 @@ module Cucumber
       end
 
       def hooks_for(phase, scenario) #:nodoc:
-        hooks[phase.to_sym].select{|hook| scenario.accept_hook?(hook)}
+        hooks[phase.to_sym].select {|hook| scenario.accept_hook?(hook)}
       end
 
       def unmatched_step_definitions
@@ -175,7 +175,7 @@ module Cucumber
       end
 
       def hooks
-        @hooks ||= Hash.new{|h, k| h[k] = []}
+        @hooks ||= Hash.new {|h, k| h[k] = []}
       end
     end
 

--- a/lib/cucumber/glue/snippet.rb
+++ b/lib/cucumber/glue/snippet.rb
@@ -70,7 +70,7 @@ module Cucumber
         end
 
         def parameters
-          block_args = (0...number_of_arguments).map { |n| "arg#{n+1}" }
+          block_args = (0...number_of_arguments).map { |n| "arg#{n + 1}" }
           multiline_argument.append_block_parameter_to(block_args)
           block_args.empty? ? '' : " |#{block_args.join(", ")}|"
         end

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -75,7 +75,7 @@ module Cucumber
         end
       end
 
-      NULL_CONVERSIONS = Hash.new({ :strict => false, :proc => lambda{ |cell_value| cell_value } }).freeze
+      NULL_CONVERSIONS = Hash.new({ :strict => false, :proc => lambda { |cell_value| cell_value } }).freeze
 
       # @param data [Core::Ast::DataTable] the data for the table
       # @param conversion_procs [Hash] see map_columns!
@@ -161,7 +161,7 @@ module Cucumber
       def symbolic_hashes
         @symbolic_hashes ||=
           self.hashes.map do |string_hash|
-            Hash[string_hash.map{ |a, b| [symbolize_key(a), b] }]
+            Hash[string_hash.map { |a, b| [symbolize_key(a), b] }]
           end
       end
 
@@ -375,7 +375,7 @@ module Cucumber
       end
 
       def has_text?(text) #:nodoc:
-        raw.flatten.compact.detect{|cell_value| cell_value.index(text)}
+        raw.flatten.compact.detect {|cell_value| cell_value.index(text)}
       end
 
       def cells_rows #:nodoc:
@@ -554,7 +554,7 @@ module Cucumber
         end
 
         def width
-          map{|cell| cell.value ? escape_cell(cell.value.to_s).unpack('U*').length : 0}.max
+          map {|cell| cell.value ? escape_cell(cell.value.to_s).unpack('U*').length : 0}.max
         end
       end
 

--- a/lib/cucumber/multiline_argument/data_table/diff_matrices.rb
+++ b/lib/cucumber/multiline_argument/data_table/diff_matrices.rb
@@ -38,7 +38,7 @@ module Cucumber
           matched_cols = []
 
           header_values.each_with_index do |v, i|
-            mapped_index = unmatched_cols.index{|unmapped_col| unmapped_col.first == v}
+            mapped_index = unmatched_cols.index {|unmapped_col| unmapped_col.first == v}
             if mapped_index
               matched_cols << unmatched_cols.delete_at(mapped_index)
             else
@@ -76,13 +76,13 @@ module Cucumber
           changes.each do |change|
             if change.action == '-'
               @missing_row_pos = change.position + inserted
-              cell_matrix[missing_row_pos].each{|cell| cell.status = :undefined}
+              cell_matrix[missing_row_pos].each {|cell| cell.status = :undefined}
               row_indices.insert(missing_row_pos, nil)
               missing += 1
             else # '+'
               @insert_row_pos = change.position + missing
               inserted_row = change.element
-              inserted_row.each{|cell| cell.status = :comment}
+              inserted_row.each {|cell| cell.status = :comment}
               cell_matrix.insert(insert_row_pos, inserted_row)
               row_indices[insert_row_pos] = nil
               inspect_rows(cell_matrix[missing_row_pos], inserted_row) if last_change == '-'
@@ -121,7 +121,7 @@ module Cucumber
         end
 
         def missing_col
-          cell_matrix[0].find{|cell| cell.status == :undefined}
+          cell_matrix[0].find {|cell| cell.status == :undefined}
         end
 
         def surplus_col

--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -39,7 +39,7 @@ module Cucumber
 
         def initialize(libs, cucumber_opts, feature_files)
           raise 'libs must be an Array when running in-process' unless Array === libs
-          libs.reverse.each{|lib| $LOAD_PATH.unshift(lib)}
+          libs.reverse.each {|lib| $LOAD_PATH.unshift(lib)}
           @args = (
             cucumber_opts +
             feature_files
@@ -169,7 +169,7 @@ module Cucumber
       end
 
       def make_command_line_safe(list)
-        list.map{|string| string.gsub(' ', '\ ')}
+        list.map {|string| string.gsub(' ', '\ ')}
       end
     end
   end

--- a/lib/cucumber/step_definition_light.rb
+++ b/lib/cucumber/step_definition_light.rb
@@ -17,7 +17,7 @@ module Cucumber
     end
 
     def hash
-      regexp_source.hash + 31*location.to_s.hash
+      regexp_source.hash + 31 * location.to_s.hash
     end
   end
 end

--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -46,7 +46,7 @@ module Cucumber
     #
     #   lambda { |param| "[#{param}]" }
     #
-    def format_args(format = lambda{|a| a}, &proc)
+    def format_args(format = lambda {|a| a}, &proc)
       replace_arguments(@name_to_match, @step_arguments, format, &proc)
     end
 

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -122,21 +122,21 @@ module Cucumber
 
         context 'handling multiple formatters' do
           it 'catches multiple command line formatters using the same stream' do
-            expect{ options.parse!(prepare_args('-f pretty -f progress')) }.to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
+            expect { options.parse!(prepare_args('-f pretty -f progress')) }.to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
           end
 
           it 'catches multiple profile formatters using the same stream' do
             given_cucumber_yml_defined_as({'default' => '-f progress -f pretty'})
             options = Options.new(output_stream, error_stream, :default_profile => 'default')
 
-            expect{ options.parse!(%w{}) }.to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
+            expect { options.parse!(%w{}) }.to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
           end
 
           it 'profiles does not affect the catching of multiple command line formatters using the same stream' do
             given_cucumber_yml_defined_as({'default' => '-q'})
             options = Options.new(output_stream, error_stream, :default_profile => 'default')
 
-            expect{ options.parse!(%w{-f progress -f pretty}) }.to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
+            expect { options.parse!(%w{-f progress -f pretty}) }.to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
           end
 
           it 'merges profile formatters and command line formatters' do
@@ -167,7 +167,7 @@ module Cucumber
           end
 
           it 'raise exception for inconsistent tag limits' do
-            expect{ after_parsing('--tags @foo:2 --tags @foo:3') }.to raise_error(RuntimeError, 'Inconsistent tag limits for @foo: 2 and 3')
+            expect { after_parsing('--tags @foo:2 --tags @foo:3') }.to raise_error(RuntimeError, 'Inconsistent tag limits for @foo: 2 and 3')
           end
         end
 
@@ -240,7 +240,7 @@ module Cucumber
           it 'raise exceptions for inconsistent tag limits' do
             given_cucumber_yml_defined_as('baz' => %w[-t @bar:2])
 
-            expect{ options.parse!(%w[--tags @bar:3 -p baz]) }.to raise_error(RuntimeError, 'Inconsistent tag limits for @bar: 3 and 2')
+            expect { options.parse!(%w[--tags @bar:3 -p baz]) }.to raise_error(RuntimeError, 'Inconsistent tag limits for @bar: 3 and 2')
           end
 
           it 'only takes the paths from the original options, and disgregards the profiles' do

--- a/spec/cucumber/filters/gated_receiver_spec.rb
+++ b/spec/cucumber/filters/gated_receiver_spec.rb
@@ -6,7 +6,7 @@ describe Cucumber::Filters::GatedReceiver do
   subject(:gated_receiver) { Cucumber::Filters::GatedReceiver.new(receiver) }
 
   let(:receiver) { double(:receiver) }
-  let(:test_cases){ [double(:test_case), double(:test_case)] }
+  let(:test_cases) { [double(:test_case), double(:test_case)] }
 
   describe '#test_case' do
     it 'does not immediately describe the test case to the receiver' do

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -16,7 +16,7 @@ module Cucumber
       RSpec::Matchers.define :have_css_node do |css, regexp|
         match do |doc|
           nodes = doc.css(css)
-          nodes.detect{ |node| node.text =~ regexp }
+          nodes.detect { |node| node.text =~ regexp }
         end
       end
 
@@ -26,7 +26,7 @@ module Cucumber
       end
 
       it 'does not raise an error when visiting a blank feature name' do
-        expect(->{ @formatter.feature_name('Feature', '') }).not_to raise_error
+        expect(-> { @formatter.feature_name('Feature', '') }).not_to raise_error
       end
 
       describe 'when writing the report to a file' do

--- a/spec/cucumber/formatter/junit_spec.rb
+++ b/spec/cucumber/formatter/junit_spec.rb
@@ -75,7 +75,7 @@ module Cucumber
           FEATURE
 
           it 'raises an exception' do
-            expect(->{ run_defined_feature }).to raise_error(Junit::UnNamedFeatureError)
+            expect(-> { run_defined_feature }).to raise_error(Junit::UnNamedFeatureError)
           end
         end
 

--- a/spec/cucumber/glue/registry_and_more_spec.rb
+++ b/spec/cucumber/glue/registry_and_more_spec.rb
@@ -183,8 +183,8 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
 
       describe 'hooks' do
         it 'finds before hooks' do
-          fish = dsl.Before('@fish'){}
-          meat = dsl.Before('@meat'){}
+          fish = dsl.Before('@fish') {}
+          meat = dsl.Before('@meat') {}
 
           scenario = double('Scenario')
 

--- a/spec/cucumber/glue/step_definition_spec.rb
+++ b/spec/cucumber/glue/step_definition_spec.rb
@@ -89,7 +89,7 @@ module Cucumber
 
         it 'has the correct location' do
           dsl.Given(/With symbol/, :with_symbol)
-          expect(step_match('With symbol').file_colon_line).to eq "spec/cucumber/glue/step_definition_spec.rb:#{__LINE__-1}"
+          expect(step_match('With symbol').file_colon_line).to eq "spec/cucumber/glue/step_definition_spec.rb:#{__LINE__ - 1}"
         end
       end
 
@@ -159,7 +159,7 @@ module Cucumber
         step_name = 'My car is white'
         step_args = step_match(step_name).args
 
-        expect(-> { run_step step_name } ).not_to change{ step_args.first }
+        expect(-> { run_step step_name } ).not_to change { step_args.first }
       end
 
       it 'allows puts' do
@@ -182,7 +182,7 @@ module Cucumber
         expect(StepDefinition.new(
           registry,
           /I CAN HAZ (\d+) CUKES/i,
-          lambda{},
+          lambda {},
           {}
         ).to_hash).to eq({
                            source: {

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -50,12 +50,12 @@ module Cucumber
 
         it 'should be able to be accessed multiple times' do
           @table.symbolic_hashes
-          expect{@table.symbolic_hashes}.to_not raise_error
+          expect {@table.symbolic_hashes}.to_not raise_error
         end
 
         it 'should not interfere with use of #hashes' do
           @table.symbolic_hashes
-          expect{@table.hashes}.to_not raise_error
+          expect {@table.hashes}.to_not raise_error
         end
       end
 
@@ -70,7 +70,7 @@ module Cucumber
           rows = ['value']
           table = DataTable.from [headers, rows]
           count = 0
-          table.map_column!('header') { |value| count +=1 }
+          table.map_column!('header') { |value| count += 1 }
           table.rows
           expect( count ).to eq rows.size
         end
@@ -116,7 +116,7 @@ module Cucumber
           rows = ['value']
           table = DataTable.from [headers, rows]
           count = 0
-          new_table = table.map_column('header') { |value| count +=1 }
+          new_table = table.map_column('header') { |value| count += 1 }
           new_table.rows
           expect( count ).to eq rows.size
         end
@@ -332,7 +332,7 @@ module Cucumber
           it 'should allow diffing empty tables' do
             t1 = DataTable.from([[]])
             t2 = DataTable.from([[]])
-            expect{ t1.diff!(t2) }.not_to raise_error
+            expect { t1.diff!(t2) }.not_to raise_error
           end
 
           it 'should be able to diff when the right table is empty' do
@@ -394,7 +394,7 @@ module Cucumber
             |d|oops|f|
             |g|h|i|
                                 })
-            expect{ t1.diff!(t2) }.to raise_error(DataTable::Different) do |error|
+            expect { t1.diff!(t2) }.to raise_error(DataTable::Different) do |error|
               expect(error.table.to_s(indent: 16, color: false)).to eq %{
                 |     a |     a    |     c |
                 | (-) d | (-) e    | (-) f |
@@ -415,7 +415,7 @@ module Cucumber
             |d|e|f|
             |g|h|i|
                                 })
-            expect{ t1.diff!(t2) }.to raise_error(DataTable::Different) do |error|
+            expect { t1.diff!(t2) }.to raise_error(DataTable::Different) do |error|
               expect(error.table.to_s(indent: 16, color: false)).to eq %{
                 |     a | (-) a |     b |     c |
                 |     d | (-) d |     e |     f |
@@ -435,7 +435,7 @@ module Cucumber
             |d|e|d|f|
             |g|h|g|i|
                                 })
-            expect{ t1.diff!(t2, :surplus_col => true) }.to raise_error(DataTable::Different) do |error|
+            expect { t1.diff!(t2, :surplus_col => true) }.to raise_error(DataTable::Different) do |error|
               expect(error.table.to_s(indent: 16, color: false)).to eq %{
                 |     a |     b |     c | (+) a |
                 |     d |     e |     f | (+) d |

--- a/spec/cucumber/step_argument_spec.rb
+++ b/spec/cucumber/step_argument_spec.rb
@@ -8,13 +8,13 @@ module Cucumber
     it 'creates 2 arguments' do
       arguments = StepArgument.arguments_from(/I (\w+) (\w+)/, 'I like fish')
 
-      expect(arguments.map{|argument| [argument.val, argument.offset]}).to eq [['like', 2], ['fish', 7]]
+      expect(arguments.map {|argument| [argument.val, argument.offset]}).to eq [['like', 2], ['fish', 7]]
     end
 
     it 'creates 2 arguments when first group is optional' do
       arguments = StepArgument.arguments_from(/should( not)? be flashed '([^']*?)'$/, "I should be flashed 'Login failed.'")
 
-      expect(arguments.map{|argument| [argument.val, argument.offset]}).to eq [[nil, nil], ['Login failed.', 21]]
+      expect(arguments.map {|argument| [argument.val, argument.offset]}).to eq [[nil, nil], ['Login failed.', 21]]
     end
   end
 end

--- a/spec/cucumber/step_match_spec.rb
+++ b/spec/cucumber/step_match_spec.rb
@@ -14,7 +14,7 @@ module Cucumber
     end
 
     def stepdef(string_or_regexp)
-      Glue::StepDefinition.new(@registry, string_or_regexp, lambda{}, {})
+      Glue::StepDefinition.new(@registry, string_or_regexp, lambda {}, {})
     end
 
     def step_match(regexp, name)
@@ -63,13 +63,13 @@ module Cucumber
     it 'formats groups with block' do
       m = step_match(/I (#{WORD}+) (\d+) (#{WORD}+) this (#{WORD}+)/, 'I ate 1 egg this morning')
 
-      expect(m.format_args(&lambda{|m| "<span>#{m}</span>"})).to eq 'I <span>ate</span> <span>1</span> <span>egg</span> this <span>morning</span>'
+      expect(m.format_args(&lambda {|m| "<span>#{m}</span>"})).to eq 'I <span>ate</span> <span>1</span> <span>egg</span> this <span>morning</span>'
     end
 
     it 'formats groups with proc object' do
       m = step_match(/I (#{WORD}+) (\d+) (#{WORD}+) this (#{WORD}+)/, 'I ate 1 egg this morning')
 
-      expect(m.format_args(lambda{|m| "<span>#{m}</span>"})).to eq 'I <span>ate</span> <span>1</span> <span>egg</span> this <span>morning</span>'
+      expect(m.format_args(lambda {|m| "<span>#{m}</span>"})).to eq 'I <span>ate</span> <span>1</span> <span>egg</span> this <span>morning</span>'
     end
 
     it 'formats groups even when first group is optional and not matched' do


### PR DESCRIPTION
# Details 
- Layout/SpaceAroundOperators
- Layout/SpaceBeforeBlockBraces
- Fixed with auto and tested

## Motivation and Context

Working to help solve issue [1021](https://github.com/cucumber/cucumber-ruby/issues/1021)!

## How Has This Been Tested?

`bundle exec rake` :+1:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Rubocop style fixes
