### PR TITLE
Add support for embed labels on json report formatter

### DIFF
--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -84,7 +84,7 @@ module Cucumber
         test_step_output << message
       end
 
-      def embed(src, mime_type, _label)
+      def embed(src, mime_type, label)
         if File.file?(src)
           content = File.open(src, 'rb', &:read)
           data = encode64(content)
@@ -94,7 +94,7 @@ module Cucumber
         else
           data = encode64(src)
         end
-        test_step_embeddings << { mime_type: mime_type, data: data }
+        test_step_embeddings << { mime_type: mime_type, data: data, label: label }
       end
 
       private

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -84,7 +84,7 @@ module Cucumber
         test_step_output << message
       end
 
-      def embed(src, mime_type, label)
+      def embed(src, mime_type, label = nil)
         if File.file?(src)
           content = File.open(src, 'rb', &:read)
           data = encode64(content)
@@ -94,7 +94,9 @@ module Cucumber
         else
           data = encode64(src)
         end
-        test_step_embeddings << { mime_type: mime_type, data: data, label: label }
+        embeddings = { mime_type: mime_type, data: data }
+        embeddings[:label] = label unless label.nil?
+        test_step_embeddings << embeddings
       end
 
       private

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -88,8 +88,8 @@ module Cucumber
         super
       end
 
-      # Embed an image in the output
-      def embed(file, mime_type, label = 'Screenshot')
+      # Embed an file in the output
+      def embed(file, mime_type, label = nil)
         super
       end
 
@@ -161,7 +161,7 @@ module Cucumber
             runtime.ask(question, timeout_seconds)
           end
 
-          define_method(:embed) do |file, mime_type, label = 'Screenshot'|
+          define_method(:embed) do |file, mime_type, label = nil|
             runtime.embed(file, mime_type, label)
           end
 

--- a/spec/cucumber/formatter/json_spec.rb
+++ b/spec/cucumber/formatter/json_spec.rb
@@ -533,7 +533,7 @@ module Cucumber
           FEATURE
 
           define_steps do
-            Given(/^there are bananas$/) { embed('YWJj', 'mime-type;base64') }
+            Given(/^there are bananas$/) { embed('YWJj', 'mime-type;base64', 'embed_label') }
           end
 
           it 'includes the data from the step in the json data' do
@@ -556,7 +556,7 @@ module Cucumber
                       "name": "there are bananas",
                       "line": 4,
                       "embeddings": [{"mime_type": "mime-type",
-                                      "data": "YWJj"}],
+                                      "data": "YWJj", "label": "embed_label"}],
                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:536"},
                       "result": {"status": "passed",
                                  "duration": 1}}]}]}]))


### PR DESCRIPTION
Add support for embed labels on json report formatter

## Details

- Added support for embed labels in json formatter
- Extended rspec test
- Make label optional

## Motivation and Context

I want to add labels to my embeddings, as i can do in other formatters.
So I'm able to categorize several string based embeddings.

#1066

## How Has This Been Tested?

Rspec tests have been extended.

## Screenshots (if appropriate):

## Types of changes

- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
