### PR TITLE
Deprecate puts and embed

### DIFF
--- a/features/docs/defining_steps/nested_steps.feature
+++ b/features/docs/defining_steps/nested_steps.feature
@@ -8,7 +8,7 @@ Feature: Nested Steps
     And a step definition that looks like this:
       """ruby
       Given /a turtle/ do
-        puts "turtle!"
+        log "turtle!"
       end
       """
 
@@ -56,7 +56,7 @@ Feature: Nested Steps
       """ruby
       Given /turtles:/ do |table|
         table.hashes.each do |row|
-          puts row[:name]
+          log row[:name]
         end
       end
       """
@@ -97,7 +97,7 @@ Feature: Nested Steps
     And a step definition that looks like this:
       """ruby
       Given /turtles:/ do |string|
-        puts string
+        log string
       end
       """
     When I run the feature with the progress formatter

--- a/features/docs/defining_steps/nested_steps_i18n.feature
+++ b/features/docs/defining_steps/nested_steps_i18n.feature
@@ -10,7 +10,7 @@ Feature: Nested Steps in I18n
       # -*- coding: utf-8 -*-
       # frozen_string_literal: true
       前提 /a turtle/ do
-        puts "turtle!"
+        log "turtle!"
       end
       """
 

--- a/features/docs/defining_steps/nested_steps_with_second_arg.feature
+++ b/features/docs/defining_steps/nested_steps_with_second_arg.feature
@@ -12,7 +12,7 @@ Feature: Nested Steps with either table or doc string
       """ruby
       Given /turtles:/ do |table|
         table.hashes.each do |row|
-          puts row[:name]
+          log row[:name]
         end
       end
       """
@@ -46,7 +46,7 @@ Feature: Nested Steps with either table or doc string
     And a step definition that looks like this:
       """ruby
       Given /turtles:/ do |text|
-        puts "#{text}:#{text.class}"
+        log "#{text}:#{text.class}"
       end
       """
     When I run the feature with the progress formatter

--- a/features/docs/defining_steps/printing_messages.feature
+++ b/features/docs/defining_steps/printing_messages.feature
@@ -1,6 +1,6 @@
 Feature: Pretty formatter - Printing messages
 
-  When you want to print to Cucumber's output, just call `puts` from
+  When you want to print to Cucumber's output, call `log` from
   a step definition. Cucumber will grab the output and print it via
   the formatter that you're using.
   
@@ -8,30 +8,30 @@ Feature: Pretty formatter - Printing messages
 
   Background:
     Given the standard step definitions
-    And a file named "features/step_definitions/puts_steps.rb" with:
+    And a file named "features/step_definitions/log_steps.rb" with:
       """
-      Given /^I use puts with text "(.*)"$/ do |ann|
-        puts(ann)
+      Given /^I use log with text "(.*)"$/ do |ann|
+        log(ann)
       end
 
-      Given /^I use multiple putss$/ do
-        puts("Multiple")
-        puts("Announce","Me")
+      Given /^I use multiple logs$/ do
+        log("Multiple")
+        log("Announce\nMe")
       end
 
       Given /^I use message (.+) in line (.+) (?:with result (.+))$/ do |ann, line, result|
-        puts("Last message") if line == "3"
-        puts("Line: #{line}: #{ann}")
+        log("Last message") if line == "3"
+        log("Line: #{line}: #{ann}")
         fail if result =~ /fail/i
       end
 
-      Given /^I use puts and step fails$/ do
-        puts("Announce with fail")
+      Given /^I use log and step fails$/ do
+        log("Announce with fail")
         fail
       end
 
