### PR TITLE
Fixes env.rb and support files load order

### DIFF
--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -174,7 +174,7 @@ module Cucumber
       #
       env_files = support_files.select { |f| f =~ %r{/support/env\..*} }
       other_files = support_files - env_files
-      env_files + other_files
+      env_files.reverse + other_files.reverse
     end
 
     def all_files_to_load

--- a/spec/cucumber/configuration_spec.rb
+++ b/spec/cucumber/configuration_spec.rb
@@ -39,6 +39,27 @@ module Cucumber
         ]
       end
 
+      it 'features/support/env.rb is loaded before any other features/**/support/env.rb file' do
+        configuration = Configuration.new
+        given_the_following_files(
+          '/features/foo/support/env.rb',
+          '/features/foo/support/a_file.rb',
+          '/features/foo/bar/support/env.rb',
+          '/features/foo/bar/support/a_file.rb',
+          '/features/support/a_file.rb',
+          '/features/support/env.rb'
+        )
+
+        expect(configuration.support_to_load).to eq [
+          '/features/support/env.rb',
+          '/features/foo/support/env.rb',
+          '/features/foo/bar/support/env.rb',
+          '/features/support/a_file.rb',
+          '/features/foo/support/a_file.rb',
+          '/features/foo/bar/support/a_file.rb'
+        ]
+      end
+
       it 'requires step defs in vendor/{plugins,gems}/*/cucumber/*.rb' do
         given_the_following_files('/vendor/gems/gem_a/cucumber/bar.rb',
                                   '/vendor/plugins/plugin_a/cucumber/foo.rb')


### PR DESCRIPTION
## Summary

Fixes the load order of `env.rb` files

## Details

According to The Cucumber Book on pp. 129-130:

> Just like `features/step_definitions`, Cucumber will load all Ruby files it finds in `features/support`. This is convenient, because it means you don't need to pepper `require` statements everywhere, but it does mean that the precise order in which files are loaded is hard to control. In practice, this means you can't have dependencies between files in the `support` directory, because you can't expect that another file will have already been loaded. There is one exception to that, a special file called `env.rb`.
>
> The file `features/support/env.rb` is always the very first file to be loaded when Cucumber starts a test run.

This is also extened such that any `env.rb` file located in descendant `support` folders are _also_ loaded before other `*.rb` files in `support` folders.

However, when attempting to create a better port of Cucumber in the Pester PowerShell testing framework, I found this load ordering to not be correct.

This commit fixes the order in which files in `support` folders are loaded so that:

1. the `features/support/env.rb` file is always loaded first, if found
2. other `env.rb` files located in descendent `support` folders under `features` are loaded second
3. all other `*.rb` files in descendant `support` folders are loaded

## Motivation and Context

For one, the most authoritative, canonical reference, _The Cucumber Book_ states that this is how Cucumber behaves. But in addition to that, the book states a very good reason for this behavior: in order to help control the load order of files (through the use of `require`). 

## How Has This Been Tested?

A new unit test has been added to ensure that `env.rb` files are loaded in the correct order.

## Types of changes

- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I'm actually not sure if this should be categorized as a breaking or non-breaking change. Changing the load order of files could potentially break tests which depend on the current behavior. The question is, how many tests would be written to depend on the load order, since that would in most cases, be a bad idea. It's probably best to label this as a breaking change&mdash;but ultimately, I'll leave this decision up to the maintainers.

## Checklist:

- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
