### PR TITLE
wip: removing the at_exit hook and explicitly closing ios inside formatters instead

### DIFF
--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -17,7 +17,11 @@ module Cucumber
 
       def output_envelope(envelope)
         @html_formatter.write_message(envelope)
-        @html_formatter.write_post_message if envelope.test_run_finished
+        if envelope.test_run_finished
+          @html_formatter.write_post_message
+          @io.flush
+          @io.close
+        end
       end
     end
   end

--- a/lib/cucumber/formatter/io.rb
+++ b/lib/cucumber/formatter/io.rb
@@ -20,12 +20,12 @@ module Cucumber
              else
                File.open(path_or_url_or_io, Cucumber.file_mode('w'))
              end
-        at_exit do
-          unless io.closed?
-            io.flush
-            io.close
-          end
-        end
+        # at_exit do
+        #   unless io.closed?
+        #     io.flush
+        #     io.close
+        #   end
+        # end
         io
       end
 

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -87,6 +87,8 @@ module Cucumber
 
       def on_test_run_finished(_event)
         @io.write(JSON.generate(@feature_hashes, pretty: true))
+        @io.flush
+        @io.close
       end
 
       def attach(src, mime_type)

--- a/lib/cucumber/formatter/message.rb
+++ b/lib/cucumber/formatter/message.rb
@@ -14,6 +14,13 @@ module Cucumber
         super(config)
       end
 
+      def on_test_run_finished(event)
+        super
+
+        @io.flush
+        @io.close
+      end
+
       def output_envelope(envelope)
         envelope.write_ndjson_to(@io)
       end

--- a/lib/cucumber/formatter/pretty.rb
+++ b/lib/cucumber/formatter/pretty.rb
@@ -136,6 +136,8 @@ module Cucumber
         print_comments(gherkin_source.split("\n").length, 0) unless current_feature_uri.empty?
         @io.puts
         print_summary
+        @io.flush
+        @io.close
       end
 
       def attach(src, media_type)

--- a/lib/cucumber/formatter/progress.rb
+++ b/lib/cucumber/formatter/progress.rb
@@ -74,6 +74,9 @@ module Cucumber
         @io.puts
         @io.puts
         print_summary
+
+        @io.flush
+        @io.close
       end
 
       private

--- a/lib/cucumber/formatter/rerun.rb
+++ b/lib/cucumber/formatter/rerun.rb
@@ -30,8 +30,9 @@ module Cucumber
         end
         config.on_event :test_run_finished do
           add_to_failures(@latest_failed_test_case) unless @latest_failed_test_case.nil?
-          next if @failures.empty?
-          @io.print file_failures.join("\n")
+          @io.print file_failures.join("\n") unless @failures.empty?
+          @io.flush
+          @io.close
         end
       end
 

--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'cucumber/formatter/spec_helper'
+require 'cucumber/formatter/html'
+require 'cucumber/cli/options'
+
+module Cucumber
+  module Formatter
+    describe HTML do
+      extend SpecHelperDsl
+      include SpecHelper
+
+      before(:each) do
+        @out = StringIO.new
+        @formatter = HTML.new(actual_runtime.configuration.with_options(out_stream: @out, source: false))
+      end
+
+      describe 'with a scenario' do
+        define_feature <<-FEATURE
+          Feature: Banana party
+
+            Scenario: Monkey eats banana
+              Given there are bananas
+        FEATURE
+
+        before(:each) do
+          run_defined_feature
+        end
+
+        it 'outputs html' do
+          expect(@out.string).to include '<!DOCTYPE html>'
+        end
+
+        it 'closes the html tag' do
+          expect(@out.string).to include '</html>'
+        end
+
+        it 'closes the stream' do
+          expect(@out).to be_closed
+        end
+      end
+    end
+  end
+end

--- a/spec/cucumber/formatter/json_spec.rb
+++ b/spec/cucumber/formatter/json_spec.rb
@@ -86,7 +86,7 @@ module Cucumber
                     [{"keyword": "Given ",
                       "name": "there are bananas",
                       "line": 4,
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:63"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:67"},
                       "result": {"status": "passed",
                                  "duration": 1}}]}]}]))
           end
