### PR TITLE
Let the Pretty Formatter use events

### DIFF
--- a/features/docs/cli/dry_run.feature
+++ b/features/docs/cli/dry_run.feature
@@ -61,7 +61,7 @@ Feature: Dry Run
 
         Scenario:                      # features/test.feature:2
           Given this step is undefined # features/test.feature:3
-            Undefined step: "this step is undefined" (Cucumber::Undefined)
+            Undefined step: "this step is undefined" (Cucumber::Core::Test::Result::Undefined)
             features/test.feature:3:in `Given this step is undefined'
 
       Undefined Scenarios:

--- a/features/docs/cli/strict_mode.feature
+++ b/features/docs/cli/strict_mode.feature
@@ -25,7 +25,7 @@ Feature: Strict mode
 
         Scenario: Missing
           Given this step passes
-            Undefined step: "this step passes" (Cucumber::Undefined)
+            Undefined step: "this step passes" (Cucumber::Core::Test::Result::Undefined)
             features/missing.feature:3:in `Given this step passes'
 
       Undefined Scenarios:

--- a/features/docs/exception_in_after_step_hook.feature
+++ b/features/docs/exception_in_after_step_hook.feature
@@ -42,7 +42,6 @@ Feature: Exception in AfterStep Block
           Given this step does something naughty # features/step_definitions/naughty_steps.rb:1
             This step has been very very naughty (NaughtyStepException)
             ./features/support/env.rb:4:in `AfterStep'
-            features/naughty_step_in_scenario.feature:4:in `Given this step does something naughty'
 
         Scenario: Success        # features/naughty_step_in_scenario.feature:6
           Given this step passes # features/step_definitions/steps.rb:1
