### PR TITLE
Defer at exit io close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
+* Defer registration of `at_exit` hook that flushes and closes formatter streams
+  ([#1458](https://github.com/cucumber/cucumber-ruby/pull/1458))
 * Fix Interceptor that was raising exception when calling `puts` on the wrapped stream ([#1445](https://github.com/cucumber/cucumber-ruby/issues/1445))
 
 ## [4.1.0](https://github.com/cucumber/cucumber-ruby/compare/v4.0.1...v4.1.0)

--- a/lib/cucumber/formatter/http_io.rb
+++ b/lib/cucumber/formatter/http_io.rb
@@ -76,7 +76,7 @@ module Cucumber
       end
 
       def close
-        resource_uri = put_content(@uri, @method, @headers)
+        resource_uri = send_content(@uri, @method, @headers)
 
         @reporter.report(resource_uri)
         @write_io.close
@@ -96,7 +96,7 @@ module Cucumber
 
       private
 
-      def put_content(uri, method, headers, attempt = 10)
+      def send_content(uri, method, headers, attempt = 10)
         content = @write_io
         http = build_client(uri, @https_verify_mode)
 
@@ -123,7 +123,7 @@ module Cucumber
         when Net::HTTPSuccess
           uri
         when Net::HTTPRedirection
-          put_content(URI(response['Location']), method, headers, attempt - 1)
+          send_content(URI(response['Location']), method, headers, attempt - 1)
         else
           raise StandardError, "request to #{uri} failed with status #{response.code}"
         end

--- a/lib/cucumber/formatter/io.rb
+++ b/lib/cucumber/formatter/io.rb
@@ -9,6 +9,8 @@ module Cucumber
     module Io
       module_function
 
+      attr_reader :ios
+
       def ensure_io(path_or_url_or_io)
         return nil if path_or_url_or_io.nil?
         io = if io?(path_or_url_or_io)
@@ -20,6 +22,7 @@ module Cucumber
              else
                File.open(path_or_url_or_io, Cucumber.file_mode('w'))
              end
+        @ios ||= []
         @ios.push(io)
         io
       end
@@ -33,16 +36,20 @@ module Cucumber
 
       module ClassMethods
         def new(*args, &block)
-          super
+          instance = super
+
           config = args[0]
-          config.on_event :test_run_finished do
-            print 'something'
+          if config.respond_to? :on_event
+            config.on_event :test_run_finished do
+              puts "#### #{instance.ios}"
+            end
           end
+
+          instance
         end
       end
 
       def self.included(formatter_class)
-        puts 'included'
         formatter_class.extend(ClassMethods)
       end
 

--- a/lib/cucumber/formatter/io.rb
+++ b/lib/cucumber/formatter/io.rb
@@ -11,9 +11,9 @@ module Cucumber
 
       def ensure_io(path_or_url_or_io)
         return nil if path_or_url_or_io.nil?
-        io = if io?(path_or_url_or_io)
-               path_or_url_or_io
-             elsif url?(path_or_url_or_io)
+        return path_or_url_or_io if io?(path_or_url_or_io)
+
+        io = if url?(path_or_url_or_io)
                url = path_or_url_or_io
                reporter = url.start_with?(Cucumber::Cli::Options::CUCUMBER_PUBLISH_URL) ? URLReporter.new($stdout) : NoReporter.new
                HTTPIO.open(url, nil, reporter)

--- a/spec/cucumber/formatter/http_io_spec.rb
+++ b/spec/cucumber/formatter/http_io_spec.rb
@@ -81,21 +81,32 @@ end
 
 module Cucumber
   module Formatter
+    class DummyFormatter
+      include Io
+
+      def initialize(config = nil)
+      end
+
+      def ensure_io(path_or_url_or_io)
+        super
+      end
+    end
+
     describe HTTPIO do
       include_context 'an HTTP server accepting file requests'
-      include Io
 
       context 'created by Io#ensure_io' do
         it 'returns a IOHTTPBuffer' do
+
           url = start_server
-          io = ensure_io("#{url}/s3 -X PUT")
+          io = DummyFormatter.new.ensure_io("#{url}/s3 -X PUT")
           expect(io).to be_a(Cucumber::Formatter::IOHTTPBuffer)
           io.close # Close during the test so the request is done while server still runs
         end
 
         it 'uses CurlOptionParser to pass correct options to IOHTTPBuffer' do
           url = start_server
-          io = ensure_io("#{url}/s3 -X GET -H 'Content-Type: text/json'")
+          io = DummyFormatter.new.ensure_io("#{url}/s3 -X GET -H 'Content-Type: text/json'")
 
           expect(io.uri).to eq(URI("#{url}/s3"))
           expect(io.method).to eq('GET')

--- a/spec/cucumber/formatter/http_io_spec.rb
+++ b/spec/cucumber/formatter/http_io_spec.rb
@@ -84,8 +84,7 @@ module Cucumber
     class DummyFormatter
       include Io
 
-      def initialize(config = nil)
-      end
+      def initialize(config = nil); end
 
       def ensure_io(path_or_url_or_io)
         super
@@ -97,7 +96,6 @@ module Cucumber
 
       context 'created by Io#ensure_io' do
         it 'returns a IOHTTPBuffer' do
-
           url = start_server
           io = DummyFormatter.new.ensure_io("#{url}/s3 -X PUT")
           expect(io).to be_a(Cucumber::Formatter::IOHTTPBuffer)


### PR DESCRIPTION
Prior to this change, all `IO` objects created by `ensure_io` would be flushed and closed when Ruby exits.

This turned out to be a problem for the new `--publish` functionality if Cucumber raised an exception.

One case where Cucumber will raise an exception (and not run anything) is when it's passed a non-existent feature file. It might also raise exceptions in other cases, for example when a feature file has syntax errors.

In those cases (where cucumber doesn't run anything), we don't want to publish any reports! However, since formatters (and their streams) are created *before* the exceptions described above are raised, it would already have registered the `at_exit` hooks that flush and close the streams (which in the case of `--publish` will publish a report).

The fix is to *defer* the registration of the `at_exit` hook which flushes and closes until we can be sure Cucumber isn't going to raise an error. If Cucumber raises an exception, the `at_exit` hook won't have been registered.

This change should preserve backwards compatibility.