### PR TITLE
Fix randomization seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
+* Fix seed printed in cucumber UI to match the seed that was actually used.
+  ([#1329](https://github.com/cucumber/cucumber-ruby/pull/1329)
+   [deivid-rodriguez](https://github.com/deivid-rodriguez))
+
 ### Added
 
 ### Improved

--- a/features/docs/cli/randomize.feature
+++ b/features/docs/cli/randomize.feature
@@ -101,6 +101,11 @@ Feature: Randomize
 
       """
 
+  Scenario: Rerun scenarios randomized
+    When I run `cucumber --order random --format summary`
+    And I rerun the previous command with the same seed
+    Then the output of both commands should be the same
+
   @spawn @todo-windows
   Scenario: Run scenarios randomized with some skipped
     When I run `cucumber --tags 'not @skipme' --order random:41544 -q`

--- a/features/lib/step_definitions/cucumber_steps.rb
+++ b/features/lib/step_definitions/cucumber_steps.rb
@@ -66,6 +66,20 @@ When(/^I run the feature with the (\w+) formatter$/) do |formatter|
   run_feature features.first, formatter
 end
 
+When(/^I rerun the previous command with the same seed$/) do
+  previous_seed = last_command_started.output.match(/with seed (\d+)/)[1]
+  second_command = all_commands.last.commandline.gsub(/random/, "random:#{previous_seed}")
+
+  step "I run `#{second_command}`"
+end
+
+Then(/the output of both commands should be the same/) do
+  first_output = all_commands.first.output.gsub(/\d+m\d+\.\d+s/, '')
+  last_output = all_commands.last.output.gsub(/\d+m\d+\.\d+s/, '')
+
+  expect(first_output).to eq(last_output)
+end
+
 module CucumberHelper
   def run_feature(filename = 'features/a_feature.feature', formatter = 'progress')
     run_simple "#{Cucumber::BINARY} #{filename} --format #{formatter}", false

--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -108,7 +108,7 @@ module Cucumber
       end
 
       def to_hash
-        Hash(@options).merge(out_stream: @out_stream, error_stream: @error_stream)
+        Hash(@options).merge(out_stream: @out_stream, error_stream: @error_stream, seed: seed)
       end
 
       private

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -54,7 +54,7 @@ module Cucumber
     end
 
     def seed
-      Integer(@options[:seed] || rand(0xFFFF))
+      @options[:seed]
     end
 
     def dry_run?


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

While debugging some apparently order dependent failures on my cucumber scenarios, I noticed that it's currently impossible to reproduce order dependent failures, because the seed cucumber says it has used is not the seed it has really used.

## Details

<!--- Describe your changes in detail -->

My changes make sure that the seed that cucumber uses to randomize the scenarios is the same that cucumber informs in the UI, so the same scenario order can actually be reproduced in subsequent runs.

In order to test this, I needed to use some stuff from newer versions of `aruba`, so I upgraded the scenarios to use that first. Happy to extract that to a separate PR, of course.

## Motivation and Context

This change makes it possible to reproduce order dependent failures when running scenarios in random order. Previously, it was not working.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I added a test that runs cucumber in random order and with summary format, then runs cucumber again with the seed the previous command informed, and then checks that both commands give the same output (excluding runtime).

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
