### PR TITLE
Remove deprecation for the JSON formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Changed
 
+- Undeprecate the JSON formatter. It won't be removed any time soon.
+
 ### Removed
 
 ### Security fixes

--- a/features/docs/formatters/json_formatter.feature
+++ b/features/docs/formatters/json_formatter.feature
@@ -672,14 +672,3 @@ Feature: JSON output formatter
       """
     When I run `cucumber --format json features/out_scenario_out_scenario_outline.feature`
     Then it should pass
-
-  Scenario: shows a deprecation warning
-    When I run `cucumber --format json`
-    Then the stderr should contain:
-      """
-      WARNING: --format=json is deprecated and will be removed after version 6.0.0
-      """
-    And the stderr should contain:
-      """
-      Please use --format=message and stand-alone json-formatter.
-      """

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -24,7 +24,7 @@ module Cucumber
                                                               "#{INDENT}the usage formatter, except that steps are not printed."],
         'junit'       => ['Cucumber::Formatter::Junit',       "Generates a report similar to Ant+JUnit. Use\n" \
                                                               "#{INDENT}junit,fileattribute=true to include a file attribute."],
-        'json'        => ['Cucumber::Formatter::Json',        '[DEPRECATED] Prints the feature as JSON'],
+        'json'        => ['Cucumber::Formatter::Json',        'Prints the feature as JSON'],
         'message'     => ['Cucumber::Formatter::Message',     'Outputs protobuf messages'],
         'html'        => ['Cucumber::Formatter::HTML',        'Outputs HTML report'],
         'summary'     => ['Cucumber::Formatter::Summary',     'Summary output of feature and scenarios']

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -24,7 +24,11 @@ module Cucumber
                                                               "#{INDENT}the usage formatter, except that steps are not printed."],
         'junit'       => ['Cucumber::Formatter::Junit',       "Generates a report similar to Ant+JUnit. Use\n" \
                                                               "#{INDENT}junit,fileattribute=true to include a file attribute."],
-        'json'        => ['Cucumber::Formatter::Json',        'Prints the feature as JSON'],
+        'json'        => ['Cucumber::Formatter::Json',        "Prints the feature as JSON.\n" \
+                                                              "#{INDENT}The JSON format is in maintenance mode.\n" \
+                                                              "#{INDENT}Please consider using the message formatter\n"\
+                                                              "#{INDENT}with the standalone json-formatter\n" \
+                                                              "#{INDENT}(https://github.com/cucumber/cucumber/tree/master/json-formatter)."],
         'message'     => ['Cucumber::Formatter::Message',     'Outputs protobuf messages'],
         'html'        => ['Cucumber::Formatter::HTML',        'Outputs HTML report'],
         'summary'     => ['Cucumber::Formatter::Summary',     'Summary output of feature and scenarios']

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -5,7 +5,6 @@ require 'base64'
 require 'cucumber/formatter/backtrace_filter'
 require 'cucumber/formatter/io'
 require 'cucumber/formatter/ast_lookup'
-require 'cucumber/deprecate'
 
 module Cucumber
   module Formatter
@@ -14,14 +13,6 @@ module Cucumber
       include Io
 
       def initialize(config)
-        Cucumber::Deprecate::CliOption.deprecate(
-          config.error_stream,
-          '--format=json',
-          "Please use --format=message and stand-alone json-formatter.\n" \
-          'json-formatter homepage: https://github.com/cucumber/cucumber/tree/master/json-formatter#cucumber-json-formatter',
-          '6.0.0'
-        )
-
         @io = ensure_io(config.out_stream, config.error_stream)
         @ast_lookup = AstLookup.new(config)
         @feature_hashes = []


### PR DESCRIPTION
As discussed at our last community meeting, the JSON formatter is no more deprecated, but entering maintenance mode.