-      Given /^I puts the world$/ do
-        puts(self)
+      Given /^I log the world$/ do
+        log(self.to_s)
       end
       """
     And a file named "features/f.feature" with:
@@ -39,11 +39,11 @@ Feature: Pretty formatter - Printing messages
       Feature:
 
         Scenario:
-          Given I use puts with text "Ann"
+          Given I use log with text "Ann"
           And this step passes
 
         Scenario:
-          Given I use multiple putss
+          Given I use multiple logs
           And this step passes
 
         Scenario Outline:
@@ -56,7 +56,7 @@ Feature: Pretty formatter - Printing messages
             | 3    | anno3 |
 
         Scenario:
-          Given I use puts and step fails
+          Given I use log and step fails
           And this step passes
 
         Scenario Outline:
@@ -68,11 +68,11 @@ Feature: Pretty formatter - Printing messages
             | 2    | anno2 | pass   |
       """
 
-    And a file named "features/puts_world.feature" with:
+    And a file named "features/log_world.feature" with:
       """
-      Feature: puts_world
-        Scenario: puts_world
-          Given I puts the world
+      Feature: log_world
+        Scenario: log_world
+          Given I log the world
       """
 
     # Don't know why, but we need to spawn this for JRuby otherwise it gives wierd errors
@@ -85,12 +85,12 @@ Feature: Pretty formatter - Printing messages
       Feature: 
 
         Scenario: 
-          Given I use puts with text "Ann"
+          Given I use log with text "Ann"
             Ann
           And this step passes
 
         Scenario: 
-          Given I use multiple putss
+          Given I use multiple logs
             Multiple
             Announce
             Me
@@ -106,11 +106,11 @@ Feature: Pretty formatter - Printing messages
             | 3    | anno3 |
 
         Scenario: 
-          Given I use puts and step fails
+          Given I use log and step fails
             Announce with fail
              (RuntimeError)
-            ./features/step_definitions/puts_steps.rb:18:in `/^I use puts and step fails$/'
-            features/f.feature:21:in `I use puts and step fails'
+            ./features/step_definitions/log_steps.rb:18:in `/^I use log and step fails$/'
+            features/f.feature:21:in `I use log and step fails'
           And this step passes
 
         Scenario Outline: 
@@ -120,7 +120,7 @@ Feature: Pretty formatter - Printing messages
             | line | ann   | result |
             | 1    | anno1 | fail   |  Line: 1: anno1
              (RuntimeError)
