### PR TITLE
CircleCI: Use circleci/jruby-9.2.5-jdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
 
   "jruby":
     docker:
-       - image: circleci/jruby:9.2.0.0-jdk
+       - image: circleci/jruby:9.2.5-jdk
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION

## Summary

This CI PR tries to use 9.2.5.0.
 
## Details

using the circleci/jruby-9.2.5-jdk (dropped the last decimal, to have  less update issues if an image would be dropped from the registry).

I am going to make the same change in the Travis build in the cucumber-ruby-core repo.


## Motivation and Context

We want to support latest generally available JRuby.

## How Has This Been Tested?

Running in CI.

## Types of changes

CI version change only.

- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

