### PR TITLE
Improve HTML formatting when `frozen_string_literal` is enabled and the `Syntax` gem is not installed.

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -566,10 +566,7 @@ module Cucumber
           raw_code, line = snippet_for(error[0])
           highlighted = @@converter.convert(raw_code, false)
 
-          if @@converter.is_a? NullConverter
-            highlighted = String.new(highlighted) if highlighted.frozen? # Ensure that a "can't modify frozen String" RuntimeError isn't raised when frozen_string_literal is enabled.
-            highlighted << "\n<span class=\"comment\"># gem install syntax to get syntax highlighting</span>"
-          end
+          highlighted += "\n<span class=\"comment\"># gem install syntax to get syntax highlighting</span>" if @@converter.is_a? NullConverter
 
           post_process(highlighted, line)
         end

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -565,7 +565,12 @@ module Cucumber
         def snippet(error)
           raw_code, line = snippet_for(error[0])
           highlighted = @@converter.convert(raw_code, false)
-          highlighted << "\n<span class=\"comment\"># gem install syntax to get syntax highlighting</span>" if @@converter.is_a?(NullConverter)
+
+          if @@converter.is_a? NullConverter
+            highlighted = String.new(highlighted) # Ensure that a "can't modify frozen String" RuntimeError isn't raised when frozen_string_literal is enabled.
+            highlighted << "\n<span class=\"comment\"># gem install syntax to get syntax highlighting</span>"
+          end
+
           post_process(highlighted, line)
         end
 

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -565,8 +565,7 @@ module Cucumber
         def snippet(error)
           raw_code, line = snippet_for(error[0])
           highlighted = @@converter.convert(raw_code, false)
-
-          highlighted += "\n<span class=\"comment\"># gem install syntax to get syntax highlighting</span>" if @@converter.is_a? NullConverter
+          highlighted += "\n<span class=\"comment\"># gem install syntax to get syntax highlighting</span>" if @@converter.is_a?(NullConverter)
 
           post_process(highlighted, line)
         end

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -566,7 +566,6 @@ module Cucumber
           raw_code, line = snippet_for(error[0])
           highlighted = @@converter.convert(raw_code, false)
           highlighted += "\n<span class=\"comment\"># gem install syntax to get syntax highlighting</span>" if @@converter.is_a?(NullConverter)
-
           post_process(highlighted, line)
         end
 

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -567,7 +567,7 @@ module Cucumber
           highlighted = @@converter.convert(raw_code, false)
 
           if @@converter.is_a? NullConverter
-            highlighted = String.new(highlighted) # Ensure that a "can't modify frozen String" RuntimeError isn't raised when frozen_string_literal is enabled.
+            highlighted = String.new(highlighted) if highlighted.frozen? # Ensure that a "can't modify frozen String" RuntimeError isn't raised when frozen_string_literal is enabled.
             highlighted << "\n<span class=\"comment\"># gem install syntax to get syntax highlighting</span>"
           end
 

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -579,7 +579,7 @@ module Cucumber
             let(:error_line) { 'path/to/file'.freeze }
             let(:error) { [error_line, nil] }
 
-            it do
+            it 'doesn\'t raise an error' do
               expect { instance.snippet(error) }.not_to raise_error
             end
           end

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -569,22 +569,22 @@ module Cucumber
     end
 
     describe Html::SnippetExtractor do
-        describe '#snippet' do
-          let(:instance) { Html::SnippetExtractor.new }
+      describe '#snippet' do
+        let(:instance) { Html::SnippetExtractor.new }
+        
+        context 'when the error string is frozen' do
+          before { Html::SnippetExtractor.class_variable_set(:@@converter, Html::SnippetExtractor::NullConverter.new) }
 
-          context 'when the error string is frozen' do
-            before { Html::SnippetExtractor.class_variable_set(:@@converter, Html::SnippetExtractor::NullConverter.new) }
+          context 'the error line doesnt end with a colon and a line number' do
+            let(:error_line) { 'path/to/file'.freeze }
+            let(:error) { [error_line, nil] }
 
