### PR TITLE
Add pretty formatter with publish

### DIFF
--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -140,8 +140,14 @@ module Cucumber
       end
 
       def needs_default_formatter?
-        return true if @options[:formats].empty?
+        formatter_missing? || publish_only?
+      end
 
+      def formatter_missing?
+        @options[:formats].empty?
+      end
+
+      def publish_only?
         @options[:formats]
           .uniq
           .map { |formatter, _, stream| [formatter, stream] }

--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -142,8 +142,12 @@ module Cucumber
       def needs_default_formatter?
         return true if @options[:formats].empty?
 
-        formatters = @options[:formats].uniq.map { |formatter, _, _| formatter }.uniq
-        formatters == ['message']
+        @options[:formats]
+          .uniq
+          .map { |formatter, _, stream| [formatter, stream] }
+          .uniq
+          .reject { |formatter, stream| formatter == 'message' && stream != @out_stream }
+          .empty?
       end
     end
   end

--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -126,12 +126,24 @@ module Cucumber
       end
 
       def arrange_formats
-        @options[:formats] << ['pretty', {}, @out_stream] if @options[:formats].empty?
+        add_default_formatter if needs_default_formatter?
+
         @options[:formats] = @options[:formats].sort_by do |f|
           f[2] == @out_stream ? -1 : 1
         end
         @options[:formats].uniq!
         @options.check_formatter_stream_conflicts
+      end
+
+      def add_default_formatter
+        @options[:formats] << ['pretty', {}, @out_stream]
+      end
+
+      def needs_default_formatter?
+        return true if @options[:formats].empty?
+
+        formatters = @options[:formats].uniq.map { |formatter, _, _| formatter }.uniq
+        formatters == ['message']
       end
     end
   end

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -246,6 +246,12 @@ Defined profiles in cucumber.yml:
         expect(config.options[:verbose]).to be true
       end
 
+      it 'uses the pretty formatter to stdout when no formatter is defined' do
+        config.parse!([])
+
+        expect(config.formats).to eq [['pretty', {}, out]]
+      end
+
       it 'accepts --out option' do
         config.parse!(%w[--out jalla.txt])
 

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -261,6 +261,15 @@ Defined profiles in cucumber.yml:
         ]
       end
 
+      it 'does not add the default formatter when a formatter is defined with --publish' do
+        config.parse!(['--publish', '--format', 'progress'])
+
+        expect(config.formats).to eq [
+          ['progress', {}, out],
+          ['message', {}, 'https://messages.cucumber.io/api/reports -X GET']
+        ]
+      end
+
       it 'accepts --out option' do
         config.parse!(%w[--out jalla.txt])
 

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -252,6 +252,15 @@ Defined profiles in cucumber.yml:
         expect(config.formats).to eq [['pretty', {}, out]]
       end
 
+      it 'adds the default formatter when no other formatter is defined with --publish' do
+        config.parse!(['--publish'])
+
+        expect(config.formats).to eq [
+          ['pretty', {}, out],
+          ['message', {}, 'https://messages.cucumber.io/api/reports -X GET']
+        ]
+      end
+
       it 'accepts --out option' do
         config.parse!(%w[--out jalla.txt])
 

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -270,6 +270,14 @@ Defined profiles in cucumber.yml:
         ]
       end
 
+      it 'does not add the default formatter with --format message' do
+        config.parse!(['--format', 'message'])
+
+        expect(config.formats).to eq [
+          ['message', {}, out]
+        ]
+      end
+
       it 'accepts --out option' do
         config.parse!(%w[--out jalla.txt])
 


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

https://github.com/cucumber/cucumber-ruby/issues/1468
Missing pretty formatter when using --publish

**Describe the solution you have implemented**
In cli/configuration, I have added the pretty formatter per default when only message(s) formatter(s) are specified.