### PR TITLE
Fix windows build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,14 @@ commands:
           name: "Add ansicon"
           command: |
             choco install ansicon
+      - run:
+          name: "Add MSYS2"
+          command: |
+            choco install msys2
+      - run:
+          name: "Set-up Ruby devkit"
+          command: |
+            ridk install 2 3
 
   build:
     description: "Build and run the tests"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 * `fileattribute` cli argument available to attach `file` to junit formatter
 
+### Fixed
+
+* Circle-CI windows build now silently installs MSYS2 using Chocolatey before
+  setting-up the ruby devkit with ridk
+
 ## [5.2.0](https://github.com/cucumber/cucumber-ruby/compare/v5.1.3...v5.2.0)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 * Circle-CI windows build now silently installs MSYS2 using Chocolatey before
   setting-up the ruby devkit with ridk
+  ([#1503](https://github.com/cucumber/cucumber-ruby/pull/1503)
+   [aurelien-reeves](https://github.com/aurelien-reeves))
+
 
 ## [5.2.0](https://github.com/cucumber/cucumber-ruby/compare/v5.1.3...v5.2.0)
 


### PR DESCRIPTION
Install MSYS2 using Chocolatey allow a silent install.
Then, ridk can set-up msys2 properly and the ruby devkit.

**Is your pull request related to a problem? Please describe.**

The circle-ci windows build is broken

**Describe the solution you have implemented**
`ridk` may not be silent when installing `msys2`.
Installing `msys2` using `choco` allows to install it silently, then `ridk install 2 3` can properly set-up the ruby devkit.