### PR TITLE
Support embeddings stored in step results

### DIFF
--- a/lib/cucumber/formatter/duration_extractor.rb
+++ b/lib/cucumber/formatter/duration_extractor.rb
@@ -24,6 +24,8 @@ module Cucumber
       def duration(duration, *)
         duration.tap { |dur| @result_duration = dur.nanoseconds / 10**9.0 }
       end
+
+      def embed(*) end
     end
   end
 end

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -190,6 +190,7 @@ module Cucumber
       def add_match_and_result(test_step, result)
         @step_or_hook_hash[:match] = create_match_hash(test_step, result)
         @step_or_hook_hash[:result] = create_result_hash(result)
+        result.embeddings.each { |e| embed(e['src'], e['mime_type'], e['label']) } if result.respond_to?(:embeddings)
       end
 
       def add_failed_around_hook(result)

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -238,6 +238,8 @@ module Cucumber
       def duration(duration, *)
         duration.tap { |dur| @test_case_duration = dur.nanoseconds / 10**9.0 }
       end
+
+      def embed(*) end
     end
   end
 end


### PR DESCRIPTION
## Summary

<!--- Provide a general summary description of your changes -->

Support embeddings listed in step results.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I'm looking into cucumber-cpp for my company.
We need to be able to embed text or images into the reports, but that feature is not available when using the wire protocol.

This patch is the 1st of a series a 4, respectively impacting _cucumber-ruby_, _cucumber-ruby-core_, _cucumber-ruby-wire_ and _cucumber-cpp_.

Basically, the idea is to allow embeddings to be specified in the success or fail responses sent through the wire protocol. E.g.:
```
["success",{"embeddings":[{"label":"Embedded text","mime_type":"text/plain","src":"Some text"}]}]
["fail",{"embeddings":[{"label":"Embedded image","mime_type":"image/png;base64","src":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="}],"message":"There was no  banana"}]
```

The embeddings will then be stored in the step Result in order to be accessible by the formatter.

The patch on _cucumber-ruby_ (cucumber/cucumber-ruby#1354) will let formatters access embeddings stored in a step result.
The patch on _cucumber-ruby-core_ (cucumber/cucumber-ruby-core#170) will store in the step result the embeddings returned by the step invocation.
The patch on _cucumber-ruby-wire_ (cucumber/cucumber-ruby-wire#20) will allow the embeddings stored in the wire response to be returned by the wire-based step invocation process.
The patch on _cucumber-cpp_ (cucumber/cucumber-cpp#223) will allow C++ steps to send embeddings through wire responses.

Note: embeddings were not considered to be useful for pending steps, but support should be possible if required.

## Details

<!--- Describe your changes in detail -->

In the current implementation, it's not possible to access data from the wire response as nothing is returned from the wire invocation when a step succeed (a step is considered successful by default, an exception needs to be raised in case of failing or pending step).

**Successful step**
```
Cucumber::Core::Test::Runner::RunningTestCase::Status::Base.execute
  Cucumber::Core::Test::Step.execute
    Cucumber::Core::Test::Action.execute
      block -> Cucumber::StepMatch.invoke
        Cucumber::Wire::StepDefinition.invoke
          Cucumber::Wire::Protocol.invoke
            Cucumber::Wire::Protocol::Requests::Invoke.execute
              Cucumber::Wire::RequestHandler.execute
                Cucumber::Wire::Connection.call_remote
                  Cucumber::Wire::DataPacket reponse = // parsed packet
                  Cucumber::Wire::DataPacket.handle_with
                    Cucumber::Wire::DataPacket.handle_success // noop
                  // response discarded
      Cucumber::Core::Test::Action.passed -> return Cucumber::Core::Test::Result::Passed
  Cucumber::Core::Test::Result::Passed.describe_to(Cucumber::Core::Test::Runner::RunningTestCase)
    Cucumber::Core::Test::Runner::RunningTestCase.passed
      Cucumber::Core::Test::Runner::RunningTestCase@status = Cucumber::Core::Test::Runner::RunningTestCase::Status::Passing
```

**Failing step**
```
Cucumber::Core::Test::Runner::RunningTestCase::Status::Base.execute
  Cucumber::Core::Test::Step.execute
    Cucumber::Core::Test::Action.execute
      block -> Cucumber::StepMatch.invoke
        Cucumber::Wire::StepDefinition.invoke
          Cucumber::Wire::Protocol.invoke
            Cucumber::Wire::Protocol::Requests::Invoke.execute
              Cucumber::Wire::RequestHandler.execute
                Cucumber::Wire::Connection.call_remote
                  Cucumber::Wire::DataPacket reponse = // parsed packet
                  Cucumber::Wire::DataPacket.handle_with
                    Cucumber::Wire::RequestHandler.handle_fail -> throw Cucumber::Wire::Exception // error message (from response) embedded in exception
                  // response discarded
      Rescue in Cucumber::Core::Test::Action.execute
        Cucumber::Core::Test::Action.failed -> return Cucumber::Core::Test::Result::Failed
  Cucumber::Core::Test::Result::Failed.describe_to(Cucumber::Core::Test::Runner::RunningTestCase)
    Cucumber::Core::Test::Runner::RunningTestCase.failed
      Cucumber::Core::Test::Runner::RunningTestCase@status = Cucumber::Core::Test::Runner::RunningTestCase::Status::Failing
```

This patch allow two things:
- Visitors of `Result` to be notified of embeddings (if any).
- The json formatter (who does not use the visitor pattern) to read embeddings (if any) in Result.

Those changes should be backward compatible.

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

No test in that repository, but I just discovered there is a `FakeWireServer`, I need to see if I can do something with it. Suggestions are welcomed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
