### PR TITLE
Deprecate json formatter

### DIFF
--- a/features/docs/formatters/json_formatter.feature
+++ b/features/docs/formatters/json_formatter.feature
@@ -639,6 +639,7 @@ Feature: JSON output formatter
     ]
 
     """
+
   Scenario: handle output from hooks
      Given a file named "features/step_definitions/output_steps.rb" with:
       """
@@ -674,3 +675,14 @@ Feature: JSON output formatter
       """
     When I run `cucumber --format json features/out_scenario_out_scenario_outline.feature`
     Then it should pass
+
+  Scenario: shows a deprecation warning
+    When I run `cucumber --format json`
+    Then the stderr should contain:
+      """
+      WARNING: --format=json is deprecated and will be removed after version 5.0.0
+      """
+    And the stderr should contain:
+      """
+      Please use --format=message and stand-alone json-formatter.
+      """

--- a/features/docs/post_configuration_hook.feature
+++ b/features/docs/post_configuration_hook.feature
@@ -8,7 +8,7 @@ Feature: Post Configuration Hook [#423]
     Given a file named "features/support/env.rb" with:
       """
       AfterConfiguration do |config|
-        config.formats << ['json', {}, config.out_stream]
+        config.formats << ['message', {}, config.out_stream]
       end
       """
     And a file named "features/simple_scenario.feature" with:
@@ -19,7 +19,7 @@ Feature: Post Configuration Hook [#423]
       """
     When I run `cucumber features`
     Then the stderr should not contain anything
-    And the output should contain JSON with key "uri" and value "features/simple_scenario.feature"
+    And the output should contain NDJSON with key "uri" and value "features/simple_scenario.feature"
 
   Scenario: feature directories read from configuration
     Given a file named "features/support/env.rb" with:

--- a/features/lib/step_definitions/aruba_steps.rb
+++ b/features/lib/step_definitions/aruba_steps.rb
@@ -17,7 +17,7 @@ Then('{string} should be required') do |file_name|
 end
 
 Then('it fails before running features with:') do |expected|
