### PR TITLE
Fix typo in help output

### DIFF
--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -335,7 +335,7 @@ Specify SEED to reproduce the shuffling from a previous run.
           'option is specified; all loading becomes explicit.',
           'Files in directories named "support" are still always',
           'loaded first when their parent directories are',
-          'required or if the "support" directoires themselves are',
+          'required or if the "support" directories themselves are',
           'explicitly required.',
           'This option can be specified multiple times.'
         ]


### PR DESCRIPTION
Fixes a tiny typo, which my eye stumbles upon on any cucumber --help call.