### PR TITLE
Restore ability to specify a line number within a scenario.

### DIFF
--- a/features/docs/cli/run_specific_scenarios.feature
+++ b/features/docs/cli/run_specific_scenarios.feature
@@ -74,3 +74,58 @@ Feature: Run specific scenarios
       """
       F.
       """
+
+  Scenario: Specify any line number of a scenario
+    Given a file named "features/test.feature" with:
+      """
+      Feature:
+
+        Scenario: Miss
+          Given this step is undefined
+
+        Scenario: Hit
+          Given this step passes
+          And this step passes
+          And this step passes
+      """
+    When I run `cucumber features/test.feature:8 --format pretty --quiet `
+    Then it should pass with exactly:
+      """
+      Feature:
+
+        Scenario: Hit
+          Given this step passes
+          And this step passes
+          And this step passes
+
+      1 scenario (1 passed)
+      3 steps (3 passed)
+
+      """
+
+  Scenario: Specify line number of a feature to run all scenarios
+    Given a file named "features/test.feature" with:
+      """
+      Feature:
+
+        Scenario: Passes
+          Given this step passes
+
+        Scenario: Passes, also
+          Given this step passes
+      """
+    When I run `cucumber features/test.feature:1 --format pretty --quiet `
+    Then it should pass with exactly:
+      """
+      Feature:
+
+        Scenario: Passes
+          Given this step passes
+
+        Scenario: Passes, also
+          Given this step passes
+
+      2 scenarios (2 passed)
+      2 steps (2 passed)
+
+      """


### PR DESCRIPTION
Fixes regression described in https://github.com/cucumber/cucumber-ruby/issues/1469

**Regression**
I used to be able to run `cucumber feature_file_name.feature:XX` with XX being a line anywhere in the scenario (usually the line that failed last time, to easily re-run a failure) but now it only works if XX is the number of the "Scenario" heading line. Additionally, running `:1` used to run all scenarios, now it runs none.

**Solution**
Due to the internal changes that seem to make a "proper" fix invasive (see https://github.com/cucumber/cucumber-ruby/issues/1469#issuecomment-687193405), here is hacky solution in the CLI layer. When an file argument is found with a line number specified, we open the file, inspect the specified line, iterate upwards until we see `Scenario:`, and then mutate the supplied line number into that line number. If we happen to find `Scenario Outline:` first, just leave the number as-is. If neither is found, i.e. we're above the first scenario in e.g. `Background:` or `Feature:`, then all scenarios should be run, so remove the line number completely.

**Notes**
This is hardly the most elegant solution (or code), but I want to solicit discussion and feedback from the cucumber dev community before iterating much further on it. What do y'all think? Is there a better way to go about fixing this regression that doesn't involve rearchitecting cucumber's internals all over again?