### PR TITLE
Force diff-lcss < 1.4

### DIFF
--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cucumber-html-formatter', '~> 6.0', '>= 6.0.1'
   s.add_dependency 'cucumber-messages', '~> 12.1', '>= 12.1.1'
   s.add_dependency 'cucumber-wire', '~> 3.0', '>= 3.0.0'
-  s.add_dependency 'diff-lcs', '~> 1.3', '>= 1.3'
+  s.add_dependency 'diff-lcs', '~> 1.3', '>= 1.3', '< 1.4'
   s.add_dependency 'multi_test', '~> 0.1', '>= 0.1.2'
   s.add_dependency 'sys-uname', '~> 1.0', '>= 1.0.2'
 


### PR DESCRIPTION
`diff-lcs` got a [new release yesterday (1.4)](https://github.com/halostatue/diff-lcs/blob/master/History.md#14--2020-06-23).
Although this is marked as a minor upgrade, the API changed and makes our CI fail. Until this is more cleanly fixed, we'll stick to 1.3.