### PR TITLE
Use gherkin 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,7 @@ elsif !ENV['CUCUMBER_USE_RELEASED_GEMS']
 end
 
 gem 'cucumber-expressions', path: ENV['CUCUMBER_EXPRESSIONS_RUBY'] if ENV['CUCUMBER_EXPRESSIONS_RUBY']
+
+gem 'gherkin', path: ENV['GHERKIN_RUBY'] if ENV['GHERKIN_RUBY']
+
+gem 'cucumber-messages', path: ENV['CUCUMBER_MESSAGES_RUBY'] if ENV['CUCUMBER_MESSAGES_RUBY']

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cucumber-expressions', '~> 6.0.1'
   s.add_dependency 'cucumber-wire', '~> 0.0.1'
   s.add_dependency 'diff-lcs', '~> 1.3'
-  s.add_dependency 'gherkin', '~> 5.1.0'
+  s.add_dependency 'gherkin', '~> 6.0'
   s.add_dependency 'multi_json', '>= 1.7.5', '< 2.0'
   s.add_dependency 'multi_test', '>= 0.1.2'
 

--- a/features/docs/cli/i18n.feature
+++ b/features/docs/cli/i18n.feature
@@ -16,7 +16,7 @@ Feature: i18n
       """
         | feature          | "Funcionalidade", "Característica", "Caracteristica"                                         |
         | background       | "Contexto", "Cenário de Fundo", "Cenario de Fundo", "Fundo"                                  |
-        | scenario         | "Cenário", "Cenario"                                                                         |
+        | scenario         | "Exemplo", "Cenário", "Cenario"                                                              |
         | scenario_outline | "Esquema do Cenário", "Esquema do Cenario", "Delineação do Cenário", "Delineacao do Cenario" |
         | examples         | "Exemplos", "Cenários", "Cenarios"                                                           |
         | given            | "* ", "Dado ", "Dada ", "Dados ", "Dadas "                                                   |

--- a/features/docs/gherkin/background.feature
+++ b/features/docs/gherkin/background.feature
@@ -461,7 +461,7 @@ Feature: Background
 
         Examples: 
  
-          Scenario: | 10 |
+          Example: | 10 |
             Then I should have '10' global cukes
 
       Scenario Outline: failing background
@@ -469,7 +469,7 @@ Feature: Background
 
         Examples: 
 
-          Scenario: | 10 |
+          Example: | 10 |
             And '10' global cukes
           FAIL (RuntimeError)
           ./features/step_definitions/cuke_steps.rb:8:in `/^'(.+)' global cukes$/'

--- a/features/docs/gherkin/expand_option_for_outlines.feature
+++ b/features/docs/gherkin/expand_option_for_outlines.feature
@@ -32,12 +32,12 @@ Feature: Scenario outlines --expand option
 
           Examples: 
 
-            Scenario: | blue | blue | right |
+            Example: | blue | blue | right |
               Given the secret code is blue
               When I guess blue
               Then I am right
 
-            Scenario: | red | blue | wrong |
+            Example: | red | blue | wrong |
               Given the secret code is red
               When I guess blue
               Then I am wrong

--- a/lib/cucumber/events/gherkin_source_parsed.rb
+++ b/lib/cucumber/events/gherkin_source_parsed.rb
@@ -3,10 +3,7 @@ require 'cucumber/core/events'
 module Cucumber
   module Events
     # Fired after we've parsed the contents of a feature file
-    class GherkinSourceParsed < Core::Event.new(:uri, :gherkin_document)
-      # The uri of the file
-      attr_reader :uri
-
+    class GherkinSourceParsed < Core::Event.new(:gherkin_document)
       # The Gherkin Ast
       attr_reader :gherkin_document
     end

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -167,10 +167,8 @@ module Cucumber
           name: test_step.text,
           line: test_step.location.lines.min
         }
-        unless step_source[:argument].nil?
-          step_hash[:doc_string] = create_doc_string_hash(step_source[:argument]) if step_source[:argument][:type] == :DocString
-          step_hash[:rows] = create_data_table_value(step_source[:argument]) if step_source[:argument][:type] == :DataTable
-        end
+        step_hash[:doc_string] = create_doc_string_hash(step_source[:doc_string]) unless step_source[:doc_string].nil?
+        step_hash[:rows] = create_data_table_value(step_source[:data_table]) unless step_source[:data_table].nil?
         step_hash
       end
 
@@ -234,7 +232,7 @@ module Cucumber
           uri = test_case.location.file
           feature = ast_lookup.gherkin_document(uri)[:feature]
           feature(feature, uri)
-          background(feature[:children].first) if feature[:children].first[:type] == :Background
+          background(feature[:children].first[:background]) unless feature[:children].first[:background].nil?
           scenario(ast_lookup.scenario_source(test_case), test_case)
         end
 
@@ -300,7 +298,7 @@ module Cucumber
         end
 
         def calculate_row_number(scenario_source)
-          scenario_source.examples[:tableBody].each_with_index do |row, index|
+          scenario_source.examples[:table_body].each_with_index do |row, index|
             return index + 2 if row == scenario_source.row
           end
         end

--- a/lib/cucumber/gherkin/data_table_parser.rb
+++ b/lib/cucumber/gherkin/data_table_parser.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require 'gherkin/token_scanner'
-require 'gherkin/parser'
+require 'gherkin/gherkin'
 require 'gherkin/dialect'
 
 module Cucumber
@@ -12,11 +11,14 @@ module Cucumber
       end
 
       def parse(text)
-        token_scanner = ::Gherkin::TokenScanner.new(feature_header + text)
-        parser = ::Gherkin::Parser.new
-        gherkin_document = parser.parse(token_scanner)
+        gherkin_document = nil
+        messages = ::Gherkin::Gherkin.from_source('dummy', feature_header + text, include_source: false, include_pickles: false)
+        messages.each do |message|
+          gherkin_document = message.gherkinDocument.to_hash unless message.gherkinDocument.nil?
+        end
 
-        gherkin_document[:feature][:children][0][:steps][0][:argument][:rows].each do |row|
+        return if gherkin_document.nil?
+        gherkin_document[:feature][:children][0][:scenario][:steps][0][:data_table][:rows].each do |row|
           @builder.row(row[:cells].map { |cell| cell[:value] })
         end
       end

--- a/lib/cucumber/gherkin/steps_parser.rb
+++ b/lib/cucumber/gherkin/steps_parser.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'gherkin/token_scanner'
-require 'gherkin/token_matcher'
-require 'gherkin/parser'
+require 'gherkin/gherkin'
 require 'gherkin/dialect'
 
 module Cucumber
@@ -15,12 +13,13 @@ module Cucumber
 
       def parse(text)
         dialect = ::Gherkin::Dialect.for(@language)
-        token_matcher = ::Gherkin::TokenMatcher.new(@language)
-        token_scanner = ::Gherkin::TokenScanner.new(feature_header(dialect) + text)
-        parser = ::Gherkin::Parser.new
-        gherkin_document = parser.parse(token_scanner, token_matcher)
+        gherkin_document = nil
+        messages = ::Gherkin::Gherkin.from_source('dummy', feature_header(dialect) + text, default_dialect: @language, include_source: false, include_pickles: false)
+        messages.each do |message|
+          gherkin_document = message.gherkinDocument.to_hash unless message.gherkinDocument.nil?
+        end
 
-        @builder.steps(gherkin_document[:feature][:children][0][:steps])
+        @builder.steps(gherkin_document[:feature][:children][0][:scenario][:steps])
       end
 
       def feature_header(dialect)

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -27,14 +27,10 @@ module Cucumber
         end
 
         def multiline_arg(step, location)
-          argument = step[:argument]
-
-          if argument
-            if argument[:type] == :DocString
-              MultilineArgument.from(argument[:content], location, argument[:content_type])
-            else
-              MultilineArgument::DataTable.from(argument[:rows].map { |row| row[:cells].map { |cell| cell[:value] } })
-            end
+          if !step[:doc_string].nil?
+            MultilineArgument.from(step[:doc_string][:content], location, step[:doc_string][:content_type])
+          elsif !step[:data_table].nil?
+            MultilineArgument::DataTable.from(step[:data_table][:rows].map { |row| row[:cells].map { |cell| cell[:value] } })
           else
             MultilineArgument.from(nil)
           end

--- a/spec/cucumber/formatter/pretty_spec.rb
+++ b/spec/cucumber/formatter/pretty_spec.rb
@@ -455,6 +455,46 @@ Feature:
 OUTPUT
             end
           end
+
+          describe 'with the rule keyword' do
+            define_feature <<-FEATURE
+          Feature: Some rules
+
+            Background: FB
+              Given fb
+
+            Rule: A
+              The rule A description
+
+              Background: AB
+                Given ab
+
+              Example: Example A
+                Given a
+
+            Rule: B
+              The rule B description
+
+              Example: Example B
+                Given b
+            FEATURE
+
+            it 'ignores the rule keyword' do
+              expect(@out.string).to include <<OUTPUT
+Feature: Some rules
+
+  Background: FB
+    Given fb
+    Given ab
+
+  Example: Example A
+    Given a
+
+  Example: Example B
+    Given b
+OUTPUT
+            end
+          end
         end
       end
 
@@ -664,14 +704,14 @@ OUTPUT
             it 'outputs the instantiated scenarios' do
               lines = <<-OUTPUT
               Examples: Fruit
-                Scenario: | apples |
+                Example: | apples |
                   Given there are apples
-                Scenario: | bananas |
+                Example: | bananas |
                   Given there are bananas
               Examples: Vegetables
-                Scenario: | broccoli |
+                Example: | broccoli |
                   Given there are broccoli
-                Scenario: | carrots |
+                Example: | carrots |
                   Given there are carrots
               OUTPUT
               lines.split("\n").each do |line|
@@ -755,14 +795,14 @@ OUTPUT
               Scenario Outline: Monkey eats a balanced diet # spec.feature:3
                 Given there are <Things>                    # spec.feature:4
                 Examples: Fruit
-                  Scenario: | apples |     # spec.feature:8
+                  Example: | apples |      # spec.feature:8
                     Given there are apples # spec.feature:8
-                  Scenario: | bananas |     # spec.feature:9
+                  Example: | bananas |      # spec.feature:9
                     Given there are bananas # spec.feature:9
                 Examples: Vegetables
-                  Scenario: | broccoli |     # spec.feature:12
+                  Example: | broccoli |      # spec.feature:12
                     Given there are broccoli # spec.feature:12
-                  Scenario: | carrots |     # spec.feature:13
+                  Example: | carrots |      # spec.feature:13
                     Given there are carrots # spec.feature:13
               OUTPUT
               lines.split("\n").each do |line|
@@ -785,8 +825,8 @@ OUTPUT
               it 'the scenario line controls the source indentation' do
                 lines = <<-OUTPUT
               Examples:
-                 Scenario: | Hominidae | Very long cell content | # spec.feature:8
-                   Given there are Hominidae                      # spec.feature:8
+                 Example: | Hominidae | Very long cell content | # spec.feature:8
+                   Given there are Hominidae                     # spec.feature:8
 
                 OUTPUT
                 lines.split("\n").each do |line|


### PR DESCRIPTION
## Summary

Update to use gherkin version 6.

## Details

Update to use gherkin version 6.
The pretty formatter will not output anything about the rule keywords from the feature file, but it will produce some more or less reasonable output for features using the rule keyword.
For some unknown reasons the junit formatter will remove leading tab signs that were previously printed for stack traces from test cases from scenario outlines.

Depends on cucumber/cucumber-ruby-core#158

## Motivation and Context

Needed to use gherkin version 6.

## How Has This Been Tested?

The automated test suite has been updated to verify this behavior.

## Types of changes

- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