@@ -88,8 +87,6 @@ Feature: Exception in AfterStep Block
             | does something naughty |
             This step has been very very naughty (NaughtyStepException)
             ./features/support/env.rb:4:in `AfterStep'
-            features/naughty_step_in_scenario_outline.feature:9:in `Given this step does something naughty'
-            features/naughty_step_in_scenario_outline.feature:4:in `Given this step <Might Work>'
             | passes                 |
 
         Scenario: Success        # features/naughty_step_in_scenario_outline.feature:12

--- a/features/docs/exception_in_around_hook.feature
+++ b/features/docs/exception_in_around_hook.feature
@@ -34,8 +34,8 @@ Feature: Exceptions in Around Hooks
       Feature: 
 
         Scenario: 
-        this should be reported (RuntimeError)
-        ./features/support/env.rb:2:in `Around'
+            this should be reported (RuntimeError)
+            ./features/support/env.rb:2:in `Around'
       
       Failing Scenarios:
       cucumber features/test.feature:2

--- a/features/docs/exception_in_before_hook.feature
+++ b/features/docs/exception_in_before_hook.feature
@@ -29,8 +29,8 @@ Feature: Exception in Before Block
       Feature: Sample
 
         Scenario: Run a good step # features/naughty_step_in_scenario.feature:3
-        I cannot even start this scenario (SomeSetupException)
-        ./features/support/env.rb:4:in `Before'
+            I cannot even start this scenario (SomeSetupException)
+            ./features/support/env.rb:4:in `Before'
           Given this step passes  # features/step_definitions/steps.rb:1
 
       Failing Scenarios:
@@ -59,8 +59,8 @@ Feature: Exception in Before Block
       Feature: Sample
       
         Background:              # features/naughty_step_in_before.feature:3
-        I cannot even start this scenario (SomeSetupException)
-        ./features/support/env.rb:4:in `Before'
+            I cannot even start this scenario (SomeSetupException)
+            ./features/support/env.rb:4:in `Before'
           Given this step passes # features/step_definitions/steps.rb:1
       
         Scenario: Run a good step # features/naughty_step_in_before.feature:6

--- a/features/docs/gherkin/background.feature
+++ b/features/docs/gherkin/background.feature
@@ -368,9 +368,6 @@ Feature: Background
 
       Background: 
         Given this step is pending
-          TODO (Cucumber::Pending)
-          ./features/step_definitions/steps.rb:3:in `/^this step is pending$/'
-          features/pending_background.feature:4:in `Given this step is pending'
 
       Scenario: pending background
         Then I should have '10' cukes

--- a/features/docs/gherkin/background.feature
+++ b/features/docs/gherkin/background.feature
@@ -35,14 +35,14 @@ Feature: Background
         Scenario Outline: passing background
           Then I should have '<count>' cukes
           Examples:
-            |count|
-            | 10  |
+            | count |
+            | 10    |
 
         Scenario Outline: another passing background
           Then I should have '<count>' cukes
           Examples:
-            |count|
-            | 10  |
+            | count |
+            | 10    |
       """
     And a file named "features/background_tagged_before_on_outline.feature" with:
       """
@@ -83,14 +83,14 @@ Feature: Background
         Scenario Outline: failing background
           Then I should have '<count>' cukes
           Examples:
-            |count|
-            | 10  |
+            | count |
+            | 10    |
 
         Scenario Outline: another failing background
           Then I should have '<count>' cukes
           Examples:
-            |count|
-            | 10  |
+            | count |
+            | 10    |
       """
     And a file named "features/pending_background.feature" with:
       """
@@ -148,8 +148,8 @@ Feature: Background
 
         Background:
           Given table
-            |a|b|
-            |c|d|
+            | a | b |
+            | c | d |
           And multiline string
             \"\"\"
             I'm a cucumber and I'm okay. 
@@ -158,8 +158,8 @@ Feature: Background
 
         Scenario: passing background
           Then the table should be
-            |a|b|
-            |c|d|
+            | a | b |
+            | c | d |
           Then the multiline string should be
             \"\"\"
             I'm a cucumber and I'm okay. 
@@ -168,8 +168,8 @@ Feature: Background
 
         Scenario: another passing background
           Then the table should be
-            |a|b|
-            |c|d|
+            | a | b |
+            | c | d |
           Then the multiline string should be
             \"\"\"
             I'm a cucumber and I'm okay. 

--- a/features/docs/gherkin/outlines.feature
+++ b/features/docs/gherkin/outlines.feature
@@ -29,13 +29,13 @@ Feature: Scenario outlines
           Given <state> without a table
           Given <other_state> without a table
         Examples: Rainbow colours
-          | state    | other_state |
-          | missing  | passing     |
-          | passing  | passing     |
-          | failing  | passing     |
+          | state   | other_state |
+          | missing | passing     |
+          | passing | passing     |
+          | failing | passing     |
       Examples:Only passing
-          | state    | other_state |
-          | passing  | passing     |
+          | state   | other_state |
+          | passing | passing     |
       """
     And a file named "features/step_definitions/steps.rb" with:
       """

--- a/features/docs/gherkin/using_descriptions.feature
+++ b/features/docs/gherkin/using_descriptions.feature
@@ -47,7 +47,7 @@ Feature: Using descriptions to give features context
           Specific examples for an outline are allowed to have
           descriptions, too.
 
-          |  state |
+          | state  |
           | passes |
     """
     When I run `cucumber -q`

--- a/features/docs/work_in_progress.feature
+++ b/features/docs/work_in_progress.feature
@@ -94,9 +94,6 @@ Feature: Cucumber --work-in-progress switch
         @pending
         Scenario: Pending
           Given this step is pending
-            TODO (Cucumber::Pending)
-            ./features/step_definitions/steps.rb:3:in `/^this step is pending$/'
-            features/wip.feature:12:in `Given this step is pending'
 
       1 scenario (1 pending)
       1 step (1 pending)

--- a/features/docs/writing_support_code/before_hook.feature
+++ b/features/docs/writing_support_code/before_hook.feature
@@ -24,9 +24,9 @@ Feature: Before Hook
     When I run `cucumber`
     Then the output should contain:
       """
-        NAMES:
-        Feature name
-        Scenario name
+            NAMES:
+            Feature name
+            Scenario name
 
       """
 

--- a/features/docs/writing_support_code/tagged_hooks.feature
+++ b/features/docs/writing_support_code/tagged_hooks.feature
@@ -22,8 +22,8 @@ Feature: Tagged hooks
           Given this step passes
 
           Examples:
-          | Value       |
-          | Irrelevant  |
+          | Value      |
+          | Irrelevant |
 
           @no-boom
           Examples:

--- a/features/docs/writing_support_code/tagged_hooks.feature
+++ b/features/docs/writing_support_code/tagged_hooks.feature
@@ -38,8 +38,8 @@ Feature: Tagged hooks
       Feature: With and without hooks
       
         Scenario: using hook     # features/f.feature:2
-        boom (RuntimeError)
-        ./features/support/hooks.rb:2:in `Before'
+            boom (RuntimeError)
+            ./features/support/hooks.rb:2:in `Before'
           Given this step passes # features/step_definitions/steps.rb:1
       
       Failing Scenarios:
@@ -77,9 +77,9 @@ Feature: Tagged hooks
 
             Examples: 
               | Value      |
+              | Irrelevant |
               boom (RuntimeError)
               ./features/support/hooks.rb:2:in `Before'
-              | Irrelevant |
 
         Failing Scenarios:
         cucumber features/f.feature:14 # Scenario Outline: omitting hook on specified examples, Examples (#1)

--- a/lib/cucumber/events.rb
+++ b/lib/cucumber/events.rb
@@ -32,6 +32,7 @@ module Cucumber
         StepActivated,
         TestRunFinished,
         GherkinSourceRead,
+        GherkinSourceParsed,
         TestRunStarted
       )
     end

--- a/lib/cucumber/events/gherkin_source_parsed.rb
+++ b/lib/cucumber/events/gherkin_source_parsed.rb
@@ -1,0 +1,14 @@
+require 'cucumber/core/events'
+
+module Cucumber
+  module Events
+    # Fired after we've parsed the contents of a feature file
+    class GherkinSourceParsed < Core::Event.new(:uri, :gherkin_document)
+      # The uri of the file
+      attr_reader :uri
+
+      # The Gherkin Ast
+      attr_reader :gherkin_document
+    end
+  end
+end

--- a/lib/cucumber/formatter/pretty.rb
+++ b/lib/cucumber/formatter/pretty.rb
@@ -1,18 +1,21 @@
 # frozen_string_literal: true
 
 require 'fileutils'
+require 'gherkin/dialect'
 require 'cucumber/formatter/console'
 require 'cucumber/formatter/io'
 require 'cucumber/gherkin/formatter/escaping'
 require 'cucumber/formatter/console_counts'
 require 'cucumber/formatter/console_issues'
