### PR TITLE
CI against Ruby 2.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: git push --force cucumber-pro $CIRCLE_BRANCH
   "ruby-2.6":
     docker:
-       - image: circleci/ruby:2.6-rc
+       - image: circleci/ruby:2.6
     working_directory: ~/repo
     steps:
       - checkout
@@ -30,7 +30,8 @@ jobs:
           key: bundle-{{ checksum "cucumber.gemspec" }}
       - run:
           name: Run Rake
-          command: bundle exec rake || echo "Ignoring failure as Ruby 2.6 support is 'optional' at this point in time."
+          command: bundle exec rake
+
   "ruby-2.5":
     docker:
        - image: circleci/ruby:2.5.1
@@ -141,6 +142,7 @@ workflows:
   build:
     jobs:
       # Keep lowest ruby-* version in sync with cucumber.gemspec & .rubocop.yml
+      - "ruby-2.6"
       - "ruby-2.5"
       - "ruby-2.4"
       - "ruby-2.3"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,8 @@ jobs:
       - restore_cache:
           keys:
           - bundle-{{ checksum "cucumber.gemspec" }}
+      # See https://github.com/protocolbuffers/protobuf/issues/5161
+      - run: "gem install google-protobuf --platform=ruby"
       - run:
           name: install dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,6 @@ jobs:
       - restore_cache:
           keys:
           - bundle-{{ checksum "cucumber.gemspec" }}
-      # See https://github.com/protocolbuffers/protobuf/issues/5161
-      - run: "gem install google-protobuf --platform=ruby"
       - run:
           name: install dependencies
           command: |


### PR DESCRIPTION
## Summary

CI against Ruby 2.6.0.

## Details

Ruby 2.6.0 has been released and this Ruby version is available on CircleCI.

- https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/
- https://hub.docker.com/r/circleci/ruby/tags/

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
