### PR TITLE
Update supported platforms in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Where to get more info:
 See [CONTRIBUTING.md](CONTRIBUTING.md) for info on contributing to Cucumber.
 
 ## Supported platforms
+* Ruby 3.0
+* Ruby 2.7
 * Ruby 2.6
 * Ruby 2.5
 * Ruby 2.4


### PR DESCRIPTION
Supported platform in the Readme is outdated.

I've added Ruby 2.7 and Ruby 3.0 as they are part of the CI.

Should we keep Ruby 2.3 and Ruby 2.4? They are not part of the CI anymore, so if it breaks, we won't actually know.