### PR TITLE
Respect Ruby configuration when filtering backtrace.

### DIFF
--- a/lib/cucumber/formatter/backtrace_filter.rb
+++ b/lib/cucumber/formatter/backtrace_filter.rb
@@ -13,9 +13,11 @@ module Cucumber
       minitest
       test/unit
       .gem/ruby
-      lib/ruby/
       bin/bundle
     ]
+
+    @backtrace_filters << RbConfig::CONFIG['rubyarchdir'] if RbConfig::CONFIG['rubyarchdir']
+    @backtrace_filters << RbConfig::CONFIG['rubylibdir'] if RbConfig::CONFIG['rubylibdir']
 
     @backtrace_filters << 'org/jruby/' if ::Cucumber::JRUBY
 

--- a/spec/cucumber/formatter/backtrace_filter_spec.rb
+++ b/spec/cucumber/formatter/backtrace_filter_spec.rb
@@ -14,8 +14,10 @@ module Cucumber
                      _anything__minitest__anything_
                      _anything__test/unit__anything_
                      _anything__Xgem/ruby__anything_
-                     _anything__lib/ruby/__anything_
                      _anything__.rbenv/versions/2.3/bin/bundle__anything_]
+          trace << "_anything__#{RbConfig::CONFIG['rubyarchdir']}__anything_"
+          trace << "_anything__#{RbConfig::CONFIG['rubylibdir']}__anything_"
+
           @exception = Exception.new
           @exception.set_backtrace(trace)
         end


### PR DESCRIPTION
The Ruby might be configured to be installed into various locations. Be smarter about filtering backtrace to properly remove all traces of standard library.

Fixes #1341.