+require 'cucumber/formatter/hook_query_visitor'
+require 'cucumber/formatter/duration_extractor'
+require 'cucumber/formatter/backtrace_filter'
 
 module Cucumber
   module Formatter
     # The formatter used for <tt>--format pretty</tt> (the default formatter).
     #
-    # This formatter prints features to plain text - exactly how they were parsed,
-    # just prettier. That means with proper indentation and alignment of table columns.
+    # This formatter prints the result of the feature executions to plain text - exactly how they were parsed.
     #
     # If the output is STDOUT (and not a file), there are bright colours to watch too.
     #
@@ -21,233 +24,476 @@ module Cucumber
       include Console
       include Io
       include Cucumber::Gherkin::Formatter::Escaping
-      attr_writer :indent
-      attr_reader :runtime
+      attr_reader :config, :options
+      private :config, :options
+      attr_reader :current_feature_uri, :current_scenario_outline, :current_examples, :current_test_case
+      private :current_feature_uri, :current_scenario_outline, :current_examples, :current_test_case
+      attr_reader :in_scenario_outline, :print_background_steps
+      private :in_scenario_outline, :print_background_steps
 
-      def initialize(runtime, path_or_io, options)
-        @runtime, @io, @options = runtime, ensure_io(path_or_io), options
-        @config = runtime.configuration
-        @exceptions = []
-        @indent = 0
-        @prefixes = options[:prefixes] || {}
-        @delayed_messages = []
+      def initialize(config)
+        @io = ensure_io(config.out_stream)
+        @config = config
+        @options = config.to_hash
         @previous_step_keyword = nil
         @snippets_input = []
-        @counts = ConsoleCounts.new(runtime.configuration)
-        @issues = ConsoleIssues.new(runtime.configuration)
-      end
-
-      def before_features(_features)
-        print_profile_information
-      end
-
-      def after_features(features)
-        print_summary(features)
-      end
-
-      def before_feature(_feature)
+        @total_duration = 0
         @exceptions = []
-        @indent = 0
+        @gherkin_sources = {}
+        @gherkin_documents = {}
+        @step_matches = {}
+        @counts = ConsoleCounts.new(config)
+        @issues = ConsoleIssues.new(config)
+        @first_feature = true
+        @current_feature_uri = ''
+        @current_scenario_outline = nil
+        @current_examples = nil
+        @current_test_case = nil
+        @in_scenario_outline = false
+        @print_background_steps = false
+        @test_step_output = []
+        @passed_test_cases = []
+        @source_indent = 0
+        @next_comment_to_be_printed = 0
+        config.on_event :gherkin_source_read, &method(:on_gherkin_source_read)
+        config.on_event :gherkin_source_parsed, &method(:on_gherkin_source_parsed)
+        config.on_event :step_activated, &method(:on_step_activated)
+        config.on_event :test_case_started, &method(:on_test_case_started)
+        config.on_event :test_step_started, &method(:on_test_step_started)
+        config.on_event :test_step_finished, &method(:on_test_step_finished)
+        config.on_event :test_case_finished, &method(:on_test_case_finished)
+        config.on_event :test_run_finished, &method(:on_test_run_finished)
       end
 
-      def comment_line(comment_line)
-        @io.puts(comment_line.indent(@indent))
-        @io.flush
+      def on_gherkin_source_read(event)
+        @gherkin_sources[event.path] = event.body
       end
 
-      def after_tags(_tags)
-        if @indent == 1
-          @io.puts
-          @io.flush
-        end
+      def on_gherkin_source_parsed(event)
+        @gherkin_documents[event.uri] = event.gherkin_document
       end
 
-      def tag_name(tag_name)
-        tag = format_string(tag_name, :tag).indent(@indent)
-        @io.print(tag)
-        @io.flush
-        @indent = 1
+      def on_step_activated(event)
+        test_step, step_match = *event.attributes
+        @step_matches[test_step.to_s] = step_match
       end
 
-      def feature_name(keyword, name)
-        @io.puts("#{keyword}: #{name}")
-        @io.puts
-        @io.flush
-      end
-
-      def before_feature_element(_feature_element)
-        @indent = 2
-        @scenario_indent = 2
-      end
-
-      def after_feature_element(_feature_element)
-        print_messages
-        @io.puts
-        @io.flush
-      end
-
-      def before_background(_background)
-        @indent = 2
-        @scenario_indent = 2
-        @in_background = true
-      end
-
-      def after_background(_background)
-        print_messages
-        @in_background = nil
-        @io.puts
-        @io.flush
-      end
-
-      def background_name(keyword, name, file_colon_line, source_indent)
-        print_feature_element_name(keyword, name, file_colon_line, source_indent)
-      end
-
-      def before_examples_array(_examples_array)
-        @indent = 4
-        @io.puts
-        @visiting_first_example_name = true
-      end
-
-      def examples_name(keyword, name)
-        @io.puts unless @visiting_first_example_name
-        @visiting_first_example_name = false
-        @io.puts("    #{keyword}: #{name}")
-        @io.flush
-        @indent = 6
-        @scenario_indent = 6
-      end
-
-      def before_outline_table(outline_table)
-        @table = outline_table
-      end
-
-      def after_outline_table(_outline_table)
-        @table = nil
-        @indent = 4
-      end
-
-      def scenario_name(keyword, name, file_colon_line, source_indent)
-        print_feature_element_name(keyword, name, file_colon_line, source_indent)
-      end
-
-      def before_step(step)
-        @current_step = step
-        @indent = 6
-        print_messages
-      end
-
-      def before_step_result(_keyword, _step_match, _multiline_arg, status, exception, _source_indent, background, _file_colon_line)
-        @hide_this_step = false
-        if exception
-          if @exceptions.include?(exception)
-            @hide_this_step = true
-            return
+      def on_test_case_started(event)
+        if !same_feature_as_previous_test_case?(event.test_case.location)
+          if first_feature?
+            @first_feature = false
+            print_profile_information
+          else
+            print_comments(gherkin_source.split("\n").length, 0)
+            @io.puts
           end
