### PR TITLE
Issue a PUT request after a GET request responding with 202 and a Location header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Added
 
+* `-X GET` in an `--out` URL will now issue a `GET` request *without* a body. If the response is `202 Accepted` *and*
+  the `Location` header is present, a new `PUT` request will be sent *with* the body.
+  
+  The main reason for this added behaviour is to allow request bodies larger than 6Mb to be sent while using `--publish`.
+  This also improves performance since the request body is only sent once (previously it would be sent twice).
+
 ### Changed
 
 ### Removed

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -9,7 +9,7 @@ require 'cucumber/core/test/result'
 module Cucumber
   module Cli
     class Options
-      CUCUMBER_PUBLISH_URL = ENV['CUCUMBER_PUBLISH_URL'] || 'https://messages.cucumber.io/api/reports'
+      CUCUMBER_PUBLISH_URL = ENV['CUCUMBER_PUBLISH_URL'] || 'https://messages.cucumber.io/api/reports -X GET'
       INDENT = ' ' * 53
       BUILTIN_FORMATS = {
         'pretty'      => ['Cucumber::Formatter::Pretty',      'Prints the feature as is - in colours.'],

--- a/lib/cucumber/formatter/http_io.rb
+++ b/lib/cucumber/formatter/http_io.rb
@@ -121,6 +121,8 @@ module Cucumber
 
         case response
         when Net::HTTPAccepted
+          return uri unless response['Location']
+
           send_content(URI(response['Location']), 'PUT', headers, attempt - 1)
         when Net::HTTPSuccess
           uri

--- a/lib/cucumber/formatter/http_io.rb
+++ b/lib/cucumber/formatter/http_io.rb
@@ -97,7 +97,7 @@ module Cucumber
       private
 
       def send_content(uri, method, headers, attempt = 10)
-        content = @write_io
+        content = (method == 'GET' ? StringIO.new : @write_io)
         http = build_client(uri, @https_verify_mode)
 
         raise StandardError, "request to #{uri} failed (too many redirections)" if attempt <= 0

--- a/lib/cucumber/formatter/http_io.rb
+++ b/lib/cucumber/formatter/http_io.rb
@@ -120,6 +120,8 @@ module Cucumber
         end
 
         case response
+        when Net::HTTPAccepted
+          send_content(URI(response['Location']), 'PUT', headers, attempt - 1)
         when Net::HTTPSuccess
           uri
         when Net::HTTPRedirection

--- a/spec/cucumber/formatter/http_io_spec.rb
+++ b/spec/cucumber/formatter/http_io_spec.rb
@@ -51,10 +51,17 @@ RSpec.shared_context 'an HTTP server accepting file requests' do
     @server.mount_proc '/putreport' do |_req, res|
       @request_count += 1
       IO.copy_stream(_req.body_reader, @received_body_io)
-      res.set_redirect(
-        WEBrick::HTTPStatus::TemporaryRedirect,
-        '/s3'
-      )
+
+      if (_req.method == 'GET')
+
+      else
+        res.set_redirect(
+            WEBrick::HTTPStatus::TemporaryRedirect,
+            '/s3'
+        )
+      end
+
+
     end
 
     @server.mount_proc '/loop_redirect' do |_req, res|

--- a/spec/cucumber/formatter/http_io_spec.rb
+++ b/spec/cucumber/formatter/http_io_spec.rb
@@ -51,17 +51,16 @@ RSpec.shared_context 'an HTTP server accepting file requests' do
     @server.mount_proc '/putreport' do |_req, res|
       @request_count += 1
       IO.copy_stream(_req.body_reader, @received_body_io)
-
-      if (_req.method == 'GET')
-
+      if _req.request_method == 'GET'
+        res.status = 202 # Accepted
+        res.header['location'] = URI('/s3').to_s
+        res.body = ''
       else
         res.set_redirect(
             WEBrick::HTTPStatus::TemporaryRedirect,
             '/s3'
         )
       end
-
-
     end
 
     @server.mount_proc '/loop_redirect' do |_req, res|

--- a/spec/cucumber/formatter/http_io_spec.rb
+++ b/spec/cucumber/formatter/http_io_spec.rb
@@ -50,10 +50,10 @@ RSpec.shared_context 'an HTTP server accepting file requests' do
       res.status = 404
     end
 
-    @server.mount_proc '/putreport' do |_req, res|
+    @server.mount_proc '/putreport' do |req, res|
       @request_count += 1
-      IO.copy_stream(_req.body_reader, @received_body_io)
-      if _req.request_method == 'GET'
+      IO.copy_stream(req.body_reader, @received_body_io)
+      if req.request_method == 'GET'
         res.status = 202 # Accepted
         res.header['location'] = putreport_returned_location if putreport_returned_location
         res.body = ''


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

Doing a PUT directly and following redirects has issues as the body gets sent several times: once for initial request, and once for subsequent redirects. The initial request should be sent without any body and only the last one should contain the body.

**Describe the solution you have implemented**

Setting `--out 'url -X GET'` will request the given url with GET method, following redirects. If the response is a 202 Accepted *and* it has a Location HTTP header, then the payload is sent with a PUT request to the given location.

This approach is also a workaround for the limitation of Lambda payload size of 6 MB.