### PR TITLE
Run full specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,9 +9,7 @@ require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
 require 'cucumber/rake/task'
-Cucumber::Rake::Task.new do |t|
-  t.profile = 'ruby' if Cucumber::RUBY
-end
+Cucumber::Rake::Task.new
 
 default_tasks = %i[spec cucumber rubocop]
 

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -12,6 +12,6 @@ default:     <%= std_opts %> --tags "not @jruby"
 jruby:       <%= std_opts %> --tags "not @wire"
 jruby_win:   <%= std_opts %> --tags "not @wire" CUCUMBER_FORWARD_SLASH_PATHS=true
 windows_mri: <%= std_opts %> --tags "not @jruby" --tags "not @wire" --tags "not @needs-many-fonts" --tags "not @todo-windows" CUCUMBER_FORWARD_SLASH_PATHS=true
-ruby:        <%= std_opts %> --tags "not @todo-windows" --tags "not @jruby"
+ruby:        <%= std_opts %> --tags "not @jruby"
 wip:         --wip <%= wip_opts %> features <%= cucumber_pro_opts %>
 none:        --format pretty --format Cucumber::Pro --out /dev/null

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -12,6 +12,5 @@ default:     <%= std_opts %> --tags "not @jruby"
 jruby:       <%= std_opts %> --tags "not @wire"
 jruby_win:   <%= std_opts %> --tags "not @wire" CUCUMBER_FORWARD_SLASH_PATHS=true
 windows_mri: <%= std_opts %> --tags "not @jruby" --tags "not @wire" --tags "not @needs-many-fonts" --tags "not @todo-windows" CUCUMBER_FORWARD_SLASH_PATHS=true
-ruby:        <%= std_opts %> --tags "not @jruby"
 wip:         --wip <%= wip_opts %> features <%= cucumber_pro_opts %>
 none:        --format pretty --format Cucumber::Pro --out /dev/null


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

#1329 is big and not focused, so I'm splitting it.

This PR changes the default profile that we run in CI and locally to run more specs.

## Details

<!--- Describe your changes in detail -->

I noticed that running `bundle exec cucumber` run way more specs than running `bundle exec rake cucumber`.

As far as I understand it, we're running a lot less features than we should. There's no reason to not run the "@todo-windows"-tagged scenarios by default, unless we're on Windows... right?

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prevention of regressions.

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Locally, via `bundle exec rake cucumber`.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
