### PR TITLE
Add optional file attribute to junit formatter

### DIFF
--- a/features/docs/formatters/junit_formatter.feature
+++ b/features/docs/formatters/junit_formatter.feature
@@ -114,6 +114,47 @@ Feature: JUnit output formatter
 
       """
 
+  Scenario: one feature, one passing scenario, one failing scenario, add file attribute
+    When I run `cucumber --format junit,fileattribute=true --out tmp/ features/one_passing_one_failing.feature`
+    Then it should fail with:
+      """
+
+      """
+    And the junit output file "tmp/TEST-features-one_passing_one_failing.xml" should contain:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuite failures="1" errors="0" skipped="0" tests="2" time="0.05" name="One passing scenario, one failing scenario">
+      <testcase classname="One passing scenario, one failing scenario" name="Passing" time="0.05" file="features/one_passing_one_failing.feature">
+        <system-out>
+          <![CDATA[]]>
+        </system-out>
+        <system-err>
+          <![CDATA[]]>
+        </system-err>
+      </testcase>
+      <testcase classname="One passing scenario, one failing scenario" name="Failing" time="0.05" file="features/one_passing_one_failing.feature">
+        <failure message="failed Failing" type="failed">
+          <![CDATA[Scenario: Failing
+
+      Given this step fails
+
+      Message:
+      ]]>
+          <![CDATA[ (RuntimeError)
+      ./features/step_definitions/steps.rb:4:in `/^this step fails$/'
+      features/one_passing_one_failing.feature:7:in `this step fails']]>
+        </failure>
+        <system-out>
+          <![CDATA[]]>
+        </system-out>
+        <system-err>
+          <![CDATA[]]>
+        </system-err>
+      </testcase>
+      </testsuite>
+
+      """
+
   Scenario: one feature in a subdirectory, one passing scenario, one failing scenario
     When I run `cucumber --format junit --out tmp/ features/some_subdirectory/one_passing_one_failing.feature --require features`
     Then it should fail with:
@@ -175,6 +216,38 @@ Feature: JUnit output formatter
         </system-err>
       </testcase>
       <testcase classname="Pending step" name="Undefined" time="0.05">
