### PR TITLE
Fix a test case description typo

### DIFF
--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -154,7 +154,7 @@ module Cucumber
             after_parsing(['--tags', 'not @foo or @bar']) { expect(options[:tag_expressions]).to eq ['not @foo or @bar'] }
           end
 
-          it 'stores tags passed with different --tags seperately' do
+          it 'stores tags passed with different --tags separately' do
             after_parsing('--tags @foo --tags @bar') { expect(options[:tag_expressions]).to eq ['@foo', '@bar'] }
           end
 


### PR DESCRIPTION
s/seperately/separately/