### PR TITLE
Remove cucumber pro publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,6 @@
 version: 2.0
 
 jobs:
-  publish:
-    machine: true
-    steps:
-      - checkout
-      - run: git remote add cucumber-pro git@git.cucumber.pro:cucumber-ruby.git
-      - run: git push --force cucumber-pro $CIRCLE_BRANCH
   "ruby-2.6":
     docker:
        - image: circleci/ruby:2.6-rc
@@ -146,4 +140,3 @@ workflows:
       - "ruby-2.3"
       - "ruby-2.2"
       - "jruby"
-      - publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 ### Deprecated
 
 ### Removed
-
+* Removed Travis publish job for cucumber-pro(a.k.a. jam)
+  ([#1350](https://github.com/cucumber/cucumber-ruby/pull/1350)
+   [luke-hill](https://github.com/luke-hill))
 ### Fixed
 
 * Fix seed printed in cucumber UI to match the seed that was actually used.


### PR DESCRIPTION
## Details

Removing a failing task from circleCI

## Motivation and Context

It's long been failing, and was added a while back: https://github.com/cucumber/cucumber-ruby/commit/24e3a2ec659a02ee7797375178de19eac7e41d0f

In the SHA @mattwynne you mention adding an SSH key. Was this done? As it keeps failing for invalid authentication

Just trying to tidy up the build process with @olleolleolle to get everything green and trustworthy again

