### PR TITLE
Fix AfterStep Hook lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
-* N/A
+* `AfterStep` hook do not cause issue when running `message` formatter. [#1433](https://github.com/cucumber/cucumber-ruby/issues/1433) - [#1434](https://github.com/cucumber/cucumber-ruby/pull/1434)
 
 
 ## [4.0.1](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0...v4.0.1)

--- a/lib/cucumber/runtime/step_hooks.rb
+++ b/lib/cucumber/runtime/step_hooks.rb
@@ -3,9 +3,10 @@
 module Cucumber
   class Runtime
     class StepHooks
-      def initialize(id_generator, hooks)
+      def initialize(id_generator, hooks, event_bus)
         @hooks = hooks
         @id_generator = id_generator
+        @event_bus = event_bus
       end
 
       def apply(test_steps)
@@ -19,7 +20,9 @@ module Cucumber
       def after_step_hooks(test_step)
         @hooks.map do |hook|
           action = ->(*args) { hook.invoke('AfterStep', [args, test_step]) }
-          Hooks.after_step_hook(@id_generator.new_id, test_step, hook.location, &action)
+          hook_step = Hooks.after_step_hook(@id_generator.new_id, test_step, hook.location, &action)
+          @event_bus.hook_test_step_created(hook_step, hook)
+          hook_step
         end
       end
     end

--- a/lib/cucumber/runtime/support_code.rb
+++ b/lib/cucumber/runtime/support_code.rb
@@ -104,7 +104,7 @@ module Cucumber
       def find_after_step_hooks(test_case)
         scenario = RunningTestCase.new(test_case)
         hooks = registry.hooks_for(:after_step, scenario)
-        StepHooks.new(@configuration.id_generator, hooks)
+        StepHooks.new(@configuration.id_generator, hooks, @configuration.event_bus)
       end
 
       def apply_before_hooks(test_case)

--- a/spec/cucumber/formatter/query/hook_by_test_step_spec.rb
+++ b/spec/cucumber/formatter/query/hook_by_test_step_spec.rb
@@ -73,6 +73,26 @@ module Cucumber
               end
             end
           end
+
+          describe 'with AfterStep hooks' do
+            context '#pickle_step_id' do
+              define_feature <<-FEATURE
+                Feature: Banana party
+
+                  Scenario: Monkey eats banana
+                    Given there are bananas
+              FEATURE
+
+              define_steps do
+                AfterStep() {}
+              end
+
+              it 'provides the ID of the AfterStepHook used to generate the Test::Step' do
+                test_case = @test_cases.first
+                expect(@formatter.hook_id(test_case.test_steps.last)).to eq(@hook_ids.first)
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
When an `AfterStep` hook is defined, the lookup for the Hook fails when trying to produce the messages.

See #1433 for more details.