### PR TITLE
Avoid lazy init of mutex by moving it to constructor

### DIFF
--- a/lib/cucumber/formatter/interceptor.rb
+++ b/lib/cucumber/formatter/interceptor.rb
@@ -9,17 +9,18 @@ module Cucumber
           @pipe = pipe
           @buffer = StringIO.new
           @wrapped = true
+          @lock = Mutex.new
         end
 
         def write(str)
-          lock.synchronize do
+          @lock.synchronize do
             @buffer << str if @wrapped
             return @pipe.write(str)
           end
         end
 
         def buffer_string
-          lock.synchronize do
+          @lock.synchronize do
             return @buffer.string.dup
           end
         end
@@ -66,12 +67,6 @@ module Cucumber
             $stdout = new($stdout)
             return $stdout
           end
-        end
-
-        private
-
-        def lock
-          @lock ||= Mutex.new
         end
       end
     end


### PR DESCRIPTION
## Summary

Move initialization of the `Mutex` to the constructor.

## Details

We need the lock for the primary concern of this class, write & read synchronized.

There's no benefit to waiting to initialize the Mutex.

## Motivation and Context

Avoid concurrency interaction trouble on non-MRI platforms.

## How Has This Been Tested?

Squinting.

## Screenshots (if appropriate):

## Types of changes

- [ ] Refactor (code change that does not change external functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
