### PR TITLE
Fix troubles with DataTable.to_hash in cucumber-ruby-wire

### DIFF
--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -352,7 +352,11 @@ module Cucumber
         end
       end
 
-      def to_hash(cells) #:nodoc:
+      def to_hash
+        cells_rows.map { |cells| cells.map(&:value) }
+      end
+
+      def cells_to_hash(cells) #:nodoc:
         hash = Hash.new do |hash_inner, key|
           hash_inner[key.to_s] if key.is_a?(Symbol)
         end
@@ -551,7 +555,7 @@ module Cucumber
         end
 
         def to_hash #:nodoc:
-          @to_hash ||= @table.to_hash(self)
+          @to_hash ||= @table.cells_to_hash(self)
         end
 
         def value(n) #:nodoc:


### PR DESCRIPTION
## Summary

`cucumber-ruby-wire` build is failing after upgrading `cucumber-ruby` and `cucumber-ruby-core` to `gherkin` 9. Some tests are fixed (see [`cucumber-ruby-wire#25`](https://github.com/cucumber/cucumber-ruby-wire/pull/25) but one test is still failing (and should be fixed by this PR).

What is happening (as far as I can tell) is that we try to serialise the `DataTable` to `json`, but the `to_hash` method on `DataTable` requires an argument.
This proposal renames the previous `to_hash` method as `cells_to_hash` and creates a `to_hash` method providing a matrix of the cells value.

This was a bit retro-engineered based  on what was expected by the test, that's a part of the code I'm definitely not familiar with, so any input is more than welcome.

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
