### PR TITLE
Ignore CUCUMBER_PUBLISH_TOKEN during cucumber tests

### DIFF
--- a/features/lib/support/env.rb
+++ b/features/lib/support/env.rb
@@ -22,15 +22,12 @@ After do |scenario|
 end
 
 Around do |_, block|
-  original_publish_token = ENV['CUCUMBER_PUBLISH_TOKEN']
-  ENV.delete('CUCUMBER_PUBLISH_TOKEN')
-
+  original_publish_token = ENV.delete('CUCUMBER_PUBLISH_TOKEN')
   original_coloring = Cucumber::Term::ANSIColor.coloring?
 
   block.call
 
   Cucumber::Term::ANSIColor.coloring = original_coloring
-
   ENV['CUCUMBER_PUBLISH_TOKEN'] = original_publish_token
 end
 

--- a/features/lib/support/env.rb
+++ b/features/lib/support/env.rb
@@ -22,9 +22,16 @@ After do |scenario|
 end
 
 Around do |_, block|
+  original_publish_token = ENV['CUCUMBER_PUBLISH_TOKEN']
+  ENV.delete('CUCUMBER_PUBLISH_TOKEN')
+
   original_coloring = Cucumber::Term::ANSIColor.coloring?
+
   block.call
+
   Cucumber::Term::ANSIColor.coloring = original_coloring
+
+  ENV['CUCUMBER_PUBLISH_TOKEN'] = original_publish_token
 end
 
 Around('@force_legacy_loader') do |_, block|


### PR DESCRIPTION
Re-set it properly after each tests to be able to actually publish our
own reports.

**Is your pull request related to a problem? Please describe.**

This is an attempt to fix our own GHA

**Describe the solution you have implemented**

Unset CUCUMBER_PUBLISH_TOKEN before each cucumber tests to avoid interference within the test.
Then reset it properly after each tests to be able to publish our own reports.