### PR TITLE
Inform about non-support of JRuby 9.3

### DIFF
--- a/.github/workflows/cucumber-ruby.yml
+++ b/.github/workflows/cucumber-ruby.yml
@@ -26,7 +26,7 @@ jobs:
         ruby: [2.5, 2.6, 2.7, '3.0']
         include:
           - os: ubuntu-latest
-            ruby: jruby
+            ruby: jruby-9.2
         exclude:
           - ruby: 2.5
             os: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   ([1564](https://github.com/cucumber/cucumber-ruby/pull/1564)
    [aurelien-reeves](https://github.com/aurelien-reeves))
 
+### Known issue
+
+- There is a known issue with JRuby 9.3. For more info, see
+  [PR#1571](https://github.com/cucumber/cucumber-ruby/pull/1571).
+
 ## [7.0.0](https://github.com/cucumber/cucumber-ruby/compare/v6.1.0...v7.0.0)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Later in this document, bundler is considered being used so all commands are usi
 - Ruby 2.3
 - JRuby 9.2 (with [some limitations](https://github.com/cucumber/cucumber-ruby/blob/main/docs/jruby-limitations.md))
 
+JRuby 9.3 is not supported yet due to a known issue. More info can
+be found in the [PR#1571](https://github.com/cucumber/cucumber-ruby/pull/1571).
+
 ### Ruby on Rails
 
 Using Ruby on Rails? You can use [cucumber-rails](https://github.com/cucumber/cucumber-rails)


### PR DESCRIPTION
# Description

Refs. https://github.com/cucumber/cucumber-ruby/pull/1571

Due to issue with JRuby 9.3, I suggest to not support it until we have a solution

That would prevent delaying a potential release of cucumber-ruby

