### PR TITLE
Fixed lengthy stacktrace when running `cucumber -f stepdefs` when steps aren't defined

### DIFF
--- a/features/docs/formatters/usage_formatter.feature
+++ b/features/docs/formatters/usage_formatter.feature
@@ -99,3 +99,25 @@ Feature: Usage formatter
         11 steps (11 skipped)
 
         """
+    
+    Scenario: Run with --format stepdefs when some steps are undefined
+      Given a file named "features/calculator.feature" with:
+      """
+      Feature: Calculator
+        Scenario: Adding numbers
+          When I add 4 and 5
+          Then I should get 9
+      """
+      When I run `cucumber -f stepdefs features/calculator.feature`
+      Then it should pass with:
+      """
+      You can implement step definitions for undefined steps with these snippets:
+
+      When("I add {int} and {int}") do |int, int2|
+        pending # Write code here that turns the phrase above into concrete actions
+      end
+
+      Then("I should get {int}") do |int|
+        pending # Write code here that turns the phrase above into concrete actions
+      end
+      """

--- a/lib/cucumber/formatter/usage.rb
+++ b/lib/cucumber/formatter/usage.rb
@@ -38,6 +38,8 @@ module Cucumber
         test_step = event.test_step
         result = event.result.with_filtered_backtrace(Cucumber::Formatter::BacktraceFilter)
         step_match = @matches[test_step.source]
+
+        unless step_match.nil?
         step_definition = step_match.step_definition
         stepdef_key = StepDefKey.new(step_definition.expression.to_s, step_definition.location)
         unless @stepdef_to_match[stepdef_key].map { |key| key[:location] }.include? test_step.location
@@ -51,6 +53,8 @@ module Cucumber
             duration: duration
           }
         end
+        end
+
         super
       end
 

--- a/lib/cucumber/formatter/usage.rb
+++ b/lib/cucumber/formatter/usage.rb
@@ -40,19 +40,19 @@ module Cucumber
         step_match = @matches[test_step.source]
 
         unless step_match.nil?
-        step_definition = step_match.step_definition
-        stepdef_key = StepDefKey.new(step_definition.expression.to_s, step_definition.location)
-        unless @stepdef_to_match[stepdef_key].map { |key| key[:location] }.include? test_step.location
-          duration = DurationExtractor.new(result).result_duration
+          step_definition = step_match.step_definition
+          stepdef_key = StepDefKey.new(step_definition.expression.to_s, step_definition.location)
+          unless @stepdef_to_match[stepdef_key].map { |key| key[:location] }.include? test_step.location
+            duration = DurationExtractor.new(result).result_duration
 
-          @stepdef_to_match[stepdef_key] << {
-            keyword: test_step.source.last.keyword,
-            step_match: step_match,
-            status: result.to_sym,
-            location: test_step.location,
-            duration: duration
-          }
-        end
+            @stepdef_to_match[stepdef_key] << {
+              keyword: test_step.source.last.keyword,
+              step_match: step_match,
+              status: result.to_sym,
+              location: test_step.location,
+              duration: duration
+            }
+          end
         end
 
         super


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
Currently, when running `cucumber -f stepdefs` against features which don't include step definitions, a lengthy stacktrace is shown to the user. This is thoroughly described [in issue #1285](https://github.com/cucumber/cucumber-ruby/issues/1285).
<!--- Provide a general summary description of your changes -->

## Details
I've simply added a condition to prevent a `NoMethodError` from being raised, if a step hasn't been defined for a test case. When an error isn't raised, example snippets are printed to stdout, as shown in the following test case:

```
Scenario: Run with --format stepdefs when some steps are undefined
  Given a file named "features/calculator.feature" with:
  """
  Feature: Calculator
    Scenario: Adding numbers
      When I add 4 and 5
      Then I should get 9
  """
  When I run `cucumber -f stepdefs features/calculator.feature`
  Then it should pass with:
  """
  You can implement step definitions for undefined steps with these snippets:

  When("I add {int} and {int}") do |int, int2|
    pending # Write code here that turns the phrase above into concrete actions
  end

  Then("I should get {int}") do |int|
    pending # Write code here that turns the phrase above into concrete actions
  end
  """
```     

## Motivation and Context
As described in issue #1285, it can be difficult for new users to understand what went wrong, when they mis-type a step, or fail to define one, and are shown a 40 line stacktrace.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I've added an additional feature to `features/docs/formatters/usage_formatter.feature`.
<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cucumber/cucumber-ruby/1286)
<!-- Reviewable:end -->
