### PR TITLE
Use single quotes in generated template steps

### DIFF
--- a/features/docs/defining_steps/snippets.feature
+++ b/features/docs/defining_steps/snippets.feature
@@ -20,19 +20,19 @@ Feature: Snippets
     When I run `cucumber features/undefined_steps.feature -s`
     Then the output should contain:
       """
-      Given("a Doc String") do |string|
+      Given('a Doc String') do |string|
         pending # Write code here that turns the phrase above into concrete actions
       end
 
-      When("{int} simple when step") do |int|
+      When('{int} simple when step') do |int|
         pending # Write code here that turns the phrase above into concrete actions
       end
 
-      When("another {string} step") do |string|
+      When('another {string} step') do |string|
         pending # Write code here that turns the phrase above into concrete actions
       end
 
-      Then("a simple then step") do
+      Then('a simple then step') do
         pending # Write code here that turns the phrase above into concrete actions
       end
       """
@@ -49,7 +49,7 @@ Feature: Snippets
     When I run `cucumber features/undefined_steps.feature -s`
     Then the output should contain:
       """
-      Given("a table") do |table|
+      Given('a table') do |table|
         # table is a Cucumber::MultilineArgument::DataTable
         pending # Write code here that turns the phrase above into concrete actions
       end

--- a/features/docs/formatters/usage_formatter.feature
+++ b/features/docs/formatters/usage_formatter.feature
@@ -113,11 +113,11 @@ Feature: Usage formatter
       """
       You can implement step definitions for undefined steps with these snippets:
 
-      When("I add {int} and {int}") do |int, int2|
+      When('I add {int} and {int}') do |int, int2|
         pending # Write code here that turns the phrase above into concrete actions
       end
 
-      Then("I should get {int}") do |int|
+      Then('I should get {int}') do |int|
         pending # Write code here that turns the phrase above into concrete actions
       end
       """

--- a/features/docs/gherkin/using_star_notation.feature
+++ b/features/docs/gherkin/using_star_notation.feature
@@ -31,7 +31,7 @@ Feature: Using star notation instead of Given/When/Then
       """
       You can implement step definitions for undefined steps with these snippets:
 
-      Given("I have some cukes") do
+      Given('I have some cukes') do
         pending # Write code here that turns the phrase above into concrete actions
       end
       """

--- a/lib/cucumber/glue/snippet.rb
+++ b/lib/cucumber/glue/snippet.rb
@@ -92,7 +92,7 @@ module Cucumber
         def to_s
           header = generated_expressions.each_with_index.map do |expr, i|
             prefix = i.zero? ? '' : '# '
-            "#{prefix}#{code_keyword}(\"#{expr.source}\") do#{parameters(expr)}"
+            "#{prefix}#{code_keyword}('#{expr.source}') do#{parameters(expr)}"
           end.join("\n")
 
           body = String.new # rubocop:disable Style/EmptyLiteral

--- a/spec/cucumber/formatter/pretty_spec.rb
+++ b/spec/cucumber/formatter/pretty_spec.rb
@@ -860,12 +860,12 @@ OUTPUT
           FEATURE
 
           it "containes snippets with 'And' or 'But' replaced by previous step name" do
-            expect(@out.string).to include('Given("there are bananas and apples")')
-            expect(@out.string).to include('Given("other monkeys are around")')
-            expect(@out.string).to include('When("one monkey eats a banana")')
-            expect(@out.string).to include('When("the other monkeys eat all the apples")')
-            expect(@out.string).to include('Then("bananas remain")')
-            expect(@out.string).to include('Then("there are no apples left")')
+            expect(@out.string).to include("Given('there are bananas and apples')")
+            expect(@out.string).to include("Given('other monkeys are around')")
+            expect(@out.string).to include("When('one monkey eats a banana')")
+            expect(@out.string).to include("When('the other monkeys eat all the apples')")
+            expect(@out.string).to include("Then('bananas remain')")
+            expect(@out.string).to include("Then('there are no apples left')")
           end
         end
 
@@ -882,12 +882,12 @@ OUTPUT
               * there are no apples left
           FEATURE
           it "replaces the first step with 'Given'" do
-            expect(@out.string).to include('Given("there are bananas and apples")')
+            expect(@out.string).to include("Given('there are bananas and apples')")
           end
           it "uses actual keywords as the 'previous' keyword for future replacements" do
-            expect(@out.string).to include('Given("other monkeys are around")')
-            expect(@out.string).to include('When("the other monkeys eat all the apples")')
-            expect(@out.string).to include('Then("there are no apples left")')
+            expect(@out.string).to include("Given('other monkeys are around')")
+            expect(@out.string).to include("When('the other monkeys eat all the apples')")
+            expect(@out.string).to include("Then('there are no apples left')")
           end
         end
 
@@ -904,7 +904,7 @@ OUTPUT
             Given('this step passes') {}
           end
           it 'uses actual keyword of the previous passing step for the undefined step' do
-            expect(@out.string).to include('Then("this step is undefined")')
+            expect(@out.string).to include("Then('this step is undefined')")
           end
         end
 
@@ -924,8 +924,8 @@ OUTPUT
             Given('this step passes') {}
           end
           it "uses 'Given' as actual keyword the step in each scenario" do
-            expect(@out.string).to include('Given("this step is undefined")')
-            expect(@out.string).to include('Given("this step is also undefined")')
+            expect(@out.string).to include("Given('this step is undefined')")
+            expect(@out.string).to include("Given('this step is also undefined')")
           end
         end
 
@@ -939,7 +939,7 @@ OUTPUT
               AN I EAT CUCUMBRZ
           FEATURE
           it 'uses actual keyword of the previous passing step for the undefined step' do
-            expect(@out.string).to include('ICANHAZ("I EAT CUCUMBRZ")')
+            expect(@out.string).to include("ICANHAZ('I EAT CUCUMBRZ')")
           end
         end
       end

--- a/spec/cucumber/glue/snippet_spec.rb
+++ b/spec/cucumber/glue/snippet_spec.rb
@@ -163,8 +163,8 @@ module Cucumber
                                           ))
 
           expect(snippet.to_s).to eq unindented(%{
-          Given("I have {float} {cucumis} in my belly") do |float, cucumis|
-          # Given("I have {float} {veg} in my belly") do |float, veg|
+          Given('I have {float} {cucumis} in my belly') do |float, cucumis|
+          # Given('I have {float} {veg} in my belly') do |float, veg|
             pending # Write code here that turns the phrase above into concrete actions
           end
           })


### PR DESCRIPTION
## Summary

Update the missing step generation template to use single-quotes for strings instead of double-quotes.

## Details

When pending steps are generated for undefined steps, the step name does
not include any interpolation so double-quotes are not necessary. Only
the single-quotes are necessary for those strings.

This will make the generated steps allow consistent with the ruby style guide:
  https://github.com/rubocop-hq/ruby-style-guide#strings

And with the default settings for Rubocop Style/StringLiterals cop:
  https://github.com/rubocop-hq/rubocop/blob/ab6346ed37d88a4b900c96979f8ef18959e8dcce/lib/rubocop/cop/style/string_literals.rb

## Motivation and Context

This will make it easier to use the generated steps, in a project using Rubocop, by making those steps already back the default Rubocop rules.

## How Has This Been Tested?

I have updated the existing cucumber and rspec tests for the step generation.

## Types of changes

- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Thank you to everyone who works on cucumber. I use in in my work and personal projects, and I am very grateful that it exists!
This is my first PR to a cucumber repo, so if there is anything that I got wrong, or can do to make it easier to merge, please let me know and I will try to update it quickly.