@@ -123,9 +123,9 @@ module Cucumber
                     [{"keyword": "Given ",
                       "name": "there are bananas",
                       "line": 4,
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:100"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:104"},
                       "result": {"status": "failed",
-                                 "error_message": "no bananas (RuntimeError)\\n./spec/cucumber/formatter/json_spec.rb:100:in `/^there are bananas$/'\\nspec.feature:4:in `there are bananas'",
+                                 "error_message": "no bananas (RuntimeError)\\n./spec/cucumber/formatter/json_spec.rb:104:in `/^there are bananas$/'\\nspec.feature:4:in `there are bananas'",
                                  "duration": 1}}]}]}]})
           end
         end
@@ -161,9 +161,9 @@ module Cucumber
                     [{"keyword": "Given ",
                       "name": "there are bananas",
                       "line": 4,
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:138"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:142"},
                       "result": {"status": "pending",
-                                 "error_message": "TODO (Cucumber::Pending)\\n./spec/cucumber/formatter/json_spec.rb:138:in `/^there are bananas$/'\\nspec.feature:4:in `there are bananas'",
+                                 "error_message": "TODO (Cucumber::Pending)\\n./spec/cucumber/formatter/json_spec.rb:142:in `/^there are bananas$/'\\nspec.feature:4:in `there are bananas'",
                                  "duration": 1}}]}]}]})
           end
         end
@@ -203,7 +203,7 @@ module Cucumber
                     [{"keyword": "Given ",
                       "name": "there are bananas",
                       "line": 4,
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:180"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:184"},
                       "result": {"status": "passed",
                                  "duration": 1}}]}]}]))
           end
@@ -257,7 +257,7 @@ module Cucumber
                     [{"keyword": "Given ",
                       "name": "there are bananas",
                       "line": 6,
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:228"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:232"},
                       "result": {"status": "passed",
                                  "duration": 1}}]},
                    {"id": "banana-party;monkey-eats-bananas;fruit-table;2",
@@ -276,7 +276,7 @@ module Cucumber
                     [{"keyword": "Given ",
                       "name": "there are bananas",
                       "line": 10,
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:228"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:232"},
                       "result": {"status": "passed",
                                  "duration": 1}}]}]}]))
           end
@@ -331,7 +331,7 @@ module Cucumber
                     [{"keyword": "Given ",
                       "name": "there are bananas",
                       "line": 6,
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:308"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:312"},
                       "result": {"status": "passed",
                                  "duration": 1}}]},
                   {"id": "banana-party;monkey-eats-bananas",
@@ -344,7 +344,7 @@ module Cucumber
                     [{"keyword": "Then ",
                       "name": "the monkey eats bananas",
                       "line": 11,
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:309"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:313"},
                       "result": {"status": "passed",
                                  "duration": 1}}]},
                   {"keyword": "Background",
@@ -356,7 +356,7 @@ module Cucumber
                     [{"keyword": "Given ",
                       "name": "there are bananas",
                       "line": 6,
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:308"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:312"},
                       "result": {"status": "passed",
                                  "duration": 1}}]},
                    {"id": "banana-party;monkey-eats-bananas;fruit-table;2",
@@ -369,7 +369,7 @@ module Cucumber
                     [{"keyword": "Then ",
                       "name": "the monkey eats bananas",
                       "line": 16,
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:309"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:313"},
                       "result": {"status": "passed",
                                  "duration": 1}}]}]}]))
           end
@@ -412,7 +412,7 @@ module Cucumber
                       "doc_string": {"value": "the doc string",
                                      "content_type": "",
                                      "line": 5},
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:386"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:390"},
                       "result": {"status": "passed",
                                  "duration": 1}}]}]}]))
           end
@@ -450,7 +450,7 @@ module Cucumber
                       "name": "there are bananas",
                       "line": 4,
                       "output": ["from step"],
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:426"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:430"},
                       "result": {"status": "passed",
                                  "duration": 1}}]}]}]))
           end
