### PR TITLE
Include response body when --publish errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Changed
 
+* `--publish` request errors now include the response's body in the error message
+
 ### Removed
 
 ### Deprecated

--- a/lib/cucumber/formatter/http_io.rb
+++ b/lib/cucumber/formatter/http_io.rb
@@ -125,7 +125,7 @@ module Cucumber
         when Net::HTTPRedirection
           send_content(URI(response['Location']), method, headers, attempt - 1)
         else
-          raise StandardError, "request to #{uri} failed with status #{response.code}"
+          raise StandardError, "request to #{uri} failed with status #{response.code}: #{response.body}"
         end
       end
 

--- a/spec/cucumber/formatter/http_io_spec.rb
+++ b/spec/cucumber/formatter/http_io_spec.rb
@@ -56,6 +56,7 @@ RSpec.shared_context 'an HTTP server accepting file requests' do
       @request_count += 1
       @received_headers << req.header
       res.status = 404
+      res.body = 'Not found'
     end
 
     @server.mount_proc '/putreport' do |req, res|
@@ -222,7 +223,7 @@ module Cucumber
       it 'raises an error on close when server in unreachable' do
         io = IOHTTPBuffer.new("#{url}/404", 'PUT')
 
-        expect { io.close }.to(raise_error("request to #{url}/404 failed with status 404"))
+        expect { io.close }.to(raise_error("request to #{url}/404 failed with status 404: Not found"))
       end
 
       it 'raises an error on close when the server is unreachable' do


### PR DESCRIPTION
A small improvement re: #1473 

Simply includes the response's body in the error message.

Here's an example:

```
$ # before
$ CUCUMBER_PUBLISH_URL="http://localhost:4567/422 -X GET" be cucumber --publish
Traceback (most recent call last):
	2: from /home/jmks/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/cucumber-5.1.3/lib/cucumber/formatter/io.rb:40:in `block (3 levels) in new'
	1: from /home/jmks/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/cucumber-5.1.3/lib/cucumber/formatter/http_io.rb:75:in `close'
/home/jmks/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/cucumber-5.1.3/lib/cucumber/formatter/http_io.rb:128:in `send_content': request to http://localhost:4567/422 failed with status 422 (StandardError)

$ # after
$ CUCUMBER_PUBLISH_URL="http://localhost:4567/422 -X GET" be cucumber --publish
Traceback (most recent call last):
	2: from ~/src/cucumber-ruby/lib/cucumber/formatter/io.rb:40:in `block (3 levels) in new'
	1: from ~/src/cucumber-ruby/lib/cucumber/formatter/http_io.rb:75:in `close'
~/src/cucumber-ruby/lib/cucumber/formatter/http_io.rb:128:in `send_content': request to http://localhost:4567/422 failed with status 422: you did something wrong (StandardError)
```

from the "server":

```ruby
require "sinatra"

get "/422" do
  [422, "you did something wrong"]
end
```