-          @exceptions << exception
+          @current_feature_uri = event.test_case.location.file
+          @test_case_lookup = create_test_case_lookup
+          @test_step_lookup = create_test_step_lookup
+          @exceptions = []
+          print_feature_data
+          if feature_has_background?
+            print_background_data
+            @print_background_steps = true
+            @in_scenario_outline = false
+          end
+        else
+          @print_background_steps = false
         end
-        if status != :failed && @in_background ^ background
-          @hide_this_step = true
-          return
-        end
-        @status = status
-      end
-
-      def step_name(keyword, step_match, status, source_indent, _background, _file_colon_line)
-        return if @hide_this_step
-        source_indent = nil unless @options[:source]
-        name_to_report = format_step(keyword, step_match, status, source_indent)
-        @io.puts(name_to_report.indent(@scenario_indent + 2))
-        print_messages
-      end
-
-      def doc_string(string)
-        return if @options[:no_multiline] || @hide_this_step
-        s = %{"""\n#{string}\n"""}.indent(@indent)
-        s = s.split("\n").map { |l| l =~ /^\s+$/ ? '' : l }.join("\n")
-        @io.puts(format_string(s, @current_step.status))
-        @io.flush
-      end
-
-      def exception(exception, status)
-        return if @hide_this_step
-        print_messages
-        print_exception(exception, status, @indent)
-        @io.flush
-      end
-
-      def before_multiline_arg(multiline_arg)
-        return if @options[:no_multiline] || @hide_this_step
-        @table = multiline_arg
-      end
-
-      def after_multiline_arg(_multiline_arg)
-        @table = nil
-      end
-
-      def before_table_row(_table_row)
-        return if !@table || @hide_this_step
-        @col_index = 0
-        @io.print '  |'.indent(@indent - 2)
-      end
-
-      def after_table_row(table_row)
-        return if !@table || @hide_this_step
-        print_table_row_messages
-        @io.puts
-        if table_row.exception && !@exceptions.include?(table_row.exception)
-          print_exception(table_row.exception, table_row.status, @indent)
-        end
-      end
-
-      def after_table_cell(_cell)
-        return unless @table
-        @col_index += 1
-      end
-
-      def table_cell_value(value, status)
-        return if !@table || @hide_this_step
-        status ||= @status || :passed
-        width = @table.col_width(@col_index)
-        cell_text = escape_cell(value.to_s || '')
-        padded = cell_text + (' ' * (width - cell_text.unpack('U*').length))
-        prefix = cell_prefix(status)
-        @io.print(' ' + format_string("#{prefix}#{padded}", status) + ::Cucumber::Term::ANSIColor.reset(' |'))
-        @io.flush
-      end
-
-      def before_test_case(_test_case)
+        @current_test_case = event.test_case
+        print_step_header(current_test_case) unless print_background_steps
         @previous_step_keyword = nil
       end
 
-      def after_test_step(test_step, result)
-        collect_snippet_data(test_step, result)
+      def on_test_step_started(event)
+        hook_query = HookQueryVisitor.new(event.test_step)
+        return if hook_query.hook?
+        print_step_header(current_test_case) if first_step_after_printing_background_steps?(event.test_step)
+      end
+
+      def on_test_step_finished(event)
+        hook_query = HookQueryVisitor.new(event.test_step)
+        collect_snippet_data(event.test_step, event.result) unless hook_query.hook?
+        return if in_scenario_outline && !options[:expand]
+        exception_to_be_printed = find_exception_to_be_printed(event.result)
+        print_step_data(event.test_step, event.result) if !hook_query.hook? && (print_background_steps || event.test_step.location.line >= current_test_case.location.line || exception_to_be_printed)
+        print_step_output
+        return unless exception_to_be_printed
+        print_exception(exception_to_be_printed, event.result.to_sym, 6)
+        @exceptions << exception_to_be_printed
+      end
+
+      def on_test_case_finished(event)
+        @total_duration += DurationExtractor.new(event.result).result_duration
+        @passed_test_cases << event.test_case if config.wip? && event.result.passed?
+        if in_scenario_outline && !options[:expand]
+          print_row_data(event.test_case, event.result)
+        else
+          exception_to_be_printed = find_exception_to_be_printed(event.result)
+          return unless exception_to_be_printed
+          print_exception(exception_to_be_printed, event.result.to_sym, 6)
+          @exceptions << exception_to_be_printed
+        end
+      end
+
+      def on_test_run_finished(_event)
+        print_comments(gherkin_source.split("\n").length, 0) unless current_feature_uri.empty?
+        @io.puts
+        print_summary
+      end
+
+      def puts(*messages)
+        messages.each do |message|
+          @test_step_output.push message
+        end
       end
 
       private
 
