### PR TITLE
Remove the support of old style tag expressions.

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -6,7 +6,7 @@ std_opts << " --tags 'not @wip-jruby'" if defined?(JRUBY_VERSION)
 
 wip_opts = "--color -r features".dup
 wip_opts << " --tags @wip" if !defined?(JRUBY_VERSION)
-wip_opts << " --tags @wip,@wip-jruby" if defined?(JRUBY_VERSION)
+wip_opts << " --tags '@wip or @wip-jruby'" if defined?(JRUBY_VERSION)
 %>
 default:     <%= std_opts %> --tags "not @jruby"
 jruby:       <%= std_opts %> --tags "not @wire"

--- a/features/docs/cli/randomize.feature
+++ b/features/docs/cli/randomize.feature
@@ -17,10 +17,10 @@ Feature: Randomize
     Given a file named "features/bad_practice_part_1.feature" with:
       """
       Feature: Bad practice, part 1
-        
+
         Scenario: Set state
           Given I set some state
-      
+
         Scenario: Depend on state from a preceding scenario
           When I depend on the state
       """
@@ -89,7 +89,7 @@ Feature: Randomize
 
         Scenario: Set state
           Given I set some state
-      
+
       Failing Scenarios:
       cucumber features/bad_practice_part_1.feature:6
       cucumber features/bad_practice_part_2.feature:3
@@ -103,7 +103,7 @@ Feature: Randomize
 
   @spawn @todo-windows
   Scenario: Run scenarios randomized with some skipped
-    When I run `cucumber --tags ~@skipme --order random:41544 -q`
+    When I run `cucumber --tags 'not @skipme' --order random:41544 -q`
     Then it should fail
     And the stdout should contain exactly:
       """

--- a/features/docs/writing_support_code/around_hooks.feature
+++ b/features/docs/writing_support_code/around_hooks.feature
@@ -150,13 +150,13 @@ Feature: Around hooks
         block.call
       end
 
-      Around('@one,@two') do |scenario, block|
+      Around('@one or @two') do |scenario, block|
         $hooks_called ||= []
         $hooks_called << 'one or two'
         block.call
       end
 
-      Around('@one', '@two') do |scenario, block|
+      Around('@one and @two') do |scenario, block|
         $hooks_called ||= []
         $hooks_called << 'one and two'
         block.call

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -366,8 +366,8 @@ Specify SEED to reproduce the shuffling from a previous run.
       end
 
       def add_tag(value)
-        warn("Deprecated: Found tags option '#{value}'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.") if value.include?('~')
-        warn("Deprecated: Found tags option '#{value}'. Support for '@tag1,@tag2' will be removed from the next release of Cucumber. Please use '@tag or @tag2' instead.") if value.include?(',')
+        raise("Found tags option '#{value}'. '~@tag' is no longer supported, use 'not @tag' instead.") if value.include?('~')
+        raise("Found tags option '#{value}'. '@tag1,@tag2' is no longer supported, use '@tag or @tag2' instead.") if value.include?(',')
         @options[:tag_expressions] << value.gsub(/(@\w+)(:\d+)?/, '\1')
         add_tag_limits(value)
       end

--- a/lib/cucumber/glue/hook.rb
+++ b/lib/cucumber/glue/hook.rb
@@ -10,10 +10,10 @@ module Cucumber
 
       def initialize(registry, tag_expressions, proc)
         @registry = registry
-        @tag_expressions = tag_expressions
+        @tag_expressions = sanitize_tag_expressions(tag_expressions)
         @proc = proc
         @location = Cucumber::Core::Test::Location.from_source_location(*@proc.source_location)
-        warn_for_old_style_tag_expressions(tag_expressions)
+        fail_for_old_style_tag_expressions(@tag_expressions)
       end
 
       def invoke(pseudo_method, arguments, &block)
@@ -29,18 +29,21 @@ module Cucumber
 
       private
 
-      def warn_for_old_style_tag_expressions(tag_expressions)
+      def sanitize_tag_expressions(tag_expressions)
+        # TODO: remove when '~@no-clobber' has been changed to 'not @no-clobber' in aruba
+        tag_expressions.map { |tag_expression| tag_expression == '~@no-clobber' ? 'not @no-clobber' : tag_expression }
+      end
+
+      def fail_for_old_style_tag_expressions(tag_expressions)
         tag_expressions.each do |tag_expression|
-          if tag_expression.include?('~') && tag_expression != '~@no-clobber' # ~@no-clobber is used in aruba
-            warn("Deprecated: Found tagged hook with '#{tag_expression}'." \
-            "Support for '~@tag' will be removed from the next release of Cucumber. " \
-            "Please use 'not @tag' instead.")
+          if tag_expression.include?('~')
+            raise("Found tagged hook with '#{tag_expression}'." \
+            "'~@tag' is no longer supported, use 'not @tag' instead.")
           end
 
           next unless tag_expression.include?(',')
-          warn("Deprecated: Found tagged hook with '#{tag_expression}'." \
-            "Support for '@tag1,@tag2' will be removed from the next release " \
-            "of Cucumber. Please use '@tag or @tag2' instead.")
+          warn("Found tagged hook with '#{tag_expression}'." \
+            "'@tag1,@tag2' is no longer supported, use '@tag or @tag2' instead.")
         end
       end
     end


### PR DESCRIPTION
## Summary

Remove the support of old style tag expressions.

## Details

Remove the support for "~" and "," in tag expressions.
Still support the use of `~@no-clobber` tagged hooks in aruba (that is convert '`~@no-clobber`' to '`not @no-clobber`').

## Motivation and Context

Old style tag expressions have been deprecated since v3.0.0, so their support should be removed in v4.0.0.

## How Has This Been Tested?

The automated test suite has been updated to verify the changed behavior.

## Types of changes

- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
