### PR TITLE
Remove deprecated `embed` and `puts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 - Upgraded dependencies (see diff)
 
+### Removed
+
+- `embed` in step definitions in favor of `attach`.
+  `embed` has been deprecated in version 4.0.
+  Simply replace `embed` with `attach`.
+- `puts` in step definitions in favor of `log`. `log` has been deprecated in version 4.0
+  `puts` has been deprecated in version 4.0.
+  Simply replace `puts` with `log`.
+
 ## [5.3.0](https://github.com/cucumber/cucumber-ruby/compare/v5.2.0...v5.3.0)
 
 ### Added

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -73,40 +73,9 @@ module Cucumber
         MultilineArgument::DataTable.from(text_or_table)
       end
 
-      # Print a message to the output.
-      #
-      # @note Cucumber might surprise you with the behaviour of this method. Instead
-      #   of sending the output directly to STDOUT, Cucumber will intercept and cache
-      #   the message until the current step has finished, and then display it.
-      #
-      #   If you'd prefer to see the message immediately, call {Kernel.puts} instead.
-      def puts(*messages)
-        Cucumber.deprecate(
-          'Messages emitted with "puts" will no longer be caught by Cucumber ' \
-          'and sent to the formatter. If you want message to be in the formatted output, ' \
-          "please use log(message) instead.\n" \
-          'If you simply want it in the console, '\
-          'keep using "puts" (or Kernel.puts to avoid this message)',
-          'puts(message)',
-          '6.0.0'
-        )
-        messages.each { |message| log(message.to_s) }
-      end
-
       # Pause the tests and ask the operator for input
       def ask(question, timeout_seconds = 60)
         super
-      end
-
-      # Embed an image in the output
-      # @deprecated Use {#attach} instead
-      def embed(file, mime_type, _label = 'Screenshot')
-        Cucumber.deprecate(
-          'Please use attach(file, media_type) instead',
-          'embed(file, mime_type, label)',
-          '6.0.0'
-        )
-        attach(file, mime_type)
       end
 
       def log(*messages)

--- a/spec/cucumber/formatter/json_spec.rb
+++ b/spec/cucumber/formatter/json_spec.rb
@@ -423,7 +423,7 @@ module Cucumber
           FEATURE
 
           define_steps do
-            Given(/^there are bananas$/) { puts 'from step' }
+            Given(/^there are bananas$/) { log 'from step' }
           end
 
           it 'includes the output from the step in the json data' do
@@ -533,7 +533,7 @@ module Cucumber
           FEATURE
 
           define_steps do
-            Given(/^there are bananas$/) { embed('YWJj', 'mime-type;base64') }
+            Given(/^there are bananas$/) { attach('YWJj', 'mime-type;base64') }
           end
 
           it 'includes the data from the step in the json data' do
@@ -575,7 +575,7 @@ module Cucumber
             Given(/^there are bananas$/) do
               RSpec::Mocks.allow_message(File, :file?) { true }
               RSpec::Mocks.allow_message(File, :read) { 'foo' }
-              embed('out/snapshot.jpeg', 'image/png')
+              attach('out/snapshot.jpeg', 'image/png')
             end
           end
 

--- a/spec/cucumber/formatter/pretty_spec.rb
+++ b/spec/cucumber/formatter/pretty_spec.rb
@@ -283,13 +283,13 @@ OUTPUT
 
             define_steps do
               Before do
-                puts 'Before hook'
+                log 'Before hook'
               end
               AfterStep do
-                puts 'AfterStep hook'
+                log 'AfterStep hook'
               end
               After do
-                puts 'After hook'
+                log 'After hook'
               end
               Given('this step passes') {}
             end
@@ -328,13 +328,13 @@ OUTPUT
 
             define_steps do
               Before do
-                puts 'Before hook'
+                log 'Before hook'
               end
               AfterStep do
-                puts 'AfterStep hook'
+                log 'AfterStep hook'
               end
               After do
-                puts 'After hook'
+                log 'After hook'
               end
               Given('this step passes') {}
             end

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -21,7 +21,7 @@ module Cucumber
         end
       end
 
-      describe 'Handling puts in step definitions' do
+      describe 'Handling logs in step definitions' do
         extend Cucumber::Formatter::SpecHelperDsl
         include Cucumber::Formatter::SpecHelper
 
@@ -32,26 +32,26 @@ module Cucumber
           run_defined_feature
         end
 
-        describe 'when modifying the printed variable after the call to puts' do
+        describe 'when modifying the printed variable after the call to log' do
           define_feature <<-FEATURE
         Feature: Banana party
 
           Scenario: Monkey eats banana
-            When puts is called twice for the same variable
+            When log is called twice for the same variable
           FEATURE
 
           define_steps do
-            When(/^puts is called twice for the same variable$/) do
+            When(/^log is called twice for the same variable$/) do
               foo = String.new('a')
-              puts foo
+              log foo
               foo.upcase!
-              puts foo
+              log foo
             end
           end
 
           it 'prints the variable value at the time puts was called' do
             expect(@out.string).to include <<OUTPUT
-    When puts is called twice for the same variable
+    When log is called twice for the same variable
       a
       A
 OUTPUT

--- a/spec/cucumber/glue/step_definition_spec.rb
+++ b/spec/cucumber/glue/step_definition_spec.rb
@@ -164,24 +164,6 @@ module Cucumber
         expect(-> { run_step step_name }).not_to change { step_args.first } # rubocop:disable Lint/AmbiguousBlockAssociation
       end
 
-      context 'allows puts' do
-        it 'is deprecated is favor of "log"' do
-          expect(user_interface).to receive(:attach).with('wasup', 'text/x.cucumber.log+plain')
-          dsl.Given(/Loud/) do
-            puts 'wasup'
-          end
-          run_step 'Loud'
-        end
-
-        it 'cast the message as a String before logging it' do
-          expect(user_interface).to receive(:attach).with('[1]', 'text/x.cucumber.log+plain')
-          dsl.Given(/Loud/) do
-            puts [1]
-          end
-          run_step 'Loud'
-        end
-      end
-
       context 'allows log' do
         it 'calls "attach" with the correct media type' do
           expect(user_interface).to receive(:attach).with('wasup', 'text/x.cucumber.log+plain')


### PR DESCRIPTION
Removal of deprecated code.
Code deprecated in 4.0.
We are about to release 6.0.
The removed code can be easily replaced with `attach` and `log` without any other change in the code.