-      def print_feature_element_name(keyword, name, file_colon_line, source_indent)
-        @io.puts if @scenario_indent == 6
-        names = name.empty? ? [name] : name.split("\n")
-        line = "#{keyword}: #{names[0]}".indent(@scenario_indent)
-        @io.print(line)
-        if @options[:source]
-          line_comment = "# #{file_colon_line}".indent(source_indent)
-          @io.print(format_string(line_comment, :comment))
+      def find_exception_to_be_printed(result)
+        return nil if result.ok?(options[:strict])
+        result = result.with_filtered_backtrace(Cucumber::Formatter::BacktraceFilter)
+        exception = result.failed? ? result.exception : result
+        return nil if @exceptions.include?(exception)
+        exception
+      end
+
+      def calculate_source_indent(test_case)
+        scenario = scenario_source(test_case).scenario
+        @source_indent = calculate_source_indent_for_ast_node(scenario)
+      end
+
+      def calculate_source_indent_for_ast_node(ast_node)
+        indent = 4 + ast_node[:keyword].length
+        indent += 1 + ast_node[:name].length
+        ast_node[:steps].each do |step|
+          step_indent = 5 + step[:keyword].length + step[:text].length
+          indent = step_indent if step_indent > indent
         end
-        @io.puts
-        names[1..-1].each { |s| @io.puts s.to_s }
+        indent
+      end
+
+      def calculate_source_indent_for_expanded_test_case(test_case, scenario_keyword, expanded_name)
+        indent = 7 + scenario_keyword.length
+        indent += 2 + expanded_name.length
+        test_case.test_steps.each do |step|
+          hook_query = HookQueryVisitor.new(step)
+          if !hook_query.hook? && step.location.line >= test_case.location.line
+            step_indent = 9 + test_step_keyword(step).length + step.text.length
+            indent = step_indent if step_indent > indent
+          end
+        end
+        indent
+      end
+
+      def print_step_output
+        @test_step_output.each { |message| @io.puts(format_string(message, :tag).indent(6)) }
+        @test_step_output = []
+      end
+
+      def first_feature?
+        @first_feature
+      end
+
+      def same_feature_as_previous_test_case?(location)
+        location.file == current_feature_uri
+      end
+
+      def feature_has_background?
+        feature_children = gherkin_document[:feature][:children]
+        return false if feature_children.empty?
+        feature_children[0][:type] == :Background
+      end
+
+      def print_step_header(test_case)
+        if from_scenario_outline?(test_case)
+          @in_scenario_outline = true
+          unless same_outline_as_previous_test_case?(test_case.location)
+            @current_scenario_outline = scenario_source(test_case).scenario_outline
+            @io.puts
+            print_outline_data(current_scenario_outline)
+          end
+          unless same_examples_as_previous_test_case?(test_case.location)
+            @current_examples = scenario_source(test_case).examples
+            @io.puts
+            print_examples_data(current_examples)
+          end
+          print_expanded_row_data(current_test_case) if options[:expand]
+        else
+          @in_scenario_outline = false
+          @current_scenario_outline = nil
+          @current_examples = nil
+          @io.puts
+          @source_indent = calculate_source_indent(current_test_case)
+          print_scenario_data(test_case)
+        end
+      end
+
+      def same_outline_as_previous_test_case?(location)
+        @test_case_lookup[location.line].scenario_outline == current_scenario_outline
+      end
+
+      def same_examples_as_previous_test_case?(location)
+        @test_case_lookup[location.line].examples == current_examples
+      end
+
+      def from_scenario_outline?(test_case)
+        scenario = scenario_source(test_case)
+        scenario.type != :Scenario
+      end
+
+      def first_step_after_printing_background_steps?(test_step)
+        return false unless print_background_steps
+        return false unless test_step.location.line >= current_test_case.location.line
+        @print_background_steps = false
+        true
+      end
+
+      ScenarioSource = Struct.new(:type, :scenario)
+
+      ScenarioOutlineSource = Struct.new(:type, :scenario_outline, :examples, :row)
+
+      StepSource = Struct.new(:type, :step)
+
+      def create_test_case_lookup
+        feature = gherkin_document[:feature]
+        lookup_hash = {}
+        feature[:children].each do |child|
+          if child[:type] == :Scenario
+            lookup_hash[child[:location][:line]] = ScenarioSource.new(:Scenario, child)
+          elsif child[:type] == :ScenarioOutline
+            child[:examples].each do |examples|
+              examples[:tableBody].each do |row|
+                lookup_hash[row[:location][:line]] = ScenarioOutlineSource.new(:ScenarioOutline, child, examples, row)
+              end
+            end
+          end
+        end
+        lookup_hash
+      end
+
+      def create_test_step_lookup
+        feature = gherkin_document[:feature]
+        lookup_hash = {}
+        feature[:children].each do |child|
+          child[:steps].each do |step|
+            lookup_hash[step[:location][:line]] = StepSource.new(:Step, step)
+          end
+        end
+        lookup_hash
+      end
+
+      def print_feature_data
+        feature = gherkin_document[:feature]
+        print_language_comment(feature[:location][:line])
+        print_comments(feature[:location][:line], 0)
+        print_tags(feature[:tags], 0)
+        print_feature_line(feature)
+        print_description(feature[:description])
         @io.flush
       end
 
