### PR TITLE
Remove JRuby from supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for info on contributing to Cucumber.
 * Ruby 2.5
 * Ruby 2.4
 * Ruby 2.3
-* JRuby 9.1
 
 ## Code of Conduct
 


### PR DESCRIPTION
Saw that in the latest commit e34971024b850541 it was stated that JRuby was no longer supported (which is sad) but I guess then it also shouldn't be part of the supported platforms.

Thanks for cucumber!
