### PR TITLE
Updates --require option help text

### DIFF
--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -306,11 +306,13 @@ Specify SEED to reproduce the shuffling from a previous run.
         [
           'Require files before executing the features. If this',
           'option is not specified, all *.rb files that are',
-          'siblings or below the features will be loaded auto-',
+          'siblings of or below the features will be loaded auto-',
           'matically. Automatic loading is disabled when this',
-          'option is specified, and all loading becomes explicit.',
-          'Files under directories named "support" are always',
-          'loaded first.',
+          'option is specified; all loading becomes explicit.',
+          'Files in directories named "support" are still always',
+          'loaded first when their parent directories are',
+          'required or if the "support" directoires themselves are',
+          'explicitly required.',
           'This option can be specified multiple times.'
         ]
       end


### PR DESCRIPTION
## Details

When I read the help text for the --require option, it was conceivable
that the text could have been interpreted in at least two ways.

This commit aims to clarify the help text to reduce ambiguity/improve
the clarity of the behavior of the option, espcially with respect to the
loading of files under "support" directories.

## How Has This Been Tested?

This change did not require any additional tests. Though, of course, all tests were run to ensure no existing tests were broken by this change.

## Types of changes

- [x] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

I'm not sure if this requires a change to the documentation. If it does, I'd be more than happy to make that change&mdash;though, I don't know where that documentation is. Is it in a separate repository?