-  expect(all_stdout).to match(/\A#{expected}/)
+  expect(all_output).to match(/\A#{expected}/)
   step 'it should fail'
 end
 
@@ -25,6 +25,6 @@ Then('the output includes the message {string}') do |message|
   expect(all_stdout).to include(message)
 end
 
-Then('the output should contain JSON with key {string} and value {string}') do |key, value|
+Then('the output should contain (ND)JSON with key {string} and value {string}') do |key, value|
   expect(all_stdout).to match(/"#{key}": ?"#{value}"/)
 end

--- a/features/lib/support/normalise_output.rb
+++ b/features/lib/support/normalise_output.rb
@@ -3,6 +3,10 @@
 # override aruba to filter out some stuff
 module NormaliseArubaOutput
   def all_stdout
+    all_commands.map(&:stdout).join("\n")
+  end
+
+  def all_output
     all_commands.map(&:output).join("\n")
   end
 

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -22,7 +22,7 @@ module Cucumber
         'stepdefs'    => ['Cucumber::Formatter::Stepdefs',    "Prints All step definitions with their locations. Same as\n" \
                                                               "#{INDENT}the usage formatter, except that steps are not printed."],
         'junit'       => ['Cucumber::Formatter::Junit',       'Generates a report similar to Ant+JUnit.'],
-        'json'        => ['Cucumber::Formatter::Json',        'Prints the feature as JSON'],
+        'json'        => ['Cucumber::Formatter::Json',        '[DEPRECATED] Prints the feature as JSON'],
         'message'     => ['Cucumber::Formatter::Message',     'Outputs protobuf messages'],
         'summary'     => ['Cucumber::Formatter::Summary',     'Summary output of feature and scenarios']
       }.freeze

--- a/lib/cucumber/deprecate.rb
+++ b/lib/cucumber/deprecate.rb
@@ -5,6 +5,21 @@ require 'cucumber/gherkin/formatter/ansi_escapes'
 
 module Cucumber
   module Deprecate
+    class CliOption
+      include Cucumber::Gherkin::Formatter::AnsiEscapes
+
+      def self.deprecate(stream, option, message, remove_after_version)
+        return if stream.nil?
+        CliOption.new.deprecate(stream, option, message, remove_after_version)
+      end
+
+      def deprecate(stream, option, message, remove_after_version)
+        stream.puts(failed + "\nWARNING: #{option} is deprecated" \
+        " and will be removed after version #{remove_after_version}.\n#{message}.\n" \
+        + reset)
+      end
+    end
+
     module ForUsers
       AnsiEscapes = Cucumber::Gherkin::Formatter::AnsiEscapes
 

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -9,31 +9,16 @@ require 'cucumber/deprecate'
 require 'cucumber/gherkin/formatter/ansi_escapes'
 
 module Cucumber
-  class DeprecatedJSONFormatter
-    include Cucumber::Gherkin::Formatter::AnsiEscapes
-
-    def self.deprecate(stream, message, method, remove_after_version)
-      return if stream.nil?
-      DeprecatedJSONFormatter.new.deprecate(stream, message, method, remove_after_version)
-    end
-
-    def deprecate(stream, message, method, remove_after_version)
-      stream.puts(failed + "\nWARNING: #{method} is deprecated" \
-      " and will be removed after version #{remove_after_version}.\n#{message}.\n" \
-      + reset)
-    end
-  end
-
   module Formatter
     # The formatter used for <tt>--format json</tt>
     class Json
       include Io
 
       def initialize(config)
-        Cucumber::DeprecatedJSONFormatter.deprecate(
+        Cucumber::Deprecate::CliOption.deprecate(
           config.error_stream,
-          'Please use --format=message and stand-alone json-formatter',
           '--format=json',
+          'Please use --format=message and stand-alone json-formatter',
           '5.0.0'
         )
 

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -18,7 +18,8 @@ module Cucumber
         Cucumber::Deprecate::CliOption.deprecate(
           config.error_stream,
           '--format=json',
-          'Please use --format=message and stand-alone json-formatter',
+          "Please use --format=message and stand-alone json-formatter.\n" \
+          'json-formatter homepage: https://github.com/cucumber/cucumber/tree/master/json-formatter#cucumber-json-formatter',
           '5.0.0'
         )
 

--- a/spec/cucumber/deprecate_spec.rb
+++ b/spec/cucumber/deprecate_spec.rb
@@ -4,13 +4,12 @@ require 'spec_helper'
 
 module Cucumber::Deprecate
   describe CliOption do
-    let(:subject) { Cucumber::Deprecate::CliOption }
     let(:error_stream) { double }
 
     context '.deprecate' do
       it 'outputs a warning to the provided channel' do
         allow(error_stream).to receive(:puts)
-        subject.deprecate(error_stream, '--some-option', 'Please use --another-option instead', '1.2.3')
+        described_class.deprecate(error_stream, '--some-option', 'Please use --another-option instead', '1.2.3')
 
         expect(error_stream).to have_received(:puts).with(
           a_string_including(

--- a/spec/cucumber/deprecate_spec.rb
+++ b/spec/cucumber/deprecate_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Cucumber::Deprecate
+  describe CliOption do
+    let(:subject) { Cucumber::Deprecate::CliOption }
+    let(:error_stream) { double }
+
+    context '.deprecate' do
+      it 'outputs a warning to the provided channel' do
+        allow(error_stream).to receive(:puts)
+        subject.deprecate(error_stream, '--some-option', 'Please use --another-option instead', '1.2.3')
+
+        expect(error_stream).to have_received(:puts).with(
+          a_string_including(
+            "WARNING: --some-option is deprecated and will be removed after version 1.2.3.\n" \
+            'Please use --another-option instead.'
+          )
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

As we now have a `message`formatter working and that has been tested with the new stand-alone `json-formatter`, we can deprecate the old json-formatter.

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
