### PR TITLE
Use IdGenerator::UUID 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 if ENV['CUCUMBER_RUBY_CORE']
   gem 'cucumber-core', path: ENV['CUCUMBER_RUBY_CORE']
 elsif !ENV['CUCUMBER_USE_RELEASED_GEMS']
-  gem 'cucumber-core', github: 'cucumber/cucumber-ruby-core', branch: 'use-idgenerator-uuid'
+  gem 'cucumber-core', github: 'cucumber/cucumber-ruby-core'
 end
 
 if ENV['CUCUMBER_RUBY_WIRE']

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 if ENV['CUCUMBER_RUBY_CORE']
   gem 'cucumber-core', path: ENV['CUCUMBER_RUBY_CORE']
 elsif !ENV['CUCUMBER_USE_RELEASED_GEMS']
-  gem 'cucumber-core', github: 'cucumber/cucumber-ruby-core'
+  gem 'cucumber-core', github: 'cucumber/cucumber-ruby-core', branch: 'use-idgenerator-uuid'
 end
 
 if ENV['CUCUMBER_RUBY_WIRE']

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -244,7 +244,7 @@ module Cucumber
     end
 
     def id_generator
-      @id_generator ||= Cucumber::Messages::IdGenerator::Incrementing.new
+      @id_generator ||= Cucumber::Messages::IdGenerator::UUID.new
     end
 
     private

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -70,7 +70,7 @@ module Cucumber
       self.visitor = report
 
       receiver = Test::Runner.new(@configuration.event_bus)
-      compile features, receiver, filters, @configuration.event_bus, @configuration.id_generator
+      compile features, receiver, filters, @configuration.event_bus
       @configuration.notify :test_run_finished
     end
 

--- a/spec/cucumber/formatter/query/hook_by_test_step_spec.rb
+++ b/spec/cucumber/formatter/query/hook_by_test_step_spec.rb
@@ -22,6 +22,13 @@ module Cucumber
           @config.on_event :test_case_started do |event|
             @test_cases << event.test_case
           end
+
+          @hook_ids = []
+          @config.on_event :envelope do |event|
+            next unless event.envelope.hook
+
+            @hook_ids << event.envelope.hook.id
+          end
         end
 
         describe 'given a single feature' do
@@ -45,12 +52,12 @@ module Cucumber
 
               it 'provides the ID of the Before Hook used to generate the Test::Step' do
                 test_case = @test_cases.first
-                expect(@formatter.hook_id(test_case.test_steps.first)).to eq('0')
+                expect(@formatter.hook_id(test_case.test_steps.first)).to eq(@hook_ids.first)
               end
 
               it 'provides the ID of the After Hook used to generate the Test::Step' do
                 test_case = @test_cases.first
-                expect(@formatter.hook_id(test_case.test_steps.last)).to eq('1')
+                expect(@formatter.hook_id(test_case.test_steps.last)).to eq(@hook_ids.last)
               end
 
               it 'returns nil if the step was not generated from a hook' do

--- a/spec/cucumber/formatter/query/pickle_by_test_spec.rb
+++ b/spec/cucumber/formatter/query/pickle_by_test_spec.rb
@@ -22,6 +22,13 @@ module Cucumber
           @config.on_event :test_case_created do |event|
             @test_cases << event.test_case
           end
+
+          @pickle_ids = []
+          @config.on_event :envelope do |event|
+            next unless event.envelope.pickle
+
+            @pickle_ids << event.envelope.pickle.id
+          end
         end
 
         describe 'given a single feature' do
@@ -39,11 +46,7 @@ module Cucumber
               FEATURE
 
               it 'provides the ID of the pickle used to generate the Test::Case' do
-                # - 0 -> first step
-                # - 1 -> scenario
-                # - 2 -> pickle step
-                # - 3 -> the pickle
-                expect(@formatter.pickle_id(@test_cases.first)).to eq('3')
+                expect(@formatter.pickle_id(@test_cases.first)).to eq(@pickle_ids.first)
               end
 
               it 'raises an error when the Test::Case is unknown' do

--- a/spec/cucumber/formatter/query/pickle_step_by_test_step_spec.rb
+++ b/spec/cucumber/formatter/query/pickle_step_by_test_step_spec.rb
@@ -22,6 +22,15 @@ module Cucumber
           @config.on_event :test_case_created do |event|
             @test_cases << event.test_case
           end
+
+          @pickle_step_ids = []
+          @config.on_event :envelope do |event|
+            next unless event.envelope.pickle
+
+            event.envelope.pickle.steps.each do |step|
+              @pickle_step_ids << step.id
+            end
+          end
         end
 
         describe 'given a single feature' do
@@ -39,15 +48,10 @@ module Cucumber
               FEATURE
 
               it 'provides the ID of the PickleStep used to generate the Test::Step' do
-                # IDs are predictable:
-                # - 0 -> first step
-                # - 1 -> scenario
-                # - 2 -> pickle step
-                # - 3 -> the pickle
                 test_case = @test_cases.first
                 test_step = test_case.test_steps.first
 
-                expect(@formatter.pickle_step_id(test_step)).to eq('2')
+                expect(@formatter.pickle_step_id(test_step)).to eq(@pickle_step_ids.first)
               end
 
               it 'raises an exception when the test_step is unknown' do

--- a/spec/cucumber/formatter/query/step_definitions_by_test_step_spec.rb
+++ b/spec/cucumber/formatter/query/step_definitions_by_test_step_spec.rb
@@ -22,6 +22,13 @@ module Cucumber
           @config.on_event :test_case_created do |event|
             @test_cases << event.test_case
           end
+
+          @step_definition_ids = []
+          @config.on_event :envelope do |event|
+            next unless event.envelope.step_definition
+
+            @step_definition_ids << event.envelope.step_definition.id
+          end
         end
 
         describe 'given a single feature' do
@@ -46,7 +53,7 @@ module Cucumber
                 test_case = @test_cases.first
                 test_step = test_case.test_steps.first
 
-                expect(@formatter.step_definition_ids(test_step)).to eq(['0'])
+                expect(@formatter.step_definition_ids(test_step)).to eq([@step_definition_ids.first])
               end
             end
 


### PR DESCRIPTION
## Summary

Original idea behind CCK was to have predictable ids for comparing messages, but the way we compare messages in CCK (using `json-formatter`) makes this useless finally.

See [cucumber-ruby-core#195](https://github.com/cucumber/cucumber-ruby-core/pull/195)