### PR TITLE
Fix errors when running JUnit reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
-* N/A
+* Fix Interceptor that was raising exception when calling `puts` on the wrapped stream ([#1445](https://github.com/cucumber/cucumber-ruby/issues/1445))
 
 ## [4.1.0](https://github.com/cucumber/cucumber-ruby/compare/v4.0.1...v4.1.0)
 

--- a/lib/cucumber/formatter/interceptor.rb
+++ b/lib/cucumber/formatter/interceptor.rb
@@ -5,6 +5,7 @@ module Cucumber
     module Interceptor
       class Pipe
         attr_reader :pipe
+
         def initialize(pipe)
           @pipe = pipe
           @buffer = StringIO.new
@@ -31,7 +32,8 @@ module Cucumber
         end
 
         def method_missing(method, *args, &blk)
-          @pipe.send(method, *args, &blk) || super
+          return @pipe.send(method, *args, &blk) if @pipe.respond_to?(method)
+          super
         end
 
         def respond_to_missing?(method, include_private = false)

--- a/lib/cucumber/formatter/interceptor.rb
+++ b/lib/cucumber/formatter/interceptor.rb
@@ -32,8 +32,7 @@ module Cucumber
         end
 
         def method_missing(method, *args, &blk)
-          return @pipe.send(method, *args, &blk) if @pipe.respond_to?(method)
-          super
+          @pipe.respond_to?(method) ? @pipe.send(method, *args, &blk) : super
         end
 
         def respond_to_missing?(method, include_private = false)

--- a/spec/cucumber/formatter/interceptor_spec.rb
+++ b/spec/cucumber/formatter/interceptor_spec.rb
@@ -124,5 +124,13 @@ module Cucumber::Formatter
         $stderr.methods.each { |m| expect(pi.respond_to?(m)).to be true }
       end
     end
+
+    describe 'when calling `puts` on the stream' do
+      it 'does not raise errors' do
+        wrapped = Interceptor::Pipe.wrap(:stderr)
+
+        expect { $stderr.puts('Oh, hi here !') }.not_to raise_exception(NoMethodError)
+      end
+    end
   end
 end

--- a/spec/cucumber/formatter/interceptor_spec.rb
+++ b/spec/cucumber/formatter/interceptor_spec.rb
@@ -125,11 +125,15 @@ module Cucumber::Formatter
       end
     end
 
-    describe 'when calling `puts` on the stream' do
+    describe 'when calling `methods` on the stream' do
       it 'does not raise errors' do
-        wrapped = Interceptor::Pipe.wrap(:stderr)
-
+        Interceptor::Pipe.wrap(:stderr)
         expect { $stderr.puts('Oh, hi here !') }.not_to raise_exception(NoMethodError)
+      end
+
+      it 'does not shadow errors when method do not exist on the stream' do
+        Interceptor::Pipe.wrap(:stderr)
+        expect { $stderr.not_really_puts('Oh, hi here !') }.to raise_exception(NoMethodError)
       end
     end
   end

--- a/spec/cucumber/formatter/interceptor_spec.rb
+++ b/spec/cucumber/formatter/interceptor_spec.rb
@@ -127,6 +127,8 @@ module Cucumber::Formatter
 
     describe 'when calling `methods` on the stream' do
       it 'does not raise errors' do
+        allow($stderr).to receive(:puts)
+
         Interceptor::Pipe.wrap(:stderr)
         expect { $stderr.puts('Oh, hi here !') }.not_to raise_exception(NoMethodError)
       end


### PR DESCRIPTION
See #1445 

The trouble came from `method_missing` in the interceptor which called `super` when the method called on the stream did not return a value.

This is a piece of code showing the same kind of issue:

```ruby
class FakePipe
  def no_return_value
    puts "No, I won't return anything"
  end

  def with_return_value
    puts "I let something here before returning a value"
    return 1
  end
end

class FakeInterceptor
  def initialize
    @pipe = FakePipe.new()
  end

  def method_missing(method, *args, &blk)
    @pipe.send(method, *args, &blk) || super
  end
end

interceptor = FakeInterceptor.new()
interceptor.with_return_value # calls  `with_return_value` on the fake stream and does not call super 
interceptor.no_return_value   # calls `no_return_value` on the fake stream, then `super` which fails.
```

I've check in the code and did not find other `method_missing` implementation which may show the same problem.