### PR TITLE
Update CI, remove support for unsupported rubies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
 
   build_monorepo:
     docker:
-      - image: cucumber/cucumber-build:889c9aabdae3f09025837b97c358d10a
+      - image: cucumber/cucumber-build:latest
     working_directory: ~
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,24 +64,6 @@ jobs:
             bundle exec rspec
             bundle exec cucumber
 
-  build-ruby-2_3:
-    docker:
-      - image: circleci/ruby:2.3
-
-    working_directory: ~/repo
-    steps:
-      - build
-      - test
-
-  build-ruby-2_4:
-    docker:
-      - image: circleci/ruby:2.4
-
-    working_directory: ~/repo
-    steps:
-      - build
-      - test
-
   build-ruby-2_5:
     docker:
       - image: circleci/ruby:2.5
@@ -94,6 +76,15 @@ jobs:
   build-ruby-2_6:
     docker:
       - image: circleci/ruby:2.6
+
+    working_directory: ~/repo
+    steps:
+      - build
+      - test
+
+  build-ruby-2_7:
+    docker:
+      - image: circleci/ruby:2.7
 
     working_directory: ~/repo
     steps:
@@ -126,7 +117,7 @@ jobs:
       - run:
           name: Checkout monorepo and build
           command: |
-            git clone https://github.com/cucumber/cucumber.git --branch messages/v12.1.1 ~/cucumber
+            git clone https://github.com/cucumber/cucumber.git ~/cucumber
             cd ~/cucumber
             NO_CROSS_COMPILE=1 LANGUAGES=go PACKAGES="messages json-formatter" make
       - persist_to_workspace:
@@ -137,7 +128,7 @@ jobs:
 
   validate-cck:
     docker:
-      - image: cucumber/cucumber-build:889c9aabdae3f09025837b97c358d10a
+      - image: cucumber/cucumber-build:latest
     working_directory: ~/repo
     steps:
       - attach_workspace:
@@ -155,7 +146,7 @@ jobs:
 
   validate-messages:
     docker:
-      - image: cucumber/cucumber-build:889c9aabdae3f09025837b97c358d10a
+      - image: cucumber/cucumber-build:latest
     working_directory: ~/repo
     steps:
       - attach_workspace:
@@ -184,18 +175,16 @@ workflows:
                 - master
 
     jobs:
-      - build-ruby-2_3
-      - build-ruby-2_4
       - build-ruby-2_5
       - build-ruby-2_6
+      - build-ruby-2_7
 
   build:
     jobs:
       - build_windows
-      - build-ruby-2_3
-      - build-ruby-2_4
       - build-ruby-2_5
       - build-ruby-2_6
+      - build-ruby-2_7
       - build-ruby-latest
       - build-jruby-9_2
       - build_monorepo


### PR DESCRIPTION
This removes support for Ruby 2.3 and 2.4 as they are now unsupported ruby versions.

This does not mean Cucumber won't work on those rubies. It just means we no longer verify that it does. The reason for this is that some gems we depend on require ruby >= 2.5.