### PR TITLE
Report empty scenarios with the json formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Changed
 
+- The json formatter now reports empty scenarios. 
+  No status is reported for empty scenarios in the resulting json.
+  ([1533](https://github.com/cucumber/cucumber-ruby/pull/1533)
+   [1530](https://github.com/cucumber/cucumber-ruby/issues/1530)
+   [aurelien-reeves](https://github.com/aurelien-reeves))
 - Undeprecate the JSON formatter. It won't be removed any time soon.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 - The json formatter now reports empty scenarios. 
   No status is reported for empty scenarios in the resulting json.
+  No more empty background is reported with empty scenarios.
   ([1533](https://github.com/cucumber/cucumber-ruby/pull/1533)
    [1530](https://github.com/cucumber/cucumber-ruby/issues/1530)
    [aurelien-reeves](https://github.com/aurelien-reeves))

--- a/features/docs/gherkin/empty_scenario.feature
+++ b/features/docs/gherkin/empty_scenario.feature
@@ -46,6 +46,14 @@ Feature: Empty scenario
         "description": "",
         "elements": [
           {
+            "description": "",
+            "keyword": "Background",
+            "line": 3,
+            "name": "",
+            "steps": [],
+            "type": "background"
+          },
+          {
             "id": "minimal;empty",
             "description": "",
             "keyword": "Scenario",

--- a/features/docs/gherkin/empty_scenario.feature
+++ b/features/docs/gherkin/empty_scenario.feature
@@ -46,14 +46,6 @@ Feature: Empty scenario
         "description": "",
         "elements": [
           {
-            "description": "",
-            "keyword": "Background",
-            "line": 3,
-            "name": "",
-            "steps": [],
-            "type": "background"
-          },
-          {
             "id": "minimal;empty",
             "description": "",
             "keyword": "Scenario",

--- a/features/docs/gherkin/empty_scenario.feature
+++ b/features/docs/gherkin/empty_scenario.feature
@@ -1,0 +1,65 @@
+Feature: Empty scenario
+
+  A scenario can be empty.
+  Background and hooks are not executed.
+  The state of the resulting test for the scenario is `undefined`
+
+  Background:
+    Given a file named "features/empty_scenario.feature" with:
+      """
+      Feature: minimal
+
+        Background:
+          Given some context 
+
+        Scenario: empty
+      """
+    And a file named "features/step_definitions/steps.rb" with:
+      """
+      Given("some context") do
+        raise "error" # should not be executed
+      end
+
+      After do |scenario|
+        raise "error" # should not be executed
+      end
+      """
+
+  Scenario: test status for empty scenario is `undefined`
+    When I run `cucumber --quiet features/empty_scenario.feature`
+    Then it should pass with exactly:
+    """
+    Feature: minimal
+
+      Background:
+
+    1 scenario (1 undefined)
+    0 steps
+    """
+
+  Scenario: reporting with the json formatter
+    When I run `cucumber --quiet --format json features/empty_scenario.feature`
+    Then it should pass with JSON:
+    """
+    [
+      {
+        "description": "",
+        "elements": [
+          {
+            "id": "minimal;empty",
+            "description": "",
+            "keyword": "Scenario",
+            "line": 6,
+            "name": "empty",
+            "steps": [],
+            "type": "scenario"
+          }
+        ],
+        "id": "minimal",
+        "keyword": "Feature",
+        "line": 1,
+        "name": "minimal",
+        "uri": "features/empty_scenario.feature"
+      }
+    ]
+    """

--- a/features/lib/support/json.rb
+++ b/features/lib/support/json.rb
@@ -5,7 +5,7 @@ module JSONWorld
     json.each do |feature|
       elements = feature.fetch('elements') { [] }
       elements.each do |scenario|
-        scenario['steps'].each do |_step|
+        scenario['steps']&.each do |_step|
           %w[steps before after].each do |type|
             next unless scenario[type]
             scenario[type].each do |step_or_hook|

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -38,9 +38,9 @@ module Cucumber
           @element_hash = builder.background_hash
         else
           @in_background = false
+          feature_elements << @test_case_hash
+          @element_hash = @test_case_hash
         end
-        feature_elements << @test_case_hash
-        @element_hash = @test_case_hash
         @any_step_failed = false
       end
 
@@ -71,6 +71,8 @@ module Cucumber
       end
 
       def on_test_case_finished(event)
+        feature_elements << @test_case_hash if @in_background
+
         _test_case, result = *event.attributes
         result = result.with_filtered_backtrace(Cucumber::Formatter::BacktraceFilter)
         add_failed_around_hook(result) if result.failed? && !@any_step_failed

--- a/lib/cucumber/formatter/json.rb
+++ b/lib/cucumber/formatter/json.rb
@@ -38,9 +38,9 @@ module Cucumber
           @element_hash = builder.background_hash
         else
           @in_background = false
-          feature_elements << @test_case_hash
-          @element_hash = @test_case_hash
         end
+        feature_elements << @test_case_hash
+        @element_hash = @test_case_hash
         @any_step_failed = false
       end
 
@@ -257,7 +257,8 @@ module Cucumber
             name: background.name,
             description: value_or_empty_string(background.description),
             line: background.location.line,
-            type: 'background'
+            type: 'background',
+            steps: []
           }
         end
 
@@ -269,7 +270,8 @@ module Cucumber
             name: test_case.name,
             description: value_or_empty_string(scenario.description),
             line: test_case.location.lines.max,
-            type: 'scenario'
+            type: 'scenario',
+            steps: []
           }
           @test_case_hash[:tags] = create_tags_array_from_tags_array(test_case.tags) unless test_case.tags.empty?
         end


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

Fixes #1530
Empty scenarios are not reported in the json formatter.
In order to standardize support for empty scenario, one has been added in the CCK: https://github.com/cucumber/cucumber/pull/1498

cucumber-ruby has been chosen for reference, but yet the support could be improved.

That is the purpose of that PR

**Describe the solution you have implemented**

We report empty scenarios in the json formatter, with an empty `steps` array