@@ -561,7 +561,7 @@ module Cucumber
                       "line": 4,
                       "embeddings": [{"mime_type": "mime-type",
                                       "data": "YWJj"}],
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:536"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:540"},
                       "result": {"status": "passed",
                                  "duration": 1}}]}]}]))
           end
@@ -606,7 +606,7 @@ module Cucumber
                       "line": 4,
                       "embeddings": [{"mime_type": "image/png",
                                       "data": "Zm9v"}],
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:575"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:579"},
                       "result": {"status": "passed",
                                  "duration": 1}}]}]}]))
           end
@@ -647,31 +647,31 @@ module Cucumber
                    "description": "",
                    "type": "scenario",
                    "before":
-                    [{"match": {"location": "spec/cucumber/formatter/json_spec.rb:620"},
+                    [{"match": {"location": "spec/cucumber/formatter/json_spec.rb:624"},
                       "result": {"status": "passed",
                                  "duration": 1}},
-                     {"match": {"location": "spec/cucumber/formatter/json_spec.rb:621"},
+                     {"match": {"location": "spec/cucumber/formatter/json_spec.rb:625"},
                       "result": {"status": "passed",
                                  "duration": 1}}],
                    "steps":
                     [{"keyword": "Given ",
                       "name": "there are bananas",
                       "line": 4,
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:627"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:631"},
                       "result": {"status": "passed",
                                  "duration": 1},
                       "after":
-                       [{"match": {"location": "spec/cucumber/formatter/json_spec.rb:624"},
+                       [{"match": {"location": "spec/cucumber/formatter/json_spec.rb:628"},
                          "result": {"status": "passed",
                                     "duration": 1}},
-                        {"match": {"location": "spec/cucumber/formatter/json_spec.rb:625"},
+                        {"match": {"location": "spec/cucumber/formatter/json_spec.rb:629"},
                          "result": {"status": "passed",
                                     "duration": 1}}]}],
                    "after":
-                    [{"match": {"location": "spec/cucumber/formatter/json_spec.rb:623"},
+                    [{"match": {"location": "spec/cucumber/formatter/json_spec.rb:627"},
                       "result": {"status": "passed",
                                  "duration": 1}},
-                     {"match": {"location": "spec/cucumber/formatter/json_spec.rb:622"},
+                     {"match": {"location": "spec/cucumber/formatter/json_spec.rb:626"},
                       "result": {"status": "passed",
                                  "duration": 1}}]}]}]))
           end
@@ -712,13 +712,13 @@ module Cucumber
                     [{"keyword": "Given ",
                       "name": "there are bananas",
                       "line": 4,
-                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:689"},
+                      "match": {"location": "spec/cucumber/formatter/json_spec.rb:693"},
                       "result": {"status": "passed",
                                  "duration": 1}}],
                    "around":
                     [{"match": {"location": "unknown_hook_location:1"},
                       "result": {"status": "failed",
-                                 "error_message": "error (RuntimeError)\\n./spec/cucumber/formatter/json_spec.rb:687:in `Around'",
+                                 "error_message": "error (RuntimeError)\\n./spec/cucumber/formatter/json_spec.rb:691:in `Around'",
                                  "duration": 1}}]}]}]})
           end
         end
@@ -759,7 +759,7 @@ module Cucumber
                        "rows":
                          [{"cells": ["aa", "bb"]},
                           {"cells": ["cc", "dd"]}],
-                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:733"},
+                       "match": {"location": "spec/cucumber/formatter/json_spec.rb:737"},
                        "result": {"status": "passed",
                                   "duration": 1}}]}]}]))
           end

--- a/spec/cucumber/formatter/json_spec.rb
+++ b/spec/cucumber/formatter/json_spec.rb
@@ -19,6 +19,10 @@ module Cucumber
           run_defined_feature
         end
 