-      def cell_prefix(status)
-        @prefixes[status]
+      def print_language_comment(feature_line)
+        gherkin_source.split("\n")[0..feature_line].each do |line|
+          if /# *language *:/ =~ line
+            @io.puts(format_string(line, :comment))
+          end
+        end
       end
 
-      def print_summary(features)
-        print_statistics(features.duration, @config, @counts, @issues)
-        print_snippets(@options)
-        print_passing_wip(@options)
+      def print_comments(up_to_line, indent)
+        comments = gherkin_document[:comments]
+        return if comments.empty? || comments.length <= @next_comment_to_be_printed
+        comments[@next_comment_to_be_printed..-1].each do |comment|
+          if comment[:location][:line] <= up_to_line
+            @io.puts(format_string(comment[:text].strip, :comment).indent(indent))
+            @next_comment_to_be_printed += 1
+          end
+          break if @next_comment_to_be_printed >= comments.length
+        end
+      end
+
+      def print_tags(tags, indent)
+        return if !tags || tags.empty?
+        @io.puts(tags.map { |tag| format_string(tag[:name], :tag) }.join(' ').indent(indent))
+      end
+
+      def print_feature_line(feature)
+        print_keyword_name(feature[:keyword], feature[:name], 0)
+      end
+
+      def print_keyword_name(keyword, name, indent, location = nil)
+        line = "#{keyword}:"
+        line += " #{name}"
+        @io.print(line.indent(indent))
+        if location && options[:source]
+          line_comment = format_string("# #{location}", :comment).indent(@source_indent - line.length - indent)
+          @io.print(line_comment)
+        end
+        @io.puts
+      end
+
+      def print_description(description)
+        return unless description
+        description.split("\n").each do |line|
+          @io.puts(line)
+        end
+      end
+
+      def print_background_data
+        @io.puts
+        background = gherkin_document[:feature][:children][0]
+        @source_indent = calculate_source_indent_for_ast_node(background) if options[:source]
+        print_comments(background[:location][:line], 2)
+        print_background_line(background)
+        print_description(background[:description])
+        @io.flush
+      end
+
+      def print_background_line(background)
+        print_keyword_name(background[:keyword], background[:name], 2, "#{current_feature_uri}:#{background[:location][:line]}")
+      end
+
+      def print_scenario_data(test_case)
+        scenario = scenario_source(test_case).scenario
+        print_comments(scenario[:location][:line], 2)
+        print_tags(scenario[:tags], 2)
+        print_scenario_line(scenario, test_case.location)
+        print_description(scenario[:description])
+        @io.flush
+      end
+
+      def print_scenario_line(scenario, location = nil)
+        print_keyword_name(scenario[:keyword], scenario[:name], 2, location)
+      end
+
+      def print_step_data(test_step, result)
+        base_indent = options[:expand] && in_scenario_outline ? 8 : 4
+        step_keyword = test_step_keyword(test_step)
+        indent = options[:source] ? @source_indent - step_keyword.length - test_step.text.length - base_indent : nil
+        print_comments(test_step.location.line, base_indent)
+        name_to_report = format_step(step_keyword, @step_matches.fetch(test_step.to_s) { NoStepMatch.new(test_step, test_step.text) }, result.to_sym, indent)
+        @io.puts(name_to_report.indent(base_indent))
+        print_multiline_argument(test_step, result, base_indent + 2) unless options[:no_multiline]
+        @io.flush
+      end
+
+      def test_step_keyword(test_step)
+        step = step_source(test_step).step
+        step[:keyword]
+      end
+
+      def step_source(test_step)
+        @test_step_lookup[test_step.original_location.line]
+      end
+
+      def scenario_source(test_case)
+        @test_case_lookup[test_case.location.line]
+      end
+
+      def gherkin_source
+        @gherkin_sources[current_feature_uri]
+      end
+
+      def gherkin_document
+        @gherkin_documents[current_feature_uri]
+      end
+
+      def print_multiline_argument(test_step, result, indent)
+        step = step_source(test_step).step
+        multiline_arg = step[:argument]
+        return unless multiline_arg
+        if multiline_arg[:type] == :DocString
+          print_doc_string(multiline_arg[:content], result.to_sym, indent)
+        elsif multiline_arg[:type] == :DataTable
+          print_data_table(step[:argument], result.to_sym, indent)
+        end
+      end
+
+      def print_data_table(data_table, status, indent)
+        data_table[:rows].each do |row|
+          print_comments(row[:location][:line], indent)
+          @io.puts format_string(gherkin_source.split("\n")[row[:location][:line] - 1].strip, status).indent(indent)
+        end
+      end
+
+      def print_outline_data(scenario_outline)
+        print_comments(scenario_outline[:location][:line], 2)
+        print_tags(scenario_outline[:tags], 2)
+        @source_indent = calculate_source_indent_for_ast_node(scenario_outline) if options[:source]
+        print_scenario_line(scenario_outline, "#{current_feature_uri}:#{scenario_outline[:location][:line]}")
+        print_description(scenario_outline[:description])
+        scenario_outline[:steps].each do |step|
+          print_comments(step[:location][:line], 4)
+          step_line = "    #{step[:keyword]}#{step[:text]}"
+          @io.print(format_string(step_line, :skipped))
+          if options[:source]
+            comment_line = format_string("# #{current_feature_uri}:#{step[:location][:line]}", :comment)
+            @io.print(comment_line.indent(@source_indent - step_line.length))
+          end
+          @io.puts
+          next if options[:no_multiline]
+          if step[:argument] && step[:argument][:type] == :DocString
+            print_doc_string(step[:argument][:content], :skipped, 6)
+          end
+          if step[:argument] && step[:argument][:type] == :DataTable
+            print_data_table(step[:argument], :skipped, 6)
+          end
+        end
+        @io.flush
+      end
+
+      def print_doc_string(content, status, indent)
+        s = %{"""\n#{content}\n"""}.indent(indent)
+        s = s.split("\n").map { |l| l =~ /^\s+$/ ? '' : l }.join("\n")
+        @io.puts(format_string(s, status))
+      end
+
+      def print_examples_data(examples)
+        print_comments(examples[:location][:line], 4)
+        print_tags(examples[:tags], 4)
+        print_keyword_name(examples[:keyword], examples[:name], 4)
+        print_description(examples[:description])
+        unless options[:expand]
+          print_comments(examples[:tableHeader][:location][:line], 6)
+          @io.puts(gherkin_source.split("\n")[examples[:tableHeader][:location][:line] - 1].strip.indent(6))
+        end
+        @io.flush
+      end
+
+      def print_row_data(test_case, result)
+        print_comments(test_case.location.line, 6)
+        @io.print(format_string(gherkin_source.split("\n")[test_case.location.line - 1].strip, result.to_sym).indent(6))
+        @io.print(format_string(@test_step_output.join(', '), :tag).indent(2)) unless @test_step_output.empty?
+        @test_step_output = []
+        @io.puts
+        if result.failed? || result.pending?
+          result = result.with_filtered_backtrace(Cucumber::Formatter::BacktraceFilter)
+          exception = result.failed? ? result.exception : result
+          unless @exceptions.include?(exception)
+            print_exception(exception, result.to_sym, 6)
+            @exceptions << exception
+          end
+        end
+        @io.flush
+      end
+
+      def print_expanded_row_data(test_case)
+        feature = gherkin_document[:feature]
+        language_code = feature[:language] ? feature[:language] : 'en'
+        language = ::Gherkin::Dialect.for(language_code)
+        scenario_keyword = language.scenario_keywords[0]
+        row = scenario_source(test_case).row
+        expanded_name = '| ' + row[:cells].map { |cell| cell[:value] }.join(' | ') + ' |'
+        @source_indent = calculate_source_indent_for_expanded_test_case(test_case, scenario_keyword, expanded_name)
+        @io.puts
+        print_keyword_name(scenario_keyword, expanded_name, 6, test_case.location)
+      end
+
+      def print_summary
+        print_statistics(@total_duration, config, @counts, @issues)
+        print_snippets(options)
+        print_passing_wip(config, @passed_test_cases)
       end
     end
   end

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -72,7 +72,7 @@ module Cucumber
       self.visitor = report
 
       receiver = Test::Runner.new(@configuration.event_bus)
