### PR TITLE
Let the Rerun Formatter handle flaky scenarios

### DIFF
--- a/lib/cucumber/formatter/rerun.rb
+++ b/lib/cucumber/formatter/rerun.rb
@@ -13,11 +13,23 @@ module Cucumber
         @failures = {}
         config.on_event :test_case_finished do |event|
           test_case, result = *event.attributes
-          next if result.ok?(@config.strict)
-          @failures[test_case.location.file] ||= []
-          @failures[test_case.location.file] << test_case.location.lines.max
+          if @config.strict.strict?(:flaky)
+            next if result.ok?(@config.strict)
+            add_to_failures(test_case)
+          else
+            unless @latest_failed_test_case.nil?
+              if @latest_failed_test_case != test_case
+                add_to_failures(@latest_failed_test_case)
+                @latest_failed_test_case = nil
+              elsif result.ok?(@config.strict)
+                @latest_failed_test_case = nil
+              end
+            end
+            @latest_failed_test_case = test_case unless result.ok?(@config.strict)
+          end
         end
         config.on_event :test_run_finished do
+          add_to_failures(@latest_failed_test_case) unless @latest_failed_test_case.nil?
           next if @failures.empty?
           @io.print file_failures.join("\n")
         end
@@ -27,6 +39,12 @@ module Cucumber
 
       def file_failures
         @failures.map { |file, lines| [file, lines].join(':') }
+      end
+
+      def add_to_failures(test_case)
+        location = test_case.location
+        @failures[location.file] ||= []
+        @failures[location.file] << location.lines.max unless @failures[location.file].include?(location.lines.max)
       end
     end
   end

--- a/spec/cucumber/formatter/rerun_spec.rb
+++ b/spec/cucumber/formatter/rerun_spec.rb
@@ -93,6 +93,75 @@ module Cucumber
           expect(io.string).to eq ''
         end
       end
+
+      context 'with only a flaky scenarios' do
+        class FlakyStepActions < Cucumber::Core::Filter.new
+          def test_case(test_case)
+            failing_test_steps = test_case.test_steps.map do |step|
+              step.with_action { raise Failure }
+            end
+            passing_test_steps = test_case.test_steps.map do |step|
+              step.with_action {}
+            end
+
+            test_case.with_steps(failing_test_steps).describe_to(receiver)
+            test_case.with_steps(passing_test_steps).describe_to(receiver)
+          end
+        end
+
+        context 'with option --no-strict-flaky' do
+          it 'prints nothing' do
+            gherkin = gherkin('foo.feature') do
+              feature do
+                scenario do
+                  step 'flaky'
+                end
+              end
+            end
+
+            Rerun.new(config)
+            execute [gherkin], [FlakyStepActions.new], config.event_bus
+            config.event_bus.test_run_finished
+
+            expect(io.string).to eq ''
+          end
+        end
+        context 'with option --strict-flaky' do
+          let(:config) { Configuration.new(out_stream: io, strict: Core::Test::Result::StrictConfiguration.new([:flaky])) }
+
+          it 'prints the location of the flaky scenario' do
+            foo = gherkin('foo.feature') do
+              feature do
+                scenario do
+                  step 'flaky'
+                end
+              end
+            end
+
+            Rerun.new(config)
+            execute [foo], [FlakyStepActions.new], config.event_bus
+            config.event_bus.test_run_finished
+
+            expect(io.string).to eq 'foo.feature:3'
+          end
+
+          it 'does not include retried failing scenarios more than once' do
+            foo = gherkin('foo.feature') do
+              feature do
+                scenario do
+                  step 'failing'
+                end
+              end
+            end
+
+            Rerun.new(config)
+            execute [foo, foo], [StandardStepActions.new], config.event_bus
+            config.event_bus.test_run_finished
+
+            expect(io.string).to eq 'foo.feature:3'
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Let the Rerun Formatter handle flaky scenarios.

## Details

Let the Rerun Formatter detect the retry of scenarios, and only with the `--strict-flaky` options, include the flaky scenarios in the output.

## Motivation and Context

The Rerun Formatter output should be empty if the exit code is zero. Without the `--strict-flaky` option flaky scenarios do not make the exit code non-zero.

## How Has This Been Tested?

The automated test suite has been updated to verify this behavior.

## Types of changes

- [ ] Refactor (code change that does not change external functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
