### PR TITLE
Fix 'attach' when passing null byte in the data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,14 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
+- `attach` can now handle null bytes in the data.
+  ([1536](https://github.com/cucumber/cucumber-ruby/pull/1536)
+   [1529](https://github.com/cucumber/cucumber-ruby/issues/1529)
+   [aurelien-reeves](https://github.com/aurelien-reeves))
+
 ### Changed
 
-- The JSON formatter now reports empty scenarios. 
+- The JSON formatter now reports empty scenarios.
   No status is reported for empty scenarios in the resulting JSON.
   No more empty background is reported with empty scenarios.
   ([1533](https://github.com/cucumber/cucumber-ruby/pull/1533)

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -95,6 +95,8 @@ module Cucumber
         media_type = MIME::Types.type_for(file).first if media_type.nil?
 
         super(content, media_type.to_s)
+      rescue StandardError
+        super
       end
 
       # Mark the matched step as pending.

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -127,6 +127,43 @@ OUTPUT
           end
         end
       end
+
+      describe 'Handling attachments in step definitions' do
+        extend Cucumber::Formatter::SpecHelperDsl
+        include Cucumber::Formatter::SpecHelper
+
+        before(:each) do
+          Cucumber::Term::ANSIColor.coloring = false
+          @out = StringIO.new
+          @formatter = Cucumber::Formatter::Pretty.new(actual_runtime.configuration.with_options(out_stream: @out, source: false))
+          run_defined_feature
+        end
+
+        describe 'when attaching data with null byte' do
+          define_feature <<-FEATURE
+            Feature: Banana party
+
+              Scenario: Monkey eats banana
+                When some data is attached
+          FEATURE
+
+          define_steps do
+            When('some data is attached') do
+              data = "'\x00'attachement"
+              attach(data, 'text/x.cucumber.log+plain')
+            end
+          end
+
+          it 'does not report an error' do
+            expect(@out.string).not_to include 'Error'
+          end
+
+          it 'properly attach the data' do
+            data = "'\x00'attachement"
+            expect(@out.string).to include data
+          end
+        end
+      end
     end
   end
 end

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -149,8 +149,7 @@ OUTPUT
 
           define_steps do
             When('some data is attached') do
-              data = "'\x00'attachement"
-              attach(data, 'text/x.cucumber.log+plain')
+              attach("'\x00'attachement", 'text/x.cucumber.log+plain')
             end
           end
 
@@ -158,9 +157,8 @@ OUTPUT
             expect(@out.string).not_to include 'Error'
           end
 
-          it 'properly attach the data' do
-            data = "'\x00'attachement"
-            expect(@out.string).to include data
+          it 'properly attaches the data' do
+            expect(@out.string).to include "'\x00'attachement"
           end
         end
       end


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

Fixes #1529 

**Describe the solution you have implemented**

Rescue any standard error in the attach method, then call super without any further process around it
