### PR TITLE
Use secure protocol when running `bundle install`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,19 @@
 source 'https://rubygems.org'
+
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
 gemspec
 
 if ENV['CUCUMBER_RUBY_CORE']
   gem 'cucumber-core', path: ENV['CUCUMBER_RUBY_CORE']
 elsif !ENV['CUCUMBER_USE_RELEASED_GEMS']
-  gem 'cucumber-core', git: 'git://github.com/cucumber/cucumber-ruby-core.git'
+  gem 'cucumber-core', github: 'cucumber/cucumber-ruby-core'
 end
 
 if ENV['CUCUMBER_RUBY_WIRE']
   gem 'cucumber-wire', path: ENV['CUCUMBER_RUBY_WIRE']
 elsif !ENV['CUCUMBER_USE_RELEASED_GEMS']
-  gem 'cucumber-wire', git: 'git://github.com/cucumber/cucumber-ruby-wire.git'
+  gem 'cucumber-wire', github: 'cucumber/cucumber-ruby-wire'
 end
 
 gem 'cucumber-expressions', path: ENV['CUCUMBER_EXPRESSIONS_RUBY'] if ENV['CUCUMBER_EXPRESSIONS_RUBY']


### PR DESCRIPTION
## Summary

This PR suppresses the following warnings.

```console
% bundle install
The git source `git://github.com/cucumber/cucumber-ruby-core.git` uses
the `git` protocol, which transmits data without encryption. Disable
this warning with `bundle config git.allow_insecure true`, or switch to
the `https` protocol to keep your data secure.
The git source `git://github.com/cucumber/cucumber-ruby-wire.git` uses
the `git` protocol, which transmits data without encryption. Disable
this warning with `bundle config git.allow_insecure true`, or switch to
the `https` protocol to keep your data secure.
Fetching git://github.com/cucumber/cucumber-ruby-core.git
Fetching git://github.com/cucumber/cucumber-ruby-wire.Git
```

Refer: bundler/bundler#4127

## Types of changes

- [x] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
