### PR TITLE
 Suppress unnecessary warnings about ANSICON in integrated terminal of vscode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Removed
 
+- On Windows, support for ANSICON has been removed due to recent version of Windows properly supporting ansi colors in the terminal (integrated terminal in vscode, PS, and cmd.exe also support it). If you needs (on some older version of Windows), you can use `--no-color` or install ANSICON globally (with a link to https://github.com/adoxa/ansicon/).
+
 ### Security fixes
 
 ## [v6.1.0](https://github.com/cucumber/cucumber-ruby/compare/v6.0.0...v6.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Removed
 
-- On Windows, auto-detection of ANSICON has been removed - Windows now properly supports ANSI colors in the terminal. In case of issues on older version of Windows, execute cucumber with `--no-color`, or install [ANSICON](https://github.com/adoxa/ansicon/) globally.
+- On Windows, auto-detection of ANSICON has been removed - Windows now properly supports ANSI colors in the terminal. In case of issues on older versions of Windows, execute cucumber with `--no-color`, or install [ANSICON](https://github.com/adoxa/ansicon/) globally.
 
 ### Security fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Removed
 
-- On Windows, support for ANSICON has been removed due to recent version of Windows properly supporting ansi colors in the terminal (integrated terminal in vscode, PS, and cmd.exe also support it). If you needs (on some older version of Windows), you can use `--no-color` or install ANSICON globally (with a link to https://github.com/adoxa/ansicon/).
+- On Windows, auto-detection of ANSICON has been removed - Windows now properly supports ANSI colors in the terminal. In case of issues on older version of Windows, execute cucumber with `--no-color`, or install [ANSICON](https://github.com/adoxa/ansicon/) globally.
 
 ### Security fixes
 

--- a/lib/cucumber/formatter/ansicolor.rb
+++ b/lib/cucumber/formatter/ansicolor.rb
@@ -4,7 +4,7 @@ require 'cucumber/platform'
 require 'cucumber/term/ansicolor'
 
 if Cucumber::WINDOWS_MRI
-  unless ENV['ANSICON']
+  unless ENV['ANSICON'] || ENV['TERM_PROGRAM'] == "vscode"
     STDERR.puts %{*** WARNING: You must use ANSICON 1.31 or higher (https://github.com/adoxa/ansicon/) to get coloured output on Windows}
     Cucumber::Term::ANSIColor.coloring = false
   end
@@ -152,3 +152,4 @@ module Cucumber
     end
   end
 end
+

--- a/lib/cucumber/formatter/ansicolor.rb
+++ b/lib/cucumber/formatter/ansicolor.rb
@@ -4,7 +4,7 @@ require 'cucumber/platform'
 require 'cucumber/term/ansicolor'
 
 if Cucumber::WINDOWS_MRI
-  unless ENV['ANSICON'] || ENV['TERM_PROGRAM'] == "vscode"
+  unless ENV['ANSICON'] || ENV['TERM_PROGRAM'] == 'vscode'
     STDERR.puts %{*** WARNING: You must use ANSICON 1.31 or higher (https://github.com/adoxa/ansicon/) to get coloured output on Windows}
     Cucumber::Term::ANSIColor.coloring = false
   end

--- a/lib/cucumber/formatter/ansicolor.rb
+++ b/lib/cucumber/formatter/ansicolor.rb
@@ -152,4 +152,3 @@ module Cucumber
     end
   end
 end
-

--- a/lib/cucumber/formatter/ansicolor.rb
+++ b/lib/cucumber/formatter/ansicolor.rb
@@ -3,13 +3,6 @@
 require 'cucumber/platform'
 require 'cucumber/term/ansicolor'
 
-if Cucumber::WINDOWS_MRI
-  unless ENV['ANSICON'] || ENV['TERM_PROGRAM'] == 'vscode'
-    STDERR.puts %{*** WARNING: You must use ANSICON 1.31 or higher (https://github.com/adoxa/ansicon/) to get coloured output on Windows}
-    Cucumber::Term::ANSIColor.coloring = false
-  end
-end
-
 Cucumber::Term::ANSIColor.coloring = false if !STDOUT.tty? && !ENV.key?('AUTOTEST')
 
 module Cucumber


### PR DESCRIPTION
# Description
On the integrated terminal of vscode, Cucumber always warns about ANSICON as below.

```bash
*** WARNING: You must use ANSICON 1.31 or higher (https://github.com/adoxa/ansicon/) to get coloured output on Windows
```

This behavior was discussed in https://github.com/cucumber/cucumber-ruby/issues/1163 or https://github.com/cucumber/cucumber-ruby/pull/1119, but unfortunately has not resolved yet.

Because the environment variable `VSCODE_PID` mentioned in #1163 is already  obsolete, it seems to be good to check the value of `TERM_PROGRAM` instead of it.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Note to other contributors

## Update required of cucumber.io/docs

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [x] Tests have been added for any changes to behaviour of the code
  - I have tested the above change with my local copy of the gem, and I am able to see the correct color output from cucumber in the vscode integrated terminal.
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] (N/A) RDoc comments have been updated
- [x] (N/A) CHANGELOG.md has been updated
