### PR TITLE
Add a ruby 3.0 job to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,15 @@ jobs:
       - build
       - test
 
+  build-ruby-3_0:
+    docker:
+      - image: circleci/ruby:3.0
+
+    working_directory: ~/repo
+    steps:
+      - build
+      - test
+
   build-jruby-9_2:
     docker:
       - image: circleci/jruby:9.2.16.0
@@ -186,6 +195,7 @@ workflows:
       - build-ruby-2_5
       - build-ruby-2_6
       - build-ruby-2_7
+      - build-ruby-3_0
 
   build:
     jobs:
@@ -193,6 +203,7 @@ workflows:
       - build-ruby-2_5
       - build-ruby-2_6
       - build-ruby-2_7
+      - build-ruby-3_0
       - build-ruby-latest
       - build-jruby-9_2
       # - build_monorepo


### PR DESCRIPTION
Refs. https://github.com/cucumber/cucumber-ruby/issues/1498
Add a job explicitly dedicated to ruby 3.0 in addition to the ruby:latest one