+        after(:each) do
+          expect(@out).to be_closed
+        end
+
         describe 'with a scenario with an undefined step' do
           define_feature <<-FEATURE
           Feature: Banana party

--- a/spec/cucumber/formatter/pretty_spec.rb
+++ b/spec/cucumber/formatter/pretty_spec.rb
@@ -18,6 +18,10 @@ module Cucumber
           @formatter = Pretty.new(actual_runtime.configuration.with_options(out_stream: @out, source: false))
         end
 
+        after(:each) do
+          expect(@out).to be_closed
+        end
+
         describe 'given a single feature' do
           before(:each) do
             run_defined_feature
@@ -44,7 +48,7 @@ module Cucumber
             define_feature <<-FEATURE
 Feature: Banana party
 
-  Background: 
+  Background:
     Given a tree
 
   Scenario: Monkey eats banana
@@ -296,18 +300,18 @@ OUTPUT
 
             it 'displays hook output appropriately ' do
               expect(@out.string).to include <<OUTPUT
-Feature: 
+Feature:
 
-  Scenario: 
+  Scenario:
       Before hook
     Given this step passes
       AfterStep hook
       After hook
 
-  Scenario Outline: 
+  Scenario Outline:
     Given this step <status>
 
-    Examples: 
+    Examples:
       | status |
       | passes |  Before hook, AfterStep hook, After hook
 
@@ -341,14 +345,14 @@ OUTPUT
 
             it 'displays hook output appropriately ' do
               expect(@out.string).to include <<OUTPUT
-Feature: 
+Feature:
 
-  Background: 
+  Background:
       Before hook
     Given this step passes
       AfterStep hook
 
-  Scenario: 
+  Scenario:
     Given this step passes
       AfterStep hook
       After hook
@@ -378,18 +382,18 @@ OUTPUT
             it 'includes the tags in the output ' do
               expect(@out.string).to include <<OUTPUT
 @tag1
-Feature: 
+Feature:
 
   @tag2
-  Scenario: 
+  Scenario:
     Given this step passes
 
   @tag3
-  Scenario Outline: 
+  Scenario Outline:
     Given this step passes
 
     @tag4
-    Examples: 
+    Examples:
       | dummy |
       | dummy |
 OUTPUT
@@ -426,27 +430,27 @@ OUTPUT
             it 'includes the all comments in the output' do
               expect(@out.string).to include <<OUTPUT
 #comment1
-Feature: 
+Feature:
 
   #comment2
-  Background: 
+  Background:
     #comment3
     Given this step passes
 
   #comment4
-  Scenario: 
+  Scenario:
     #comment5
     Given this step passes
       #comment6
       | dummy |
 
   #comment7
-  Scenario Outline: 
+  Scenario Outline:
     #comment8
     Given this step passes
 
     #comment9
-    Examples: 
+    Examples:
       #comment10
       | dummy |
       #comment11

--- a/spec/cucumber/formatter/pretty_spec.rb
+++ b/spec/cucumber/formatter/pretty_spec.rb
@@ -5,6 +5,7 @@ require 'cucumber/formatter/spec_helper'
 require 'cucumber/formatter/pretty'
 require 'cucumber/cli/options'
 
+# rubocop:disable Lint/LiteralInInterpolation
 module Cucumber
   module Formatter
     describe Pretty do
@@ -48,7 +49,7 @@ module Cucumber
             define_feature <<-FEATURE
 Feature: Banana party
 
-  Background:
+  Background:#{' '}
     Given a tree
 
   Scenario: Monkey eats banana
@@ -300,18 +301,18 @@ OUTPUT
 
             it 'displays hook output appropriately ' do
               expect(@out.string).to include <<OUTPUT
-Feature:
+Feature:#{' '}
 
-  Scenario:
+  Scenario:#{' '}
       Before hook
     Given this step passes
       AfterStep hook
       After hook
 
-  Scenario Outline:
+  Scenario Outline:#{' '}
     Given this step <status>
 
-    Examples:
+    Examples:#{' '}
       | status |
       | passes |  Before hook, AfterStep hook, After hook
 