-            context 'the error line doesnt end with a colon and a line number' do
-              let(:error_line) { 'path/to/file'.freeze }
-              let(:error) { [error_line, nil] }
-
-              it do
-                expect { instance.snippet(error) }.not_to raise_error
-              end
+            it do
+              expect { instance.snippet(error) }.not_to raise_error
             end
           end
         end
+      end
     end
   end
 end

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -571,7 +571,7 @@ module Cucumber
     describe Html::SnippetExtractor do
       describe '#snippet' do
         let(:instance) { Html::SnippetExtractor.new }
-        
+
         context 'when the error string is frozen' do
           before { Html::SnippetExtractor.class_variable_set(:@@converter, Html::SnippetExtractor::NullConverter.new) }
 

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -567,5 +567,24 @@ module Cucumber
         end
       end
     end
+
+    describe Html::SnippetExtractor do
+        describe '#snippet' do
+          let(:instance) { Html::SnippetExtractor.new }
+      
+          context 'when the error string is frozen' do
+            before { Html::SnippetExtractor.class_variable_set(:@@converter, Html::SnippetExtractor::NullConverter.new) }
+
+            context 'the error line doesnt end with a colon and a line number' do
+              let(:error_line) { 'path/to/file'.freeze }
+              let(:error) { [error_line, nil] }
+      
+              it do
+                expect { instance.snippet(error) }.not_to raise_error
+              end
+            end
+          end
+        end
+      end
   end
 end

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -571,20 +571,20 @@ module Cucumber
     describe Html::SnippetExtractor do
         describe '#snippet' do
           let(:instance) { Html::SnippetExtractor.new }
-      
+
           context 'when the error string is frozen' do
             before { Html::SnippetExtractor.class_variable_set(:@@converter, Html::SnippetExtractor::NullConverter.new) }
 
             context 'the error line doesnt end with a colon and a line number' do
               let(:error_line) { 'path/to/file'.freeze }
               let(:error) { [error_line, nil] }
-      
+
               it do
                 expect { instance.snippet(error) }.not_to raise_error
               end
             end
           end
         end
-      end
+    end
   end
 end


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary 
_This has been copied directly from [the original issue](https://github.com/cucumber/cucumber-ruby/issues/1240)._

When `Cucumber::Formatter::Html` tries to render an error where `snippet_for` goes to the `else`-branch (line 581)
https://github.com/cucumber/cucumber-ruby/blob/84bc859a62220290383a0a8c80ebf6820a426b4c/lib/cucumber/formatter/html.rb#L575-L583

it returns a frozen string (because of `frozen_string_literal: true`). When the syntax gem is not installed, modifying the frozen string in the `snippet`-method (line 571) raises an error (`can't modify frozen String`).
https://github.com/cucumber/cucumber-ruby/blob/84bc859a62220290383a0a8c80ebf6820a426b4c/lib/cucumber/formatter/html.rb#L568-L573


## Details

To resolve this, I simply created a new string from the original one, rather than mutating the frozen string.

## Motivation and Context
When the `@@converter` class variable (under `Cucumber::Formatter::Html::SnippetExtractor`) is assigned an instance of `Cucumber::Formatter::Html::SnippetExtractor::NullConverter` (or more simply, when the `Syntax` gem is not installed), and `frozen_string_literal` is enabled, `Cucumber::Formatter::Html::SnippetExtractor#snippet` raises an error when the `gem install syntax to get syntax highlighting` comment is appended to the error message.

This issue is thoroughly defined in issue #1240.

## How Has This Been Tested?
I've added a Spec to `spec/cucumber/formatter/html_spec.rb`, to test `Cucumber::Formatter::Html::SnippetExtractor#snippet`

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cucumber/cucumber-ruby/1287)
<!-- Reviewable:end -->
