### PR TITLE
Use cucumber-create-meta > 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
+### Security fixes
+
+* Update `cucumber-create-meta` to 2.0.2
+
 ## [5.1.0](https://github.com/cucumber/cucumber-ruby/compare/v5.0.0...5.1.0)
 
 ### Added

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5'
   s.add_dependency 'builder', '~> 3.2', '>= 3.2.4'
   s.add_dependency 'cucumber-core', '~> 8.0', '>= 8.0.1'
-  s.add_dependency 'cucumber-create-meta', '~> 2.0', '>= 2.0.1'
+  s.add_dependency 'cucumber-create-meta', '~> 2.0', '>= 2.0.2'
   s.add_dependency 'cucumber-cucumber-expressions', '~> 10.3', '>= 10.3.0'
   s.add_dependency 'cucumber-gherkin', '~> 15.0', '>= 15.0.2'
   s.add_dependency 'cucumber-html-formatter', '~> 9.0', '>= 9.0.0'


### PR DESCRIPTION
This follows  [cucumber#1168](https://github.com/cucumber/cucumber/pull/1168)
There is a security issue involved which was fixed by `cucumber-ruby-meta` 2.0.2, this change ensures we use the fixed version.