@@ -345,14 +346,14 @@ OUTPUT
 
             it 'displays hook output appropriately ' do
               expect(@out.string).to include <<OUTPUT
-Feature:
+Feature:#{' '}
 
-  Background:
+  Background:#{' '}
       Before hook
     Given this step passes
       AfterStep hook
 
-  Scenario:
+  Scenario:#{' '}
     Given this step passes
       AfterStep hook
       After hook
@@ -382,18 +383,18 @@ OUTPUT
             it 'includes the tags in the output ' do
               expect(@out.string).to include <<OUTPUT
 @tag1
-Feature:
+Feature:#{' '}
 
   @tag2
-  Scenario:
+  Scenario:#{' '}
     Given this step passes
 
   @tag3
-  Scenario Outline:
+  Scenario Outline:#{' '}
     Given this step passes
 
     @tag4
-    Examples:
+    Examples:#{' '}
       | dummy |
       | dummy |
 OUTPUT
@@ -430,27 +431,27 @@ OUTPUT
             it 'includes the all comments in the output' do
               expect(@out.string).to include <<OUTPUT
 #comment1
-Feature:
+Feature:#{' '}
 
   #comment2
-  Background:
+  Background:#{' '}
     #comment3
     Given this step passes
 
   #comment4
-  Scenario:
+  Scenario:#{' '}
     #comment5
     Given this step passes
       #comment6
       | dummy |
 
   #comment7
-  Scenario Outline:
+  Scenario Outline:#{' '}
     #comment8
     Given this step passes
 
     #comment9
-    Examples:
+    Examples:#{' '}
       #comment10
       | dummy |
       #comment11
@@ -950,3 +951,4 @@ OUTPUT
     end
   end
 end
+# rubocop:enable Lint/LiteralInInterpolation

--- a/spec/cucumber/formatter/progress_spec.rb
+++ b/spec/cucumber/formatter/progress_spec.rb
@@ -17,6 +17,10 @@ module Cucumber
         @formatter = Progress.new(actual_runtime.configuration.with_options(out_stream: @out))
       end
 
+      after(:each) do
+        expect(@out).to be_closed
+      end
+
       describe 'given a single feature' do
         before(:each) do
           run_defined_feature
@@ -39,7 +43,7 @@ module Cucumber
           define_feature <<-FEATURE
             Feature: Banana party
 
-              Background: 
+              Background:
                 Given a tree
 
               Scenario: Monkey eats banana

--- a/spec/cucumber/formatter/rerun_spec.rb
+++ b/spec/cucumber/formatter/rerun_spec.rb
@@ -16,6 +16,10 @@ module Cucumber
       let(:config) { Cucumber::Configuration.new(out_stream: io) }
       let(:io) { StringIO.new }
 
+      after(:each) do
+        expect(io).to be_closed
+      end
+
       # after_test_case
       context 'when 2 scenarios fail in the same file' do
         it 'Prints the locations of the failed scenarios' do

--- a/spec/cucumber/formatter/spec_helper.rb
+++ b/spec/cucumber/formatter/spec_helper.rb
@@ -33,6 +33,7 @@ module Cucumber
           Filters::ApplyBeforeHooks.new(actual_runtime.support_code),
           Filters::ApplyAfterHooks.new(actual_runtime.support_code),
           Filters::ApplyAroundHooks.new(actual_runtime.support_code),
+          Filters::BroadcastTestCaseReadyEvent.new(actual_runtime.configuration),
           Filters::PrepareWorld.new(actual_runtime)
         ]
         event_bus.gherkin_source_read(gherkin_doc.uri, gherkin_doc.body)


### PR DESCRIPTION
when io is close at_exit when doing --publish, then the HttpIo is
pushing the report. This should not be pushed if an error occurs, like
the feature file does not exist. Hence this removal.

Co-authored-by: Aslak Hellesøy <aslak.hellesoy@smartbear.com>
Co-authored-by: Seb Rose <seb.rose@smartbear.com>
