### PR TITLE
Make --fail-fast play nice with --retry

### DIFF
--- a/features/docs/cli/retry_failing_tests.feature
+++ b/features/docs/cli/retry_failing_tests.feature
@@ -80,6 +80,16 @@ Feature: Retry failing tests
       """
 
   @todo-windows
+  Scenario: Flaky scenarios gives exit code zero in non-strict mode even when failing fast
+    When I run `cucumber -q --retry 2 --fail-fast --format summary`
+    Then it should pass with:
+      """
+
+
+      3 scenarios (2 flaky, 1 passed)
+      """
+
+  @todo-windows
   Scenario: Flaky scenarios gives non-zero exit code in strict mode
     When I run `cucumber -q --retry 2 --format summary --strict`
     Then it should fail with:

--- a/lib/cucumber/formatter/fail_fast.rb
+++ b/lib/cucumber/formatter/fail_fast.rb
@@ -9,7 +9,7 @@ module Cucumber
       def initialize(configuration)
         configuration.on_event :test_case_finished do |event|
           _test_case, result = *event.attributes
-          Cucumber.wants_to_quit = true unless result.ok?(configuration.strict)
+          Cucumber.wants_to_quit = !result.ok?(configuration.strict)
         end
       end
     end

--- a/lib/cucumber/formatter/fail_fast.rb
+++ b/lib/cucumber/formatter/fail_fast.rb
@@ -7,9 +7,15 @@ module Cucumber
   module Formatter
     class FailFast
       def initialize(configuration)
+        @previous_test_case = nil
         configuration.on_event :test_case_finished do |event|
-          _test_case, result = *event.attributes
-          Cucumber.wants_to_quit = !result.ok?(configuration.strict)
+          test_case, result = *event.attributes
+          if test_case != @previous_test_case
+            @previous_test_case = event.test_case
+            Cucumber.wants_to_quit = true unless result.ok?(configuration.strict)
+          elsif result.passed?
+            Cucumber.wants_to_quit = false
+          end
         end
       end
     end


### PR DESCRIPTION
## Summary

When running with --fail-fast and --retry, the first failure causes Cucumber to want_to_quit.  This changes resets that flag to false if the scenario succeeds on retry.

## How Has This Been Tested?

See changes to retry_failing_tests.feature

## Types of changes

- [ ] Refactor (code change that does not change external functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
