### PR TITLE
SIGINT trap consistent with TERM behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 * Fix seed printed in cucumber UI to match the seed that was actually used.
   ([#1329](https://github.com/cucumber/cucumber-ruby/pull/1329)
    [deivid-rodriguez](https://github.com/deivid-rodriguez))
+* Make SIGINT/`Ctrl+c` behavior consistent with SIGTERM/`kill` behavior - now first invocation causes existing scenario to stop running and jump to `at_exit`, second invocation causes immediate exit. Before that first invocation only instructed Cucumber to exit after scenario and second invocation caused immediate exit skipping `at_exit`.
+  ([#1353](https://github.com/cucumber/cucumber-ruby/pull/1353)
+   [akostadinov](https://github.com/akostadinov))
 
 ### Added
 

--- a/lib/cucumber/cli/main.rb
+++ b/lib/cucumber/cli/main.rb
@@ -86,6 +86,7 @@ module Cucumber
           exit_unable_to_finish! if Cucumber.wants_to_quit
           Cucumber.wants_to_quit = true
           STDERR.puts "\nExiting... Interrupt again to exit immediately."
+          exit_unable_to_finish
         end
       end
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

fixes #988

<!--- Provide a general summary description of your changes -->

## Details

Basically now first `Ctrl+C` will terminate scenario execution but will stil execute `at_exit` hooks. Second `Ctrl+C` will also interrupt that.


<!--- Describe your changes in detail -->

## Motivation and Context
see #988

In the past first `Ctrl+C` only told Cucumber to exit after this scenario. And a second one terminated immediately without `at_exit` hooks. So there was no way to interrupt immediately but still execute `at_exit`. This could lead to tested system to remain in inconsistent state and require manual restore.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->
Not sure how can I test this.


<!--- Please describe in detail how you tested your changes. -->
I editted my local copy of the gem and run a test scenario

```
$  cucumber features/long_feature.feature 
Feature: Long running scenarios

  @clean-up
  Scenario: 100 seconds with clean-up # features/long_feature.feature:4
    Given I love you                  # features/step_definitions/gah.rb:1
      hey
^C
Exiting... Interrupt again to exit immediately.
    When I wait 100 seconds           # features/step_definitions/gah.rb:8
      exit (SystemExit)
      ./features/step_definitions/gah.rb:9:in `sleep'
      ./features/step_definitions/gah.rb:9:in `/^I wait (\d+) seconds$/'
      features/long_feature.feature:6:in `When I wait 100 seconds'
    Then I do nothing                 # features/step_definitions/gah.rb:5
     --->  I cleaned you <---

Failing Scenarios:
cucumber features/long_feature.feature:4 # Scenario: 100 seconds with clean-up

1 scenario (1 failed)
3 steps (1 failed, 1 skipped, 1 passed)
0m2.806s
```


<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Not sure about the above.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.