### PR TITLE
Fix the placeholder expansions in the json formatter

### DIFF
--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -269,7 +269,7 @@ module Cucumber
           @test_case_hash = {
             id: "#{@feature_hash[:id]};#{create_id_from_scenario_source(scenario_source)}",
             keyword: scenario.keyword,
-            name: scenario.name,
+            name: test_case.name,
             description: value_or_empty_string(scenario.description),
             line: test_case.location.lines.max,
             type: 'scenario'

--- a/spec/cucumber/formatter/json_spec.rb
+++ b/spec/cucumber/formatter/json_spec.rb
@@ -168,7 +168,7 @@ module Cucumber
           define_feature <<-FEATURE
           Feature: Banana party
 
-            Scenario Outline: Monkey eats bananas
+            Scenario Outline: Monkey eats <fruit>
               Given there are <fruit>
 
               Examples: Fruit Table
@@ -189,7 +189,7 @@ module Cucumber
                 "line": 1,
                 "description": "",
                 "elements":
-                 [{"id": "banana-party;monkey-eats-bananas;fruit-table;2",
+                 [{"id": "banana-party;monkey-eats-<fruit>;fruit-table;2",
                    "keyword": "Scenario Outline",
                    "name": "Monkey eats bananas",
                    "line": 8,


### PR DESCRIPTION
## Summary

Fix the placeholder expansions in the json formatter.

## Details

It is the test case name - in which scenario outline placeholders are expanded - that shall be used by the json formatter, and not the scenario name.

## Motivation and Context

Bugfix - now when the Gherkin library compiler are used in Cucumber-Ruby, which does expand scenario outline placeholders also in scenario names.

## How Has This Been Tested?

The automated test suite has been updated to verify this behavior.

## Types of changes

- [ ] Refactor (code change that does not change external functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
