### PR TITLE
README: Remove Ruby 2.1 from supported platforms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for info on contributing to Cucumber.
 * Ruby 2.4
 * Ruby 2.3
 * Ruby 2.2
-* Ruby 2.1
 * JRuby 9.1
 
 ## Code of Conduct

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for info on contributing to Cucumber.
 * Ruby 2.2
 * JRuby 9.1
 
+For Ruby 2.1 support, please lock `cucumber-ruby` to version `3.0.1` in your gemfile.
+
 ## Code of Conduct
 
 Everyone interacting in this codebase and issue tracker is expected to follow the Cucumber [code of conduct](https://github.com/cucumber/cucumber/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for info on contributing to Cucumber.
 * Ruby 2.2
 * JRuby 9.1
 
-For Ruby 2.1 support, please lock `cucumber-ruby` to version `3.0.1` in your gemfile.
-
 ## Code of Conduct
 
 Everyone interacting in this codebase and issue tracker is expected to follow the Cucumber [code of conduct](https://github.com/cucumber/cucumber/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Removed Ruby 2.1 from 'supported platforms' in the readme file, as Ruby >= 2.2 is required (as per the gemspec file).

## Motivation and Context
To reduce confusion/improve accuracy of the Readme file.

## How Has This Been Tested?
N/A
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cucumber/cucumber-ruby/1282)
<!-- Reviewable:end -->
