### PR TITLE
Support diff-lcs 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Improved
 
-* N/A
+* Update code to be compatible with `diff-lcs` versions 1.3 and 1.4
 
 ### Fixed
 

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cucumber-html-formatter', '~> 7.0', '>= 7.0.0'
   s.add_dependency 'cucumber-messages', '~> 12.2', '>= 12.2.0'
   s.add_dependency 'cucumber-wire', '~> 3.1', '>= 3.1.0'
-  s.add_dependency 'diff-lcs', '~> 1.3', '>= 1.3', '< 1.4'
+  s.add_dependency 'diff-lcs', '~> 1.3', '>= 1.3'
   s.add_dependency 'multi_test', '~> 0.1', '>= 0.1.2'
   s.add_dependency 'sys-uname', '~> 1.0', '>= 1.0.2'
 

--- a/lib/cucumber/multiline_argument/data_table/diff_matrices.rb
+++ b/lib/cucumber/multiline_argument/data_table/diff_matrices.rb
@@ -95,7 +95,7 @@ module Cucumber
         def changes
           require 'diff/lcs'
           diffable_cell_matrix = cell_matrix.dup.extend(::Diff::LCS)
-          diffable_cell_matrix.diff(other_table_cell_matrix).flatten
+          diffable_cell_matrix.diff(other_table_cell_matrix).flatten(1)
         end
 
         def inspect_rows(missing_row, inserted_row)


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

Cucumber-ruby does not work with the latest version of diff-lcs.

**Describe the solution you have implemented**

`Array#flatten` works recursively and (apparently) operates on anything that supports `#to_ary`. Diff-lcs 1.4 added `Diff::LCS::Change#to_ary`. Because of this `DiffMatrices#changes` raises an error. This pull request avoid flattening of Diff::LCS::Change objects by limiting flattening to one level.