### PR TITLE
Fix documentation for --out=url

### DIFF
--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -302,9 +302,8 @@ Specify SEED to reproduce the shuffling from a previous run.
           "formatter's docs to see whether to pass a file, dir or URL.",
           "\n",
           'When using a URL, the output of the formatter will be sent as the HTTP request body.',
-          'HTTP headers and request method can be set with http- prefixed query parameters,',
-          'for example ?http-content-type=application/json&http-method=PUT.',
-          'All http- prefixed query parameters will be removed from the sent query parameters.'
+          'HTTP headers and request method can be set with cURL like options,',
+          'for example --out "http://example.com -X POST -H Content-Type:text/json"'
         ]
       end
 

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -302,8 +302,8 @@ Specify SEED to reproduce the shuffling from a previous run.
           "formatter's docs to see whether to pass a file, dir or URL.",
           "\n",
           'When using a URL, the output of the formatter will be sent as the HTTP request body.',
-          'HTTP headers and request method can be set with cURL like options,',
-          'for example --out "http://example.com -X POST -H Content-Type:text/json"'
+          'HTTP headers and request method can be set with cURL like options.',
+          'Example: --out "http://example.com -X POST -H Content-Type:text/json"'
         ]
       end
 


### PR DESCRIPTION
## Summary

Follow up of #1415
Display an up to date message for the `-o` option when running `cucumber -h`

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