-      compile features, receiver, filters
+      compile features, receiver, filters, @configuration.event_bus
       @configuration.notify :test_run_finished
     end
 

--- a/spec/cucumber/formatter/pretty_spec.rb
+++ b/spec/cucumber/formatter/pretty_spec.rb
@@ -278,7 +278,7 @@ OUTPUT
               Given this step <status>
               Examples:
               | status |
-              | passes  |
+              | passes |
             FEATURE
 
             define_steps do

--- a/spec/cucumber/formatter/pretty_spec.rb
+++ b/spec/cucumber/formatter/pretty_spec.rb
@@ -15,7 +15,7 @@ module Cucumber
         before(:each) do
           Cucumber::Term::ANSIColor.coloring = false
           @out = StringIO.new
-          @formatter = Pretty.new(runtime, @out, {})
+          @formatter = Pretty.new(actual_runtime.configuration.with_options(out_stream: @out, source: false))
         end
 
         describe 'given a single feature' do
@@ -420,27 +420,29 @@ OUTPUT
                 | dummy |
                 #comment11
                 | dummy |
+                #comment12
             FEATURE
 
-            it 'includes the all comments except for data table rows in the output ' do
+            it 'includes the all comments in the output' do
               expect( @out.string ).to include <<OUTPUT
 #comment1
 Feature: 
 
   #comment2
   Background: 
-      #comment3
+    #comment3
     Given this step passes
 
   #comment4
   Scenario: 
-      #comment5
+    #comment5
     Given this step passes
+      #comment6
       | dummy |
 
   #comment7
   Scenario Outline: 
-      #comment8
+    #comment8
     Given this step passes
 
     #comment9
@@ -449,6 +451,7 @@ Feature:
       | dummy |
       #comment11
       | dummy |
+#comment12
 OUTPUT
             end
           end
