### PR TITLE
Deprecate usage of built-in cucumber wire protocol

### DIFF
--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -3,6 +3,7 @@
 require 'fileutils'
 require 'cucumber/configuration'
 require 'cucumber/create_meta'
+require 'cucumber/deprecate'
 require 'cucumber/load_path'
 require 'cucumber/formatter/duration'
 require 'cucumber/file_specs'
@@ -261,7 +262,14 @@ module Cucumber
     end
 
     def install_wire_plugin
-      Cucumber::Wire::Plugin.new(@configuration, @support_code.registry).install if @configuration.all_files_to_load.any? { |f| f =~ /\.wire$/ }
+      return unless @configuration.all_files_to_load.any? { |f| f =~ /\.wire$/ }
+
+      Cucumber::Wire::Plugin.new(@configuration, @support_code.registry).install
+      Cucumber.deprecate(
+        'See https://github.com/cucumber/cucumber-ruby-wire#migration-from-built-in-to-plugin for more info',
+        ' built-in usage of the wire protocol',
+        '9.0.0'
+      )
     end
 
     def log

--- a/spec/cucumber/runtime_spec.rb
+++ b/spec/cucumber/runtime_spec.rb
@@ -20,5 +20,26 @@ module Cucumber
         expect(subject.doc_string('Text')).to eq 'Text'
       end
     end
+
+    describe '#install_wire_plugin' do
+      it 'informs the user it is deprecated' do
+        stub_const('Cucumber::Deprecate::STRATEGY', Cucumber::Deprecate::ForUsers)
+        allow(STDERR).to receive(:puts)
+        allow_any_instance_of(Configuration).to receive(:all_files_to_load).and_return(['file.wire'])
+
+        begin
+          subject.run!
+        rescue NoMethodError
+          # this is actually expected
+        end
+
+        expect(STDERR).to have_received(:puts).with(
+          a_string_including([
+            'WARNING: # built-in usage of the wire protocol is deprecated and will be removed after version 9.0.0.',
+            'See https://github.com/cucumber/cucumber-ruby-wire#migration-from-built-in-to-plugin for more info.'
+          ].join(' '))
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
# Description

This is related to https://github.com/cucumber/cucumber-ruby/pull/1562

It is planned to remove the built-in support for cucumber-ruby-wire. It will still be available but as an optional plugin.

Before removing the support for it - which is done in #1562 - we need to deprecate it. A deprecation process should last for 2 major releases at least: the once which announce the deprecation, and the one which drops the deprecation.

So that deprecation should be part of an incoming cucumber-ruby 8.0.0, for #1562 being part of 9.0.0

## Type of change

Please delete options that are not relevant.

- Breaking change (will cause existing functionality to not
  work as expected)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
