### PR TITLE
Remove Aruba reference in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,6 @@ gem 'cucumber-html-formatter', path: ENV['CUCUMBER_HTML_FORMATTER_RUBY'] if ENV[
 gem 'cucumber-messages', path: ENV['CUCUMBER_MESSAGES_RUBY'] if ENV['CUCUMBER_MESSAGES_RUBY']
 gem 'gherkin', path: ENV['GHERKIN_RUBY'] if ENV['GHERKIN_RUBY']
 
-gem 'aruba', '~> 0.14.11' if RUBY_VERSION < '2.4'
-
 require 'rbconfig'
 # rubocop:disable Style/DoubleNegation
 is_windows = !!(RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)


### PR DESCRIPTION
Thanks to #1426 - there was a reference left to Aruba in the `Gemfile`, this removes it as we don't rely on Aruba anymore.