### PR TITLE
Update code to include env files in dry run

### DIFF
--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -189,10 +189,7 @@ Specify SEED to reproduce the shuffling from a previous run.
       end
 
       def dry_run_msg
-        [
-          'Invokes formatters without executing the steps.',
-          'This also omits the loading of your support/env.rb file if it exists.'
-        ]
+        ['Invokes formatters without executing the steps.']
       end
 
       def exclude_msg

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -168,9 +168,13 @@ module Cucumber
 
     def support_to_load
       support_files = all_files_to_load.select { |f| f =~ %r{/support/} }
+
+      # env_files are separated from other_files so we can ensure env files
+      # load first.
+      #
       env_files = support_files.select { |f| f =~ %r{/support/env\..*} }
       other_files = support_files - env_files
-      @options[:dry_run] ? other_files : env_files + other_files
+      env_files + other_files
     end
 
     def all_files_to_load

--- a/spec/cucumber/configuration_spec.rb
+++ b/spec/cucumber/configuration_spec.rb
@@ -39,15 +39,6 @@ module Cucumber
         ]
       end
 
-      it 'does not require env.rb files when dry run' do
-        configuration = Configuration.new(dry_run: true)
-        given_the_following_files('/features/support/a_file.rb', '/features/support/env.rb')
-
-        expect(configuration.support_to_load).to eq [
-          '/features/support/a_file.rb'
-        ]
-      end
-
       it 'requires step defs in vendor/{plugins,gems}/*/cucumber/*.rb' do
         given_the_following_files('/vendor/gems/gem_a/cucumber/bar.rb',
                                   '/vendor/plugins/plugin_a/cucumber/foo.rb')


### PR DESCRIPTION
## Summary

Causes Cucumber to load `env.rb` files even on dry run.

## Details

This PR removes a conditional in `configuration.rb` that prevents env files from loading when the `--dry-run` option is turned on. It also updates the help message for `--dry-run` to omit the part about env files not loading.

## Motivation and Context

In #1324, @dpsi brings up an issue they're having loading constants and libraries when Cucumber runs under the `--dry-run` option, pointing out that this is [not the first time](https://groups.google.com/d/msg/cukes/Kucz1T_VBss/VkEUBpY6MQAJ) users have brought up this problem with us. The issue stems from the `env.rb` files not being loaded.

## How Has This Been Tested?

The test ensuring that env files are not loaded on dry runs has been removed. I've ensured that env files do still load first in all cases.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