+        <skipped/>
+        <system-out>
+          <![CDATA[]]>
+        </system-out>
+        <system-err>
+          <![CDATA[]]>
+        </system-err>
+      </testcase>
+      </testsuite>
+
+      """
+
+  Scenario: pending and undefined steps add fileattribute
+    When I run `cucumber --format junit,fileattribute=true --out tmp/ features/pending.feature`
+    Then it should pass with:
+      """
+
+      """
+    And the junit output file "tmp/TEST-features-pending.xml" should contain:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuite failures="0" errors="0" skipped="2" tests="2" time="0.05" name="Pending step">
+      <testcase classname="Pending step" name="Pending" time="0.05" file="features/pending.feature">
+        <skipped/>
+        <system-out>
+          <![CDATA[]]>
+        </system-out>
+        <system-err>
+          <![CDATA[]]>
+        </system-err>
+      </testcase>
+      <testcase classname="Pending step" name="Undefined" time="0.05" file="features/pending.feature">
         <skipped/>
         <system-out>
           <![CDATA[]]>

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -22,7 +22,8 @@ module Cucumber
                                                               "#{INDENT}filename instead."],
         'stepdefs'    => ['Cucumber::Formatter::Stepdefs',    "Prints All step definitions with their locations. Same as\n" \
                                                               "#{INDENT}the usage formatter, except that steps are not printed."],
-        'junit'       => ['Cucumber::Formatter::Junit',       'Generates a report similar to Ant+JUnit.'],
+        'junit'       => ['Cucumber::Formatter::Junit',       "Generates a report similar to Ant+JUnit. Use\n" \
+                                                              "#{INDENT}junit,fileattribute=true to include a file attribute."],
         'json'        => ['Cucumber::Formatter::Json',        '[DEPRECATED] Prints the feature as JSON'],
         'message'     => ['Cucumber::Formatter::Message',     'Outputs protobuf messages'],
         'html'        => ['Cucumber::Formatter::HTML',        'Outputs HTML report'],

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -156,8 +156,8 @@ module Cucumber
           @current_feature_data[:builder].tag!('system-err') do
             @current_feature_data[:builder].cdata! strip_control_chars(@interceptederr.buffer_string)
           end
-          @current_feature_data[:tests] += 1
         end
+        @current_feature_data[:tests] += 1
       end
 
       def get_testcase_attributes(classname, name, duration, filename)

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -161,17 +161,16 @@ module Cucumber
       end
 
       def get_testcase_attributes(classname, name, duration, filename)
-        attributes = { classname: classname, name: name, time: format('%<duration>.6f', duration: duration) }
-        attributes[:file] = filename if add_fileattribute?
-
-        attributes
+        { classname: classname, name: name, time: format('%<duration>.6f', duration: duration) }.tap do |attributes|
+          attributes[:file] = filename if add_fileattribute?
+        end
       end
 
       def add_fileattribute?
         return false if @config.formats.nil? || @config.formats.empty?
 
         !!@config.formats.find do |format|
-          format[0] == 'junit' and format.dig(1, 'fileattribute') == 'true'
+          format.first == 'junit' && format.dig(1, 'fileattribute') == 'true'
         end
       end
 

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -135,8 +135,9 @@ module Cucumber
         filename = @current_feature_data[:uri]
         name = scenario_designation
 
-        testcase_arguments = get_testcase_arguments(classname, name, duration, filename)
-        @current_feature_data[:builder].testcase(testcase_arguments) do
+        testcase_attributes = get_testcase_attributes(classname, name, duration, filename)
+
+        @current_feature_data[:builder].testcase(testcase_attributes) do
           if !result.passed? && result.ok?(@config.strict)
             @current_feature_data[:builder].skipped
             @current_feature_data[:skipped] += 1
@@ -159,14 +160,16 @@ module Cucumber
         end
       end
 
-      def get_testcase_arguments(classname, name, duration, filename)
-        arguments = { classname: classname, name: name, time: format('%<duration>.6f', duration: duration) }
-        arguments[:file] = filename if should_add_fileattribute?
+      def get_testcase_attributes(classname, name, duration, filename)
+        attributes = { classname: classname, name: name, time: format('%<duration>.6f', duration: duration) }
+        attributes[:file] = filename if add_fileattribute?
 
-        arguments
+        attributes
       end
 
-      def should_add_fileattribute?
+      def add_fileattribute?
+        return false if @config.formats.nil? || @config.formats.empty?
+
         !!@config.formats.find do |format|
           format[0] == 'junit' and format.dig(1, 'fileattribute') == 'true'
         end

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -118,6 +118,18 @@ module Cucumber
               expect(options[:formats]).to eq [['pretty', { 'foo' => 'bar', 'foo2' => 'bar2' }, output_stream]]
             end
           end
+
+          it 'extracts junit formatter file attribute option' do
+            after_parsing('-f junit,file-attribute=true') do
+              expect(options[:formats]).to eq [['junit', { 'file-attribute' => 'true' }, output_stream]]
+            end
+          end
+
+          it 'extracts junit formatter file attribute option with pretty' do
+            after_parsing('-f pretty -f junit,file-attribute=true -o file.txt') do
+              expect(options[:formats]).to eq [['pretty', {}, output_stream], ['junit', { 'file-attribute' => 'true' }, 'file.txt']]
+            end
+          end
         end
 
         context '-o [FILE|DIR] or --out [FILE|DIR]' do

--- a/spec/cucumber/formatter/junit_spec.rb
+++ b/spec/cucumber/formatter/junit_spec.rb
@@ -39,6 +39,107 @@ module Cucumber
         end
       end
 
+      context 'With --junit,fileattribute=true option' do
+        before(:each) do
+          allow(File).to receive(:directory?) { true }
+          @formatter = TestDoubleJunitFormatter.new(
+            actual_runtime.configuration.with_options(
+              out_stream: '',
+              formats: [['junit', { 'fileattribute' => 'true' }]]
+            )
+          )
+        end
+        describe 'includes the file' do
+          before(:each) do
+            run_defined_feature
+            @doc = Nokogiri.XML(@formatter.written_files.values.first)
+          end
+
+          define_steps do
+            Given(/a passing scenario/) do
+              Kernel.puts 'foo'
+            end
+          end
+
+          define_feature <<-FEATURE
+              Feature: One passing feature
+
+                Scenario: Passing
+                  Given a passing scenario
+          FEATURE
+
+          it 'will contain the file attribute' do
+            expect(@doc.xpath('//testsuite/testcase/@file').size).to equal 1
+            expect(@doc.xpath('//testsuite/testcase/@file').first.value).to eq('spec.feature')
+          end
+        end
+      end
+
+      context 'With --junit,fileattribute=different option' do
+        before(:each) do
+          allow(File).to receive(:directory?) { true }
+          @formatter = TestDoubleJunitFormatter.new(
+            actual_runtime.configuration.with_options(
+              out_stream: '',
+              formats: [['junit', { 'fileattribute' => 'different' }]]
+            )
+          )
+        end
+        describe 'includes the file' do
+          before(:each) do
+            run_defined_feature
+            @doc = Nokogiri.XML(@formatter.written_files.values.first)
+          end
+
+          define_steps do
+            Given(/a passing scenario/) do
+              Kernel.puts 'foo'
+            end
+          end
+
+          define_feature <<-FEATURE
+              Feature: One passing feature
+
+                Scenario: Passing
+                  Given a passing scenario
+          FEATURE
+
+          it 'will not contain the file attribute' do
+            expect(@doc.xpath('//testsuite/testcase/@file').size).to equal 0
+          end
+        end
+      end
+
+      context 'With --junit no fileattribute option' do
+        before(:each) do
+          allow(File).to receive(:directory?) { true }
+          @formatter = TestDoubleJunitFormatter.new(actual_runtime.configuration.with_options(out_stream: ''))
+        end
+        describe 'includes the file' do
+          before(:each) do
+            run_defined_feature
+            @doc = Nokogiri.XML(@formatter.written_files.values.first)
+          end
+
+          define_steps do
+            Given(/a passing scenario/) do
+              Kernel.puts 'foo'
+            end
+          end
+
+          define_feature <<-FEATURE
+              Feature: One passing scenario
+
+                Scenario: Passing
+                  Given a passing scenario
+          FEATURE
+
+          it 'will not contain the file attribute' do
+            expect(@doc.xpath('//testsuite/testcase/@file').size).to equal 0
+          end
+        end
+      end
+
       context 'With no options' do
         before(:each) do
           allow(File).to receive(:directory?) { true }


### PR DESCRIPTION
Add optional file attribute to junit formatter

* Allow for adding `file=` attribute to junit
* Use cli arg `-f junit,fileattribute=true`

**Is your pull request related to a problem? Please describe.**
CircleCI has a test splitting feature that will split tests across multiple jobs based on the time spent. This feature requires a `file` attribute to be added. The cucumber-ruby test junit formatter does not include this attribute.

**Describe the solution you have implemented**
This adds a `-f junit,fileattribute=true` cli option that will add the `file` attribute to the `<testcase/>` elements in the junit formatter. By default, all junit formatter output will be unchanged unless this additional option is added.

**Additional context**
This is a continuation of Pull Request #1457
The `junit,fileattribute=true` was based on the conventions already in use, but I am more than happy to change that to something else if you feel there is a more appropriate way. This is my first submission to this project, so my apologies in advance if I missed anything and more than happy to make any adjustments or changes that you might feel will be easier to maintain etc. Thank you for your work on the project. I very much appreciate it!
Closes #1457