### PR TITLE
Correctly handle 'log' in messages formatter

### DIFF
--- a/features/lib/step_definitions/messages_steps.rb
+++ b/features/lib/step_definitions/messages_steps.rb
@@ -12,4 +12,3 @@ Then('messages types should be:') do |expected_types|
 
   expect(expected_types.split("\n").map(&:strip)).to contain_exactly(*message_types)
 end
-

--- a/lib/cucumber/formatter/message.rb
+++ b/lib/cucumber/formatter/message.rb
@@ -47,7 +47,7 @@ module Cucumber
           media_type: media_type
         }
 
-        if media_type == 'text/plain'
+        if media_type =~ /^text\//
           attachment_data[:text] = src
         elsif src.respond_to? :read
           attachment_data[:binary] = Base64.encode64(src.read)
@@ -61,20 +61,6 @@ module Cucumber
 
         output_envelope(message)
       end
-
-      def output(text)
-        message = Cucumber::Messages::Envelope.new(
-          attachment: Cucumber::Messages::Attachment.new(
-            test_step_id: @current_test_step_id,
-            test_case_started_id: @current_test_case_started_id,
-            media_type: 'text/x.cucumber.output+plain',
-            text: text
-          )
-        )
-
-        output_envelope(message)
-      end
-      alias puts output
 
       private
 

--- a/lib/cucumber/formatter/message.rb
+++ b/lib/cucumber/formatter/message.rb
@@ -47,7 +47,7 @@ module Cucumber
           media_type: media_type
         }
 
-        if media_type =~ /^text\//
+        if media_type.start_with?('text/')
           attachment_data[:text] = src
         elsif src.respond_to? :read
           attachment_data[:binary] = Base64.encode64(src.read)


### PR DESCRIPTION
`log` did not correctly create `attachment` messages.