### PR TITLE
Fix code snippet on docstring

### DIFF
--- a/features/docs/defining_steps/snippets.feature
+++ b/features/docs/defining_steps/snippets.feature
@@ -55,3 +55,21 @@ Feature: Snippets
         pending # Write code here that turns the phrase above into concrete actions
       end
       """
+      
+  Scenario: Snippet for undefined step with combined arguments
+    Given a file named "features/undefined_steps.feature" with:
+      """
+      Feature:
+        Scenario: combined step
+          Given a file named "todos" with:
+          \"\"\"
+          - Buy milk
+          \"\"\"
+      """
+    When I run `cucumber features/undefined_steps.feature -s`
+    Then the output should contain:
+      """
+      Given('a file named {string} with:') do |string, string2|
+        pending # Write code here that turns the phrase above into concrete actions
+      end
+      """

--- a/features/docs/defining_steps/snippets.feature
+++ b/features/docs/defining_steps/snippets.feature
@@ -55,3 +55,29 @@ Feature: Snippets
         pending # Write code here that turns the phrase above into concrete actions
       end
       """
+
+  Scenario: Snippet for undefined step with multiple params
+    Given a file named "features/undefined_steps.feature" with:
+      """
+      Feature:
+        Scenario: Send emails
+          Given I send an email entitled "Hi from Cucumber" to john@example.org with content:
+          \"\"\"
+          Hello there!
+          \"\"\"
+      """
+    And a file named "features/support/parameter_types.rb" with:
+      """
+      ParameterType(
+        name: 'email_address',
+        regexp: /([a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)/,
+        transformer: -> (email) { email }
+      )
+      """
+    When I run `cucumber features/undefined_steps.feature -s`
+    Then the output should contain:
+      """
+      Given('I send an email entitled {string} to {email_address} with content:') do |string, email_address, doc_string|
+        pending # Write code here that turns the phrase above into concrete actions
+      end
+      """

--- a/features/docs/defining_steps/snippets.feature
+++ b/features/docs/defining_steps/snippets.feature
@@ -20,7 +20,7 @@ Feature: Snippets
     When I run `cucumber features/undefined_steps.feature -s`
     Then the output should contain:
       """
-      Given('a Doc String') do |string|
+      Given('a Doc String') do |doc_string|
         pending # Write code here that turns the phrase above into concrete actions
       end
 
@@ -52,24 +52,6 @@ Feature: Snippets
       """
       Given('a table') do |table|
         # table is a Cucumber::MultilineArgument::DataTable
-        pending # Write code here that turns the phrase above into concrete actions
-      end
-      """
-      
-  Scenario: Snippet for undefined step with combined arguments
-    Given a file named "features/undefined_steps.feature" with:
-      """
-      Feature:
-        Scenario: combined step
-          Given a file named "todos" with:
-          \"\"\"
-          - Buy milk
-          \"\"\"
-      """
-    When I run `cucumber features/undefined_steps.feature -s`
-    Then the output should contain:
-      """
-      Given('a file named {string} with:') do |string, string2|
         pending # Write code here that turns the phrase above into concrete actions
       end
       """

--- a/lib/cucumber/glue/snippet.rb
+++ b/lib/cucumber/glue/snippet.rb
@@ -174,7 +174,7 @@ module Cucumber
 
         class DocString
           def append_block_parameter_to(array)
-            parameter = format('string%<index>s', index: (array.size + 1 unless array.empty?))
+            parameter = format('string%<index>s', index: (array.size + 1 if array.include?('string')))
             array << parameter
           end
 

--- a/lib/cucumber/glue/snippet.rb
+++ b/lib/cucumber/glue/snippet.rb
@@ -174,8 +174,7 @@ module Cucumber
 
         class DocString
           def append_block_parameter_to(array)
-            parameter = format('string%<index>s', index: (array.size + 1 if array.include?('string')))
-            array << parameter
+            array << 'doc_string'
           end
 
           def append_comment_to(string); end

--- a/lib/cucumber/glue/snippet.rb
+++ b/lib/cucumber/glue/snippet.rb
@@ -174,7 +174,8 @@ module Cucumber
 
         class DocString
           def append_block_parameter_to(array)
-            array << 'string'
+            parameter = format('string%<index>s', index: (array.size + 1 unless array.empty?))
+            array << parameter
           end
 
           def append_comment_to(string); end

--- a/spec/cucumber/glue/snippet_spec.rb
+++ b/spec/cucumber/glue/snippet_spec.rb
@@ -109,7 +109,7 @@ module Cucumber
           @multiline_argument = MultilineArgument.from('', Core::Test::Location.new(''))
 
           expect(snippet_text).to eq unindented(%{
-          Given(/^A "([^"]*)" arg$/) do |arg1, string|
+          Given(/^A "([^"]*)" arg$/) do |arg1, doc_string|
             pending # Write code here that turns the phrase above into concrete actions
           end
           })


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
When you have a step with a string argument and a Doc String argument, the generated snippet contains a duplicate argument name

<!--- Provide a general summary description of your changes -->

## Details
This scenario currently fails

```gherkin
Scenario: Snippet for undefined step with combined arguments
    Given a file named "features/undefined_steps.feature" with:
      """
      Feature:
        Scenario: combined step
          Given a "thing" with:
          \"\"\"
          thing
          \"\"\"
      """
    When I run `cucumber features/undefined_steps.feature -s`
    Then the output should contain:
      """
      Given('a {string} with:') do |string, string2|
        pending # Write code here that turns the phrase above into concrete actions
      end
      """
```

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