@@ -459,7 +462,7 @@ OUTPUT
         before(:each) do
           Cucumber::Term::ANSIColor.coloring = false
           @out = StringIO.new
-          @formatter = Pretty.new(runtime, @out, {:no_multiline => true})
+          @formatter = Pretty.new(actual_runtime.configuration.with_options(out_stream: @out, source: false, :no_multiline => true))
         end
 
         describe 'given a single feature' do
@@ -633,7 +636,7 @@ OUTPUT
         before(:each) do
           Cucumber::Term::ANSIColor.coloring = false
           @out = StringIO.new
-          @formatter = Pretty.new(runtime, @out, {})
+          @formatter = Pretty.new(actual_runtime.configuration.with_options(out_stream: @out))
         end
 
         describe 'given a single feature' do
@@ -722,7 +725,7 @@ OUTPUT
         before(:each) do
           Cucumber::Term::ANSIColor.coloring = false
           @out = StringIO.new
-          @formatter = Pretty.new(runtime, @out, {:source => true})
+          @formatter = Pretty.new(actual_runtime.configuration.with_options(out_stream: @out, :source => true))
         end
 
         describe 'given a single feature' do
@@ -752,15 +755,15 @@ OUTPUT
               Scenario Outline: Monkey eats a balanced diet # spec.feature:3
                 Given there are <Things>                    # spec.feature:4
                 Examples: Fruit
-                  Scenario: | apples |                          # spec.feature:8
-                    Given there are apples                      # spec.feature:8
-                  Scenario: | bananas |                         # spec.feature:9
-                    Given there are bananas                     # spec.feature:9
+                  Scenario: | apples |     # spec.feature:8
+                    Given there are apples # spec.feature:8
+                  Scenario: | bananas |     # spec.feature:9
+                    Given there are bananas # spec.feature:9
                 Examples: Vegetables
-                  Scenario: | broccoli |                        # spec.feature:12
-                    Given there are broccoli                    # spec.feature:12
-                  Scenario: | carrots |                         # spec.feature:13
-                    Given there are carrots                     # spec.feature:13
+                  Scenario: | broccoli |     # spec.feature:12
+                    Given there are broccoli # spec.feature:12
+                  Scenario: | carrots |     # spec.feature:13
+                    Given there are carrots # spec.feature:13
               OUTPUT
               lines.split("\n").each do |line|
                 expect(@out.string).to include line.strip
@@ -799,7 +802,7 @@ OUTPUT
         before(:each) do
           Cucumber::Term::ANSIColor.coloring = false
           @out = StringIO.new
-          @formatter = Pretty.new(runtime, @out, {snippets: true})
+          @formatter = Pretty.new(actual_runtime.configuration.with_options(out_stream: @out, snippets: true))
           run_defined_feature
         end
 

--- a/spec/cucumber/formatter/spec_helper.rb
+++ b/spec/cucumber/formatter/spec_helper.rb
@@ -21,7 +21,7 @@ module Cucumber
 
       def run_defined_feature
         define_steps
-        actual_runtime.visitor = report
+        actual_runtime.visitor = Fanout.new([@formatter])
 
         receiver = Test::Runner.new(event_bus)
         filters = [
@@ -35,17 +35,9 @@ module Cucumber
           Filters::ApplyAroundHooks.new(actual_runtime.support_code),
           Filters::PrepareWorld.new(actual_runtime)
         ]
-        compile [gherkin_doc], receiver, filters
+        event_bus.gherkin_source_read(gherkin_doc.uri, gherkin_doc.body)
+        compile [gherkin_doc], receiver, filters, event_bus
         event_bus.test_run_finished
-      end
-
-      require 'cucumber/formatter/legacy_api/adapter'
-      def report
-        @report ||= LegacyApi::Adapter.new(
-          Fanout.new([@formatter]),
-          actual_runtime.results,
-          actual_runtime.configuration
-        )
       end
 
       require 'cucumber/core/gherkin/document'

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -28,7 +28,7 @@ module Cucumber
         before(:each) do
           Cucumber::Term::ANSIColor.coloring = false
           @out = StringIO.new
-          @formatter = Cucumber::Formatter::Pretty.new(runtime, @out, {})
+          @formatter = Cucumber::Formatter::Pretty.new(actual_runtime.configuration.with_options(out_stream: @out, source: false))
           run_defined_feature
         end
 


### PR DESCRIPTION
## Summary

Let the Pretty Formatter use events (instead of the obsolete legacy_api).

## Details

A few behavioral changes are introduced:
* the step preceding the After Step hook are no added to the exception backtrace for an exception from the After Step hook.
* exceptions are printed when the result is not #ok?(strict_setting), previously pending exceptions were printed also when the were #ok? (that is in non-strict mode).
* tables (data tables and examples tables) are not longer prettified, but printed as they appear in the feature file.
* the indentation of exceptions are sometimes slightly changes, to make more sense.

Requires cucumber/cucumber-ruby-core#155.

The removal of using the legacy_api in the `spec_helper.rb` is breaking the rspec test for the HTML Formatter.

## Motivation and Context

See https://github.com/cucumber/cucumber-ruby/issues/839

## How Has This Been Tested?

The automated test suite has been updated to verify this behavior.

## Types of changes

- [X] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
