### PR TITLE
Clarify removal of `puts` in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   ([#1523](https://github.com/cucumber/cucumber-ruby/pull/1523)
   [aurelien-reeves](https://github.com/aurelien-reeves))
   
-- `log` in step definitions in favor of `puts`. 
+- `puts` in step definitions in favor of `log`. 
   `puts` has been deprecated in version 4.0.
   Simply replace `puts` with `log`.
   ([#1523](https://github.com/cucumber/cucumber-ruby/pull/1523)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   ([#1523](https://github.com/cucumber/cucumber-ruby/pull/1523)
   [aurelien-reeves](https://github.com/aurelien-reeves))
   
-- `puts` in step definitions in favor of `log`. `log` has been deprecated in version 4.0
+- `log` in step definitions in favor of `puts`. 
   `puts` has been deprecated in version 4.0.
   Simply replace `puts` with `log`.
   ([#1523](https://github.com/cucumber/cucumber-ruby/pull/1523)


### PR DESCRIPTION
The original language of the changed item was rather confusing; it almost made it sound like the deprecation of `puts` was being reversed, and that `puts` is now preferred over `log`. But it also said that both `puts` _and_ `log` were deprecated in 4.0. I don't think that's the case or the intention of this CHANGELOG point.

My edits aim to make clear that `puts` has been deprecated, and the desire of the Cucumber Team is that `log` should be used in step definitions instead.