### PR TITLE
CircleCI: use jruby-9.2.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
 
   "jruby":
     docker:
-       - image: circleci/jruby:9.1.16.0-jdk
+       - image: circleci/jruby:9.2.0.0-jdk
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
This PR replaces the non-existent 9.1.16.0 image with the latest 9.2.0.0
one.

This only makes the tests **run**, it does not repair them.

# Motivation

I found out that the jruby build failed due to a missing image.

# Background

CircleCI throws away some older images when they're superseded by newer
ones. The latest GA version of JRuby is now 9.2.0.0.

# How has this been tested?

I'll let the CI run.

# Steps

- [ ] Refactor (code change that does not change external functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# What I did

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.