### PR TITLE
 Add read access to task_name of Cucumber::Rake::Task

### DIFF
--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -133,6 +133,9 @@ module Cucumber
       #
       # Note that this attribute has no effect if you don't run in forked mode.
       attr_accessor :bundler
+      
+      # Name of the running task
+      attr_reader :task_name
 
       # Define Cucumber Rake task
       def initialize(task_name = 'cucumber', desc = 'Run Cucumber features')

--- a/spec/cucumber/rake/task_spec.rb
+++ b/spec/cucumber/rake/task_spec.rb
@@ -7,6 +7,15 @@ require 'rake'
 module Cucumber
   module Rake
     describe Task do
+      describe '@task_name' do
+        context 'has read access to task name' do
+          it { expect(subject.respond_to? :task_name).to be true }
+        end
+        context 'has no write access to task name' do
+          it { expect(subject.respond_to? "#{:task_name}=").to be false }
+        end
+      end
+
       describe '#cucumber_opts' do
         before { subject.cucumber_opts = opts }
 


### PR DESCRIPTION
## Summary

When running tests, you may need to store the name of the task in the log file to make reproducing failures easier.

## Details

So with this commit we give read access to task_name.

## Motivation and Context

I run tests with different profiles on jenkins. For reporting and logging i needed to store the task name, to have a mapping to the task with which the test run.

## How Has This Been Tested?

Added test to retrieve the task_name.

I logged the task_name in my project successfully.

## Screenshots (if appropriate):
-

## Types of changes

- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
