### PR TITLE
Remove deep clone of step arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
+- Step definitions now uses object instances created in the ParameterType
+  ([1538](https://github.com/cucumber/cucumber-ruby/pull/1538)
+   [1532](https://github.com/cucumber/cucumber-ruby/issues/1532)
+   [aurelien-reeves](https://github.com/aurelien-reeves))
 - `attach` can now handle null bytes in the data.
   ([1536](https://github.com/cucumber/cucumber-ruby/pull/1536)
    [1529](https://github.com/cucumber/cucumber-ruby/issues/1529)

--- a/lib/cucumber/step_match.rb
+++ b/lib/cucumber/step_match.rb
@@ -28,7 +28,7 @@ module Cucumber
     end
 
     def invoke(multiline_arg)
-      all_args = deep_clone_args
+      all_args = args
       multiline_arg.append_to(all_args)
       @step_definition.invoke(all_args)
     end
@@ -92,12 +92,6 @@ module Cucumber
 
     def inspect #:nodoc:
       "#<#{self.class}: #{location}>"
-    end
-
-    private
-
-    def deep_clone_args
-      Marshal.load(Marshal.dump(args))
     end
   end
 

--- a/spec/cucumber/glue/step_definition_spec.rb
+++ b/spec/cucumber/glue/step_definition_spec.rb
@@ -164,6 +164,48 @@ module Cucumber
         expect(-> { run_step step_name }).not_to change { step_args.first } # rubocop:disable Lint/AmbiguousBlockAssociation
       end
 
+      context 'with ParameterType' do
+        class Actor
+          attr_reader :name
+          def initialize(name)
+            @name = name
+          end
+        end
+
+        before(:each) do
+          @actor = nil
+
+          dsl.ParameterType(
+            name: 'actor',
+            regexp: /[A-Z]{1}[a-z]+/,
+            transformer: -> (name) {
+              @actor = Actor.new(name)
+              @actor
+            }
+          )
+        end
+
+        it 'uses the instance created by the ParameterType transformer proc' do
+          dsl.Given 'capture this: {actor}' do |arg|
+            expect(arg.name).to eq 'Anjie'
+            expect(arg).to be @actor
+          end
+
+          run_step "capture this: Anjie"
+        end
+
+        it 'does not modify the step_match arg when arg is modified in a step' do
+          dsl.Given 'capture this: {actor}' do |arg|
+            arg = nil
+          end
+
+          step_name = 'capture this: Anjie'
+          step_args = step_match(step_name).args
+
+          expect(-> { run_step step_name }).not_to change { step_args.first } # rubocop:disable Lint/AmbiguousBlockAssociation
+        end
+      end
+
       context 'allows log' do
         it 'calls "attach" with the correct media type' do
           expect(user_interface).to receive(:attach).with('wasup', 'text/x.cucumber.log+plain')

--- a/spec/cucumber/glue/step_definition_spec.rb
+++ b/spec/cucumber/glue/step_definition_spec.rb
@@ -167,6 +167,7 @@ module Cucumber
       context 'with ParameterType' do
         class Actor
           attr_reader :name
+          attr_writer :name
           def initialize(name)
             @name = name
           end
@@ -192,14 +193,14 @@ module Cucumber
         end
 
         it 'does not modify the step_match arg when arg is modified in a step' do
-          dsl.Given 'capture this: {actor}' do |_arg|
-            _arg = nil
+          dsl.Given 'capture this: {actor}' do |actor|
+            actor.name = 'Dave'
           end
 
-          step_name = 'capture this: Anjie'
-          step_args = step_match(step_name).args
-
-          expect(-> { run_step step_name }).not_to change { step_args.first } # rubocop:disable Lint/AmbiguousBlockAssociation
+          run_step 'capture this: Anjie'
+          step_args = step_match('capture this: Anjie').args
+          expect(step_args[0].name).to_not eq 'Dave'
+          expect(step_args[0].name).to eq 'Anjie'
         end
       end
 

--- a/spec/cucumber/glue/step_definition_spec.rb
+++ b/spec/cucumber/glue/step_definition_spec.rb
@@ -178,10 +178,7 @@ module Cucumber
           dsl.ParameterType(
             name: 'actor',
             regexp: /[A-Z]{1}[a-z]+/,
-            transformer: -> (name) {
-              @actor = Actor.new(name)
-              @actor
-            }
+            transformer: ->(name) { @actor = Actor.new(name) }
           )
         end
 
@@ -191,12 +188,12 @@ module Cucumber
             expect(arg).to be @actor
           end
 
-          run_step "capture this: Anjie"
+          run_step 'capture this: Anjie'
         end
 
         it 'does not modify the step_match arg when arg is modified in a step' do
-          dsl.Given 'capture this: {actor}' do |arg|
-            arg = nil
+          dsl.Given 'capture this: {actor}' do |_arg|
+            _arg = nil
           end
 
           step_name = 'capture this: Anjie'


### PR DESCRIPTION
Fixes #1532

Step arguments are delegated to the World since 144f34177efb9259c63e3f112edf85a47b11ce6b.
That prevent state to leak so the deep-clone seems not required anymore.

But at the moment, I have no idea how to test that properly, and how to make sure state cannot leak