-            ./features/step_definitions/puts_steps.rb:13:in `/^I use message (.+) in line (.+) (?:with result (.+))$/'
+            ./features/step_definitions/log_steps.rb:13:in `/^I use message (.+) in line (.+) (?:with result (.+))$/'
             features/f.feature:29:25:in `I use message anno1 in line 1 with result fail'
             | 2    | anno2 | pass   |  Line: 2: anno2
       """

--- a/features/docs/formatters/json_formatter.feature
+++ b/features/docs/formatters/json_formatter.feature
@@ -25,7 +25,7 @@ Feature: JSON output formatter
       end
 
       Given /^I print from step definition/ do
-        puts "from step definition"
+        log "from step definition"
       end
 
       Given /^I attach data directly/ do
@@ -644,32 +644,32 @@ Feature: JSON output formatter
      Given a file named "features/step_definitions/output_steps.rb" with:
       """
       Before do
-        puts "Before hook 1"
+        log "Before hook 1"
         attach "src", "mime_type"
       end
 
       Before do
-        puts "Before hook 2"
+        log "Before hook 2"
         attach "src", "mime_type"
       end
 
       AfterStep do
-        puts "AfterStep hook 1"
+        log "AfterStep hook 1"
         attach "src", "mime_type"
       end
 
       AfterStep do
-        puts "AfterStep hook 2"
+        log "AfterStep hook 2"
         attach "src", "mime_type"
       end
 
       After do
-        puts "After hook 1"
+        log "After hook 1"
         attach "src", "mime_type"
       end
 
       After do
-        puts "After hook 2"
+        log "After hook 2"
         attach "src", "mime_type"
       end
       """

--- a/features/docs/formatters/json_formatter.feature
+++ b/features/docs/formatters/json_formatter.feature
@@ -19,26 +19,26 @@ Feature: JSON output formatter
       """
     And a file named "features/step_definitions/json_steps.rb" with:
       """
-      Given /^I embed a screenshot/ do
+      Given /^I attach a screenshot/ do
         File.open("screenshot.png", "w") { |file| file << "foo" }
-        embed "screenshot.png", "image/png"
+        attach "screenshot.png", "image/png"
       end
 
       Given /^I print from step definition/ do
         puts "from step definition"
       end
 
-      Given /^I embed data directly/ do
+      Given /^I attach data directly/ do
         data = "YWJj"
-        embed data, "mime-type;base64"
+        attach data, "mime-type;base64"
       end
       """
-    And a file named "features/embed.feature" with:
+    And a file named "features/attachments.feature" with:
       """
       Feature: A screenshot feature
 
         Scenario:
-          Given I embed a screenshot
+          Given I attach a screenshot
 
       """
     And a file named "features/outline.feature" with:
@@ -75,15 +75,15 @@ Feature: JSON output formatter
           And I print from step definition
 
       """
-    And a file named "features/embed_data_directly.feature" with:
+    And a file named "features/attach_data_directly.feature" with:
       """
       Feature: An embed data directly feature
 
         Scenario:
-          Given I embed data directly
+          Given I attach data directly
 
         Scenario Outline:
-          Given I embed data directly
+          Given I attach data directly
 
 	  Examples:
 	  | dummy |
@@ -257,13 +257,13 @@ Feature: JSON output formatter
       ]
       """
 
-  Scenario: embedding screenshot
-    When I run `cucumber --format json features/embed.feature`
+  Scenario: Attaching screenshot
+    When I run `cucumber --format json features/attachments.feature`
     Then it should pass with JSON:
     """
     [
       {
-        "uri": "features/embed.feature",
+        "uri": "features/attachments.feature",
         "id": "a-screenshot-feature",
         "keyword": "Feature",
         "name": "A screenshot feature",
@@ -280,7 +280,7 @@ Feature: JSON output formatter
             "steps": [
               {
                 "keyword": "Given ",
-                "name": "I embed a screenshot",
+                "name": "I attach a screenshot",
                 "line": 4,
                 "embeddings": [
                   {
@@ -537,13 +537,13 @@ Feature: JSON output formatter
 
     """
 
-  Scenario: embedding data directly
-    When I run `cucumber --format json -x features/embed_data_directly.feature`
+  Scenario: Attaching data directly
+    When I run `cucumber --format json -x features/attach_data_directly.feature`
     Then it should pass with JSON:
     """
     [
       {
-        "uri": "features/embed_data_directly.feature",
+        "uri": "features/attach_data_directly.feature",
         "id": "an-embed-data-directly-feature",
         "keyword": "Feature",
         "name": "An embed data directly feature",
@@ -560,7 +560,7 @@ Feature: JSON output formatter
             "steps": [
               {
                 "keyword": "Given ",
-                "name": "I embed data directly",
+                "name": "I attach data directly",
                 "line": 4,
                 "embeddings": [
                   {
@@ -588,7 +588,7 @@ Feature: JSON output formatter
             "steps": [
               {
                 "keyword": "Given ",
-                "name": "I embed data directly",
+                "name": "I attach data directly",
                 "line": 7,
                 "embeddings": [
                   {
@@ -616,7 +616,7 @@ Feature: JSON output formatter
             "steps": [
               {
                 "keyword": "Given ",
-                "name": "I embed data directly",
+                "name": "I attach data directly",
                 "line": 7,
                 "embeddings": [
                   {
@@ -645,32 +645,32 @@ Feature: JSON output formatter
       """
       Before do
         puts "Before hook 1"
-        embed "src", "mime_type", "label"
+        attach "src", "mime_type"
       end
 
       Before do
         puts "Before hook 2"
-        embed "src", "mime_type", "label"
+        attach "src", "mime_type"
       end
 
       AfterStep do
         puts "AfterStep hook 1"
-        embed "src", "mime_type", "label"
+        attach "src", "mime_type"
       end
 
       AfterStep do
         puts "AfterStep hook 2"
-        embed "src", "mime_type", "label"
+        attach "src", "mime_type"
       end
 
       After do
         puts "After hook 1"
-        embed "src", "mime_type", "label"
+        attach "src", "mime_type"
       end
 
       After do
         puts "After hook 2"
-        embed "src", "mime_type", "label"
+        attach "src", "mime_type"
       end
       """
     When I run `cucumber --format json features/out_scenario_out_scenario_outline.feature`

--- a/features/docs/formatters/pretty_formatter.feature
+++ b/features/docs/formatters/pretty_formatter.feature
@@ -40,15 +40,15 @@ Feature: Pretty output formatter
     And a file named "features/step_definitions/output_steps.rb" with:
       """
       Before do
-        puts "Before hook"
+        log "Before hook"
        end
 
       AfterStep do
-        puts "AfterStep hook"
+        log "AfterStep hook"
       end
 
       After do
-        puts "After hook"
+        log "After hook"
 	raise "error"
       end
       """

--- a/features/docs/getting_started.feature
+++ b/features/docs/getting_started.feature
@@ -1,6 +1,6 @@
 Feature: Getting started
 
-  To get started, just open a command prompt in an empty directory and run 
+  To get started, just open a command prompt in an empty directory and run
   `cucumber`. You'll be prompted for what to do next.
 
   @spawn @todo-windows
@@ -17,7 +17,7 @@ Feature: Getting started
     Given a directory without standard Cucumber project directory structure
     And a file named "should_not_load.rb" with:
       """
-      puts 'this will not be shown'
+      log 'this will not be shown'
       """
     When I run `cucumber`
     Then the exit status should be 2

--- a/features/docs/gherkin/doc_strings.feature
+++ b/features/docs/gherkin/doc_strings.feature
@@ -43,7 +43,7 @@ Feature: Doc strings
     And a step definition that looks like this:
       """ruby
       Given /say/ do |text|
-        puts text
+        log text
       end
       """
     When I run the feature with the progress formatter
@@ -66,7 +66,7 @@ Feature: Doc strings
     And a step definition that looks like this:
       """ruby
       Given /code/ do |text|
-        puts text.class
+        log text.class.to_s
       end
       """
     When I run the feature with the progress formatter

--- a/features/docs/writing_support_code/after_hooks.feature
+++ b/features/docs/writing_support_code/after_hooks.feature
@@ -15,7 +15,7 @@ Feature: After Hooks
     Given a file named "features/support/debug_hook.rb" with:
       """
       After do |scenario|
-        puts scenario.status.inspect
+        log scenario.status.inspect
       end
       """
     And a file named "features/result.feature" with:
@@ -38,7 +38,7 @@ Feature: After Hooks
       """
       After do |scenario|
         if scenario.failed?
-          puts "eek"
+          log "eek"
         end
       end
       """
@@ -80,11 +80,11 @@ Feature: After Hooks
     Given a file named "features/support/hooks.rb" with:
       """
       After do
-        puts "First"
+        log "First"
       end
 
       After do
-        puts "Second"
+        log "Second"
       end
       """
     And a file named "features/pass.feature" with:

--- a/lib/cucumber/deprecate.rb
+++ b/lib/cucumber/deprecate.rb
@@ -5,28 +5,37 @@ require 'cucumber/gherkin/formatter/ansi_escapes'
 
 module Cucumber
   module Deprecate
-    class CliOption
+    class AnsiString
       include Cucumber::Gherkin::Formatter::AnsiEscapes
 
-      def self.deprecate(stream, option, message, remove_after_version)
-        return if stream.nil?
-        CliOption.new.deprecate(stream, option, message, remove_after_version)
+      def self.failure_message(message)
+        AnsiString.new.failure_message(message)
       end
 
-      def deprecate(stream, option, message, remove_after_version)
-        stream.puts(failed + "\nWARNING: #{option} is deprecated" \
-        " and will be removed after version #{remove_after_version}.\n#{message}.\n" \
-        + reset)
+      def failure_message(message)
+        failed + message + reset
+      end
+    end
+
+    class CliOption
+      def self.deprecate(stream, option, message, remove_after_version)
+        return if stream.nil?
+        stream.puts(
+          AnsiString.failure_message(
+            "\nWARNING: #{option} is deprecated" \
+            " and will be removed after version #{remove_after_version}.\n#{message}.\n"
+          )
+        )
       end
     end
 
     module ForUsers
-      AnsiEscapes = Cucumber::Gherkin::Formatter::AnsiEscapes
-
       def self.call(message, method, remove_after_version)
-        STDERR.puts AnsiEscapes.failed + "\nWARNING: ##{method} is deprecated" \
-        " and will be removed after version #{remove_after_version}. #{message}.\n" \
-        "(Called from #{caller(3..3).first})" + AnsiEscapes.reset
+        STDERR.puts AnsiString.failure_message(
+          "\nWARNING: ##{method} is deprecated" \
+          " and will be removed after version #{remove_after_version}. #{message}.\n" \
+          "(Called from #{caller(3..3).first})"
+        )
       end
     end
 

--- a/lib/cucumber/errors.rb
+++ b/lib/cucumber/errors.rb
@@ -49,4 +49,7 @@ module Cucumber
       super(messages.join("\n"))
     end
   end
+
+  class LogTypeInvalid < StandardError
+  end
 end

--- a/lib/cucumber/formatter/console.rb
+++ b/lib/cucumber/formatter/console.rb
@@ -158,9 +158,7 @@ module Cucumber
         end
       end
 
-      def embed(file, mime_type, label)
-        # no-op
-      end
+      def attach(*) end
 
       def puts(*messages)
         return unless @io

--- a/lib/cucumber/formatter/console.rb
+++ b/lib/cucumber/formatter/console.rb
@@ -158,14 +158,11 @@ module Cucumber
         end
       end
 
-      def attach(*) end
-
-      def puts(*messages)
+      def attach(src, media_type)
+        return unless media_type == 'text/x.cucumber.log+plain'
         return unless @io
         @io.puts
-        messages.each do |message|
-          @io.puts(format_string(message, :tag))
-        end
+        @io.puts(format_string(src, :tag))
         @io.flush
       end
 

--- a/lib/cucumber/formatter/duration_extractor.rb
+++ b/lib/cucumber/formatter/duration_extractor.rb
@@ -25,7 +25,7 @@ module Cucumber
         duration.tap { |dur| @result_duration = dur.nanoseconds / 10**9.0 }
       end
 
-      def embed(*) end
+      def attach(*) end
     end
   end
 end

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -94,7 +94,7 @@ module Cucumber
         test_step_output << message
       end
 
-      def embed(src, mime_type, _label)
+      def attach(src, mime_type)
         if File.file?(src)
           content = File.open(src, 'rb', &:read)
           data = encode64(content)

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -90,11 +90,11 @@ module Cucumber
         @io.write(MultiJson.dump(@feature_hashes, pretty: true))
       end
 
-      def puts(message)
-        test_step_output << message
-      end
-
       def attach(src, mime_type)
+        if mime_type == 'text/x.cucumber.log+plain'
+          test_step_output << src
+          return
+        end
         if File.file?(src)
           content = File.open(src, 'rb', &:read)
           data = encode64(content)

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -239,7 +239,7 @@ module Cucumber
         duration.tap { |dur| @test_case_duration = dur.nanoseconds / 10**9.0 }
       end
 
-      def embed(*) end
+      def attach(*) end
     end
   end
 end

--- a/lib/cucumber/formatter/message.rb
+++ b/lib/cucumber/formatter/message.rb
@@ -40,7 +40,7 @@ module Cucumber
         @current_test_step_id = nil
       end
 
-      def embed(src, media_type, _label)
+      def attach(src, media_type)
         attachment_data = {
           test_step_id: @current_test_step_id,
           test_case_started_id: @current_test_case_started_id,

--- a/lib/cucumber/formatter/pretty.rb
+++ b/lib/cucumber/formatter/pretty.rb
@@ -131,10 +131,9 @@ module Cucumber
         print_summary
       end
 
-      def puts(*messages)
-        messages.each do |message|
-          @test_step_output.push message
-        end
+      def attach(src, media_type)
+        return unless media_type == 'text/x.cucumber.log+plain'
+        @test_step_output.push src
       end
 
       private

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -80,7 +80,16 @@ module Cucumber
       #
       #   If you'd prefer to see the message immediately, call {Kernel.puts} instead.
       def puts(*messages)
-        super
+        Cucumber.deprecate(
+          'Messages emitted with "puts" will no longer be caught by Cucumber ' \
+          'and sent to the formatter. If you want message to be in the formatted output, ' \
+          "please use log(message) instead.\n" \
+          'If you simply want it in the console, '\
+          'keep using "puts" (or Kernel.puts to avoid this message)',
+          'puts(message)',
+          '5.0.0'
+        )
+        messages.each { |message| log(message.to_s) }
       end
 
       # Pause the tests and ask the operator for input
@@ -90,8 +99,17 @@ module Cucumber
 
       # Embed an image in the output
       def embed(file, mime_type, _label = 'Screenshot')
-        Cucumber.deprecate('Please use attach(file, media_type) instead', 'embed(file, mime_type, label)', '5.0.0')
+        Cucumber.deprecate(
+          'Please use attach(file, media_type) instead',
+          'embed(file, mime_type, label)',
+          '5.0.0'
+        )
         attach(file, mime_type)
+      end
+
+      def log(message)
+        raise Cucumber::LogTypeInvalid unless message.is_a?(String)
+        attach(message.dup, 'text/x.cucumber.log+plain')
       end
 
       def attach(file, media_type)
@@ -150,17 +168,6 @@ module Cucumber
             location = Core::Test::Location.of_caller
             runtime.invoke_dynamic_steps(steps_text, language, location)
           end
-
-          # rubocop:disable Style/UnneededInterpolation
-          define_method(:puts) do |*messages|
-            # Even though they won't be output until later, converting the messages to
-            # strings right away will protect them from modifications to their original
-            # objects in the mean time
-            messages.collect! { |message| "#{message}" }
-
-            runtime.puts(*messages)
-          end
-          # rubocop:enable Style/UnneededInterpolation
 
           define_method(:ask) do |question, timeout_seconds = 60|
             runtime.ask(question, timeout_seconds)

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -2,6 +2,7 @@
 
 require 'cucumber/gherkin/formatter/ansi_escapes'
 require 'cucumber/core/test/data_table'
+require 'cucumber/deprecate'
 
 module Cucumber
   module Glue
@@ -88,7 +89,12 @@ module Cucumber
       end
 
       # Embed an image in the output
-      def embed(file, mime_type, label = 'Screenshot')
+      def embed(file, mime_type, _label = 'Screenshot')
+        Cucumber.deprecate('Please use attach(file, media_type) instead', 'embed(file, mime_type, label)', '5.0.0')
+        attach(file, mime_type)
+      end
+
+      def attach(file, media_type)
         super
       end
 
@@ -160,8 +166,8 @@ module Cucumber
             runtime.ask(question, timeout_seconds)
           end
 
-          define_method(:embed) do |file, mime_type, label = 'Screenshot'|
-            runtime.embed(file, mime_type, label)
+          define_method(:attach) do |file, media_type|
+            runtime.attach(file, media_type)
           end
 
           # Prints the list of modules that are included in the World

--- a/lib/cucumber/runtime/for_programming_languages.rb
+++ b/lib/cucumber/runtime/for_programming_languages.rb
@@ -21,6 +21,7 @@ module Cucumber
 
       def_delegators :@user_interface,
                      :embed,
+                     :attach,
                      :ask,
                      :puts,
                      :features_paths,

--- a/lib/cucumber/runtime/user_interface.rb
+++ b/lib/cucumber/runtime/user_interface.rb
@@ -7,14 +7,6 @@ module Cucumber
     module UserInterface
       attr_writer :visitor
 
-      # Output +messages+ alongside the formatted output.
-      # This is an alternative to using Kernel#puts - it will display
-      # nicer, and in all outputs (in case you use several formatters)
-      #
-      def puts(*messages)
-        @visitor.puts(*messages)
-      end
-
       # Suspends execution and prompts +question+ to the console (STDOUT).
       # An operator (manual tester) can then enter a line of text and hit
       # <ENTER>. The entered text is returned, and both +question+ and

--- a/lib/cucumber/runtime/user_interface.rb
+++ b/lib/cucumber/runtime/user_interface.rb
@@ -48,8 +48,8 @@ module Cucumber
       # be a path to a file, or if it's an image it may also be a Base64 encoded image.
       # The embedded data may or may not be ignored, depending on what kind of formatter(s) are active.
       #
-      def embed(src, mime_type, label)
-        @visitor.embed(src, mime_type, label)
+      def attach(src, media_type)
+        @visitor.attach(src, media_type)
       end
 
       private

--- a/spec/cucumber/deprecate_spec.rb
+++ b/spec/cucumber/deprecate_spec.rb
@@ -3,6 +3,30 @@
 require 'spec_helper'
 
 module Cucumber::Deprecate
+  describe 'Cucumber.deprecate' do
+    context 'for developers' do
+      it 'fails when running the tests' do
+        expect do
+          Cucumber.deprecate('Use some_method instead', 'someMethod', '1.0.0')
+        end.to raise_exception('This method is due for removal after version 1.0.0')
+      end
+    end
+
+    context 'for users' do
+      it 'outputs a message to STDERR' do
+        stub_const('Cucumber::Deprecate::STRATEGY', ForUsers)
+        allow(STDERR).to receive(:puts)
+
+        Cucumber.deprecate('Use some_method instead', 'someMethod', '1.0.0')
+        expect(STDERR).to have_received(:puts).with(
+          a_string_including(
+            'WARNING: #someMethod is deprecated and will be removed after version 1.0.0. Use some_method instead.'
+          )
+        )
+      end
+    end
+  end
+
   describe CliOption do
     let(:error_stream) { double }
 

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -57,6 +57,32 @@ module Cucumber
 OUTPUT
           end
         end
+
+        describe 'when modifying the printed variable after the call to log' do
+          define_feature <<-FEATURE
+        Feature: Banana party
+
+          Scenario: Monkey eats banana
+            When puts is called twice for the same variable
+          FEATURE
+
+          define_steps do
+            When(/^puts is called twice for the same variable$/) do
+              foo = String.new('a')
+              log foo
+              foo.upcase!
+              log foo
+            end
+          end
+
+          it 'prints the variable value at the time puts was called' do
+            expect(@out.string).to include <<OUTPUT
+    When puts is called twice for the same variable
+      a
+      A
+OUTPUT
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Following discussions in [cucumber#897](https://github.com/cucumber/cucumber/issues/897)

- [x] `embed` is deprecated in favour of `attach`
- [x] existing step definitions using `embed` should be updated to use `attach` instead
- [x] `puts` is deprecated in favour of `log`
- [x] existing step refs using `puts` should be updated to use `log` instead
- [x] `log` should be an alias for `attach`
- [x] existing formatters should handle attachments with media-type `text/x.cucumber.log+plain` as they were handling `puts`

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
