### PR TITLE
Restore release dates in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ---
 
-## [In GIT](https://github.com/cucumber/cucumber-ruby/compare/v7.0.0...main)
+## [In GIT](https://github.com/cucumber/cucumber-ruby/compare/v7.0.0...main) (2021-07-19)
 
 ### Added
 
@@ -20,7 +20,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   [features/docs/writing_support_code/hooks/README.md](./features/docs/writing_support_code/hooks/README.md).
 
   ([1569](https://github.com/cucumber/cucumber-ruby/pull/1569)
-   [aurelien-reeves](https://github.com/aurelien-reeves))
+  [aurelien-reeves](https://github.com/aurelien-reeves))
 
 - New hook: `InstallPlugin`
 
@@ -38,7 +38,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   [features/docs/writing_support_code/hooks/README.md](./features/docs/writing_support_code/hooks/README.md).
 
   ([1564](https://github.com/cucumber/cucumber-ruby/pull/1564)
-   [aurelien-reeves](https://github.com/aurelien-reeves))
+  [aurelien-reeves](https://github.com/aurelien-reeves))
 
 ### Fixed
 
@@ -62,14 +62,14 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   to update your code accordingly.
 
   ([1564](https://github.com/cucumber/cucumber-ruby/pull/1564)
-   [aurelien-reeves](https://github.com/aurelien-reeves))
+  [aurelien-reeves](https://github.com/aurelien-reeves))
 
 ### Known issue
 
 - There is a known issue with JRuby 9.3. For more info, see
   [PR#1571](https://github.com/cucumber/cucumber-ruby/pull/1571).
 
-## [7.0.0](https://github.com/cucumber/cucumber-ruby/compare/v6.1.0...v7.0.0)
+## [7.0.0](https://github.com/cucumber/cucumber-ruby/compare/v6.1.0...v7.0.0) (2021-07-19)
 
 ### Fixed
 
@@ -85,11 +85,11 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
   This brings some breaking changes in `Cucumber::Messages`.
   ([1544](https://github.com/cucumber/cucumber-ruby/pull/1544)
-   [aurelien-reeves](https://github.com/aurelien-reeves))
+  [aurelien-reeves](https://github.com/aurelien-reeves))
 
   This also fixes [1545](https://github.com/cucumber/cucumber-ruby/issues/1545)
   ([1549](https://github.com/cucumber/cucumber-ruby/pull/1549)
-   [luke-hill](https://github.com/luke-hill))
+  [luke-hill](https://github.com/luke-hill))
 
 ### Removed
 
@@ -98,17 +98,17 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   Windows, execute cucumber with `--no-color`, or install
   [ANSICON](https://github.com/adoxa/ansicon/) globally.
   ([1561](https://github.com/cucumber/cucumber-ruby/pull/1561)
-   [yosukei3108](https://github.com/yosukei3108))
+  [yosukei3108](https://github.com/yosukei3108))
 
-## [v6.1.0](https://github.com/cucumber/cucumber-ruby/compare/v6.0.0...v6.1.0)
+## [v6.1.0](https://github.com/cucumber/cucumber-ruby/compare/v6.0.0...v6.1.0) (2021-05-18)
 
 ### Fixed
 
 - `--dry-run` now supports `message` based-formatters
   ([1540](https://github.com/cucumber/cucumber-ruby/pull/1540)
-   [1496](https://github.com/cucumber/cucumber-ruby/issues/1496)
-   [1488](https://github.com/cucumber/cucumber-ruby/issues/1488)
-   [aurelien-reeves](https://github.com/aurelien-reeves))
+  [1496](https://github.com/cucumber/cucumber-ruby/issues/1496)
+  [1488](https://github.com/cucumber/cucumber-ruby/issues/1488)
+  [aurelien-reeves](https://github.com/aurelien-reeves))
 - Step definitions now uses object instances created in the ParameterType
   ([1538](https://github.com/cucumber/cucumber-ruby/pull/1538)
   [1532](https://github.com/cucumber/cucumber-ruby/issues/1532)
@@ -132,7 +132,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 - Updated `cucumber-core` ~> 9.0.1
 
-## [v6.0.0](https://github.com/cucumber/cucumber-ruby/compare/v5.3.0...v6.0.0)
+## [v6.0.0](https://github.com/cucumber/cucumber-ruby/compare/v5.3.0...v6.0.0) (2021-04-14)
 
 ### Added
 
@@ -162,7 +162,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   ([#1523](https://github.com/cucumber/cucumber-ruby/pull/1523)
   [aurelien-reeves](https://github.com/aurelien-reeves))
 
-## [5.3.0](https://github.com/cucumber/cucumber-ruby/compare/v5.2.0...v5.3.0)
+## [5.3.0](https://github.com/cucumber/cucumber-ruby/compare/v5.2.0...v5.3.0) (2021-01-28)
 
 ### Added
 
@@ -180,31 +180,31 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   [#1500](https://github.com/cucumber/cucumber-ruby/pull/1500)
   [aurelien-reeves](https://github.com/aurelien-reeves))
 
-## [5.2.0](https://github.com/cucumber/cucumber-ruby/compare/v5.1.3...v5.2.0)
+## [5.2.0](https://github.com/cucumber/cucumber-ruby/compare/v5.1.3...v5.2.0) (2020-10-21)
 
 ### Changed
 
 - `--publish` uses the response provided by the server as the banner [#1472](https://github.com/cucumber/cucumber-ruby/issues/1472)
 
-## [5.1.3](https://github.com/cucumber/cucumber-ruby/compare/v5.1.2...v5.1.3)
+## [5.1.3](https://github.com/cucumber/cucumber-ruby/compare/v5.1.2...v5.1.3) (2020-10-07)
 
 ### Fixed
 
 - The `CUCUMBER_PUBLISH_TOKEN` now sets the correct HTTP header, following a fix in the curl option parser.
 
-## [5.1.2](https://github.com/cucumber/cucumber-ruby/compare/v5.1.1...v5.1.2)
+## [5.1.2](https://github.com/cucumber/cucumber-ruby/compare/v5.1.1...v5.1.2) (2020-09-18)
 
 ### Fixed
 
 - Do not send headers after following redirection [#1475](https://github.com/cucumber/cucumber-ruby/pull/1475)
 
-## [5.1.1](https://github.com/cucumber/cucumber-ruby/compare/v5.1.0...v5.1.1)
+## [5.1.1](https://github.com/cucumber/cucumber-ruby/compare/v5.1.0...v5.1.1) (2020-09-04)
 
 ### Security fixes
 
 - Update `cucumber-create-meta` to 2.0.2
 
-## [5.1.0](https://github.com/cucumber/cucumber-ruby/compare/v5.0.0...5.1.0)
+## [5.1.0](https://github.com/cucumber/cucumber-ruby/compare/v5.0.0...5.1.0) (2020-08-24)
 
 ### Added
 
@@ -223,7 +223,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 - Display banner on stderr when publishing reports [#1462](https://github.com/cucumber/cucumber-ruby/issues/1462)
 
-## [5.0.0](https://github.com/cucumber/cucumber-ruby/compare/v4.1.0...5.0.0)
+## [5.0.0](https://github.com/cucumber/cucumber-ruby/compare/v4.1.0...5.0.0) (2020-08-19)
 
 ### Added
 
@@ -254,7 +254,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
     - Add filtering capabilities [#1444](https://github.com/cucumber/cucumber-ruby/issues/1444)
 - Fix Interceptor that was raising exception when calling `puts` on the wrapped stream ([#1445](https://github.com/cucumber/cucumber-ruby/issues/1445))
 
-## [4.1.0](https://github.com/cucumber/cucumber-ruby/compare/v4.0.1...v4.1.0)
+## [4.1.0](https://github.com/cucumber/cucumber-ruby/compare/v4.0.1...v4.1.0) (2020-07-01)
 
 ### Changed
 
@@ -273,13 +273,13 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 - `AfterStep` hook do not cause issue when running `message` formatter. [#1433](https://github.com/cucumber/cucumber-ruby/issues/1433) - [#1434](https://github.com/cucumber/cucumber-ruby/pull/1434)
 
-## [4.0.1](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0...v4.0.1)
+## [4.0.1](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0...v4.0.1) (2020-06-23)
 
 ### Fixed
 
 - force reference to `diff-lcs` to 1.3 as 1.4 introduced breaking changes.
 
-## [4.0.0](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0.rc.5...v4.0.0)
+## [4.0.0](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0.rc.5...v4.0.0) (2020-06-02)
 
 ### Changed
 
@@ -289,7 +289,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 - Display snippet when using undefined parameter type [#1411](https://github.com/cucumber/cucumber-ruby/issues/1411)
 
-## [4.0.0.rc.6](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0.rc.5...4.0.0.rc.6)
+## [4.0.0.rc.6](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0.rc.5...4.0.0.rc.6) (2020-04-24)
 
 ### Changed
 
@@ -317,7 +317,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   - use `PUT` method by default
   - use a cURL like options (for example: `cucumber --out 'http://example.com -X POST -H Content-Type: json`)
 
-## [4.0.0.rc.5](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0.rc.4...4.0.0.rc.5)
+## [4.0.0.rc.5](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0.rc.4...4.0.0.rc.5) (2020-03-17)
 
 ### Added
 
@@ -329,7 +329,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   Other `http-` prefixed query parameters will be converted to request headers
   (with the `http-` prefix stripped off).
 
-## [4.0.0.rc.4](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0.rc.3...4.0.0.rc.4)
+## [4.0.0.rc.4](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0.rc.3...4.0.0.rc.4) (2020-02-24)
 
 ### Added
 
@@ -343,13 +343,13 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 - `puts` in step definitions in favor of `log` ([cucumber#897](https://github.com/cucumber/cucumber/issues/897))
 - `embed` in step definitions in favor of `attach` ([cucumber#897](https://github.com/cucumber/cucumber/issues/897))
 
-## [4.0.0.rc.3](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0.rc.2...v4.0.0.rc.3)
+## [4.0.0.rc.3](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0.rc.2...v4.0.0.rc.3) (2019-10-31)
 
 ### Changed
 
 - Update to cucumber-wire 1.1.
 
-## [4.0.0.rc.2](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0.rc.1...v4.0.0.rc.2)
+## [4.0.0.rc.2](https://github.com/cucumber/cucumber-ruby/compare/v4.0.0.rc.1...v4.0.0.rc.2) (2019-10-31)
 
 ### Added
 
@@ -567,7 +567,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 - As per [#251](https://github.com/cucumber/cucumber/issues/251): renamed History.md to CHANGELOG.md, added contributing message at beginning, and misc formatting. ([#1185](https://github.com/cucumber/cucumber-ruby/issues/1185) [jaysonesmith](https://github.com/jaysonesmith))
 - Use past tense in event names (`xStarting` -> `xStarted`) ([#1166](https://github.com/cucumber/cucumber-ruby/issues/1166) @brasmusson).
 
-## [3.0.0.pre.2](https://github.com/cucumber/cucumber-ruby/compare/v2.4.0...v3.0.0.pre.2)
+## [3.0.0.pre.2](https://github.com/cucumber/cucumber-ruby/compare/v2.4.0...v3.0.0.pre.2) (2017-07-26)
 
 ### Breaking changes
 
@@ -643,7 +643,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 - Travis: use jruby-9.1.10.0 ([#1114](https://github.com/cucumber/cucumber-ruby/pull/1114) @olleolleolle)
 - Change the Progress, Usage and Stepdef formatter use events ([#977](https://github.com/cucumber/cucumber-ruby/pull/977), [#1129](https://github.com/cucumber/cucumber-ruby/pull/1129) @brasmusson)
 
-## [2.4.0](https://github.com/cucumber/cucumber-ruby/compare/v2.3.3...v2.4.0)
+## [2.4.0](https://github.com/cucumber/cucumber-ruby/compare/v2.3.3...v2.4.0) (2016-06-09)
 
 ### New Features
 
@@ -659,7 +659,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 - Allow Rake task to accept multiple profiles. ([#907](https://github.com/cucumber/cucumber-ruby/pull/907) @jasonkarns)
 - Let the JUnit formatter handle running test cases for different features interweaved ([#952](https://github.com/cucumber/cucumber-ruby/issues/952) @brasmusson)
 
-## [2.3.3](https://github.com/cucumber/cucumber-ruby/compare/v2.3.2...v2.3.3)
+## [2.3.3](https://github.com/cucumber/cucumber-ruby/compare/v2.3.2...v2.3.3) (2016-03-18)
 
 Added a message pointing users to [The Great Cucumber and BDD Census of 2016](https://cucumber.typeform.com/to/kjrSc2?audience=cucumber-ruby) to the installer message. Please take a few moments to help us all learn more about how you're using Cucumber and BDD.
 
@@ -668,15 +668,15 @@ Added a message pointing users to [The Great Cucumber and BDD Census of 2016](ht
 - Let the JSON formatter include data tables in the JSON file ([#948](https://github.com/cucumber/cucumber-ruby/issues/948) @brasmusson)
 - Stringifying location in the JSON formatter for more consistent json parsing ([949](https://github.com/cucumber/cucumber-ruby/pull/949), [945](https://github.com/cucumber/cucumber-ruby/issues/945) @larryprice)
 
-## [2.3.2](https://github.com/cucumber/cucumber-ruby/compare/v2.3.1...v2.3.2)
+## [2.3.2](https://github.com/cucumber/cucumber-ruby/compare/v2.3.1...v2.3.2) (2016-01-21)
 
 Brought the event bus code back into Cucumber to avoid https://github.com/fedux-org/event-bus/issues/6
 
-## [2.3.1](https://github.com/cucumber/cucumber-ruby/compare/v2.3.0...v2.3.1)
+## [2.3.1](https://github.com/cucumber/cucumber-ruby/compare/v2.3.0...v2.3.1) (2016-01-20)
 
 Better deprecation warnings to help fix https://github.com/cucumber/cucumber-ruby/issues/942
 
-## [2.3.0](https://github.com/cucumber/cucumber-ruby/compare/v2.2.0...v2.3.0)
+## [2.3.0](https://github.com/cucumber/cucumber-ruby/compare/v2.2.0...v2.3.0) (2016-01-13)
 
 ### New Features
 
@@ -686,7 +686,7 @@ Better deprecation warnings to help fix https://github.com/cucumber/cucumber-rub
 
 ### Refactoring
 
-## [2.2.0](https://github.com/cucumber/cucumber-ruby/compare/v2.1.0...v2.2.0)
+## [2.2.0](https://github.com/cucumber/cucumber-ruby/compare/v2.1.0...v2.2.0) (2016-01-08)
 
 Although this release is only bugfixes and refactorings, the extraction of the wire protocol is quite a significant change and
 could cause breaking changes for users of undocumented APIs. Hence the minor version bump.
@@ -703,7 +703,7 @@ could cause breaking changes for users of undocumented APIs. Hence the minor ver
 - Remove wire protocol to plugin ([#878](https://github.com/cucumber/cucumber-ruby/pull/878) @mattwynne @tooky)
 - Remove event bus to separate gem ([#933](https://github.com/cucumber/cucumber-ruby/pull/933) @dg-ratiodata)
 
-## [2.1.0](https://github.com/cucumber/cucumber-ruby/compare/v2.0.2...v2.1.0)
+## [2.1.0](https://github.com/cucumber/cucumber-ruby/compare/v2.0.2...v2.1.0) (2015-09-11)
 
 ### New Features
 
@@ -723,14 +723,14 @@ could cause breaking changes for users of undocumented APIs. Hence the minor ver
 - Move behaviour from `Cucumber::Cli::Configuration` to `Cucumber::Configuration` (@tooky, @mattwynne)
 - Integrate Gherkin3 parser ([884](https://github.com/cucumber/cucumber-ruby/pull/884) (@brasmusson)
 
-## [2.0.2](https://github.com/cucumber/cucumber-ruby/compare/v2.0.1...v2.0.2)
+## [2.0.2](https://github.com/cucumber/cucumber-ruby/compare/v2.0.1...v2.0.2) (2015-07-15)
 
 ### Bugfixes
 
 - Revert interface change in Cucumber::Formatter::Console (which can break custom formatters in v2.0.1) ([893](https://github.com/cucumber/cucumber-ruby/issues/893) @brasmusson).
 - Calculate the locations of hooks properly (so it also work between drives on Windows) ([885](https://github.com/cucumber/cucumber-ruby/issues/885) @brasmusson).
 
-## [2.0.1](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0...v2.0.1)
+## [2.0.1](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0...v2.0.1) (2015-07-08)
 
 ### New Features
 
@@ -757,7 +757,7 @@ could cause breaking changes for users of undocumented APIs. Hence the minor ver
 - Rewrite the JUnit Formatter to the new formatter API ([855](https://github.com/cucumber/cucumber-ruby/pull/855) @brasmusson)
 - Rewrite the Progress, Usage, Stepdefs formatters to the new formatter API ([859](https://github.com/cucumber/cucumber-ruby/pull/859) @brasmusson)
 
-## [2.0.0](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.rc.5...v2.0.0)
+## [2.0.0](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.rc.5...v2.0.0) (2015-03-31)
 
 ### New Features
 
@@ -769,7 +769,7 @@ could cause breaking changes for users of undocumented APIs. Hence the minor ver
 - Ensure After Hooks execute in reverse order (@tooky)
 - Make console output with embedded cr/lf look correct. ([820](https://github.com/cucumber/cucumber-ruby/pull/820) @SteveDonie)
 
-## [2.0.0.rc5](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.rc.4...v2.0.0.rc.5)
+## [2.0.0.rc5](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.rc.4...v2.0.0.rc.5) (2015-03-19)
 
 ### New Features
 
@@ -786,7 +786,7 @@ could cause breaking changes for users of undocumented APIs. Hence the minor ver
 - JUnit expand option ([808](https://github.com/cucumber/cucumber-ruby/pull/808) @richarda @brasmusson)
 - Around hooks not executing in correct world context ([807](https://github.com/cucumber/cucumber-ruby/pull/807) @tooky)
 
-## [2.0.0.rc.4](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.rc.3...2.0.0.rc.4)
+## [2.0.0.rc.4](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.rc.3...2.0.0.rc.4) (2015-02-15)
 
 ### Features
 
@@ -800,19 +800,19 @@ could cause breaking changes for users of undocumented APIs. Hence the minor ver
 - Sort scenarios by location ([789](https://github.com/cucumber/cucumber-ruby/issues/789) @mattwynne)
 - Remove keyword from name property of test case object yielded to hooks ([768](https://github.com/cucumber/cucumber-ruby/issues/768) @richarda, @akostadinov)
 
-## [2.0.0.rc.3](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.rc.2...v2.0.0.rc.3)
+## [2.0.0.rc.3](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.rc.2...v2.0.0.rc.3) (2015-01-23)
 
 ### Bugfixes
 
 - MultilineArgument::DataTable#diff will correctly compare to an Array (@tooky)
 
-## [2.0.0.rc.2](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.rc.1...v2.0.0.rc.2)
+## [2.0.0.rc.2](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.rc.1...v2.0.0.rc.2) (2015-01-23)
 
 ### Bugfixes
 
 - World#table no longer creates invalid table objects when using an Array (@tooky, @mattwynne)
 
-## [2.0.0.rc.1](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.beta.5...v2.0.0.rc.1)
+## [2.0.0.rc.1](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.beta.5...v2.0.0.rc.1) (2015-01-23)
 
 ### Removed Features
 
@@ -831,11 +831,11 @@ could cause breaking changes for users of undocumented APIs. Hence the minor ver
 - Using file:line CLI to select scenarios was running same scenario multiple times ([786](https://github.com/cucumber/cucumber-ruby/pull/786) @jdks)
 - Allow spaces in filenames for rerun formatter ([793](https://github.com/cucumber/cucumber-ruby/pull/793) @callahat)
 
-## [2.0.0.beta.5](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.beta.4...v2.0.0.beta.5)
+## [2.0.0.beta.5](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.beta.4...v2.0.0.beta.5) (2014-12-18)
 
 - Depend on the correct version of core (@tooky)
 
-## [2.0.0.beta.4](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.beta.3...v2.0.0.beta.4)
+## [2.0.0.beta.4](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.beta.3...v2.0.0.beta.4) (2014-12-18)
 
 ### New Features
 
@@ -851,7 +851,7 @@ could cause breaking changes for users of undocumented APIs. Hence the minor ver
 
 - Re-write rerun formatter against new formatter API
 
-## [2.0.0.beta.3](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.beta.2...v2.0.0.beta.3)
+## [2.0.0.beta.3](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.beta.2...v2.0.0.beta.3) (2014-09-14)
 
 ### Removed Features
 
@@ -871,14 +871,14 @@ could cause breaking changes for users of undocumented APIs. Hence the minor ver
 - Add back support for the DataTable API ([729](https://github.com/cucumber/cucumber-ruby/pull/729) @mattwynne and @tooky)
 - Fix Windows support loading files properly ([739](https://github.com/cucumber/cucumber-ruby/issues/739) @os97673)
 
-## [2.0.0.beta.2](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.beta.1...v2.0.0.beta.2)
+## [2.0.0.beta.2](https://github.com/cucumber/cucumber-ruby/compare/v2.0.0.beta.1...v2.0.0.beta.2) (2014-08-29)
 
 ### Bugfixes
 
 - Better reporting of exceptions in Before / After hooks ([723](https://github.com/cucumber/cucumber-ruby/pull/723) @mattwynne)
 - Add `#source_tag_names` method to `TestCase` object passed to hooks (@mattwynne)
 
-## [2.0.0.beta.1 ](https://github.com/cucumber/cucumber-ruby/compare/v1.3.8...v2.0.0.beta.1)
+## [2.0.0.beta.1 ](https://github.com/cucumber/cucumber-ruby/compare/v1.3.8...v2.0.0.beta.1) (2014-08-22)
 
 Version 2.0 contains a major internal redesign, extracting the core logic of
 parsing and executing tests into a [separate gem](https://github.com/cucumber/cucumber-ruby-ruby-core).
@@ -913,53 +913,53 @@ all.
 
 - Greek examples added ([497](https://github.com/cucumber/cucumber-ruby/issues/497) @rousisk)
 
-## [1.3.16](https://github.com/cucumber/cucumber-ruby/compare/v1.3.15...v1.3.16)
+## [1.3.16](https://github.com/cucumber/cucumber-ruby/compare/v1.3.15...v1.3.16) (2014-07-28)
 
 - Pass output from the step definition on to the JSON formatter ([701](https://github.com/cucumber/cucumber-ruby/pull/701) @brasmusson)
 - Add RSpec 3 test double support ([689](https://github.com/cucumber/cucumber-ruby/pull/689) @cyphactor)
 - Fix bug with rerun formatter and `--expand` option ([710](https://github.com/cucumber/cucumber-ruby/pull/710) @brasmusson)
 
-## [1.3.15](https://github.com/cucumber/cucumber-ruby/compare/v1.3.14...v1.3.15)
+## [1.3.15](https://github.com/cucumber/cucumber-ruby/compare/v1.3.14...v1.3.15) (2014-05-09)
 
 - Fixed intermittent ConcurrencyError seen in JRuby
   ([671](https://github.com/cucumber/cucumber-ruby/issues/670) @cbusbey)
 
-## [1.3.14](https://github.com/cucumber/cucumber-ruby/compare/v1.3.13...v1.3.14)
+## [1.3.14](https://github.com/cucumber/cucumber-ruby/compare/v1.3.13...v1.3.14) (2014-03-28)
 
 - Rerun formatter includes all scenarios when the background fails
   ([660](https://github.com/cucumber/cucumber-ruby/issues/660),
   [661](https://github.com/cucumber/cucumber-ruby/pull/661) @brasmusson)
 
-## [1.3.13](https://github.com/cucumber/cucumber-ruby/compare/v1.3.12...v1.3.13)
+## [1.3.13](https://github.com/cucumber/cucumber-ruby/compare/v1.3.12...v1.3.13) (2014-03-25)
 
 - Rerun formatter includes all scenarios when the background fails
   ([654](https://github.com/cucumber/cucumber-ruby/pull/654) @brasmusson)
 
-## [1.3.12](https://github.com/cucumber/cucumber-ruby/compare/v1.3.11...v1.3.12)
+## [1.3.12](https://github.com/cucumber/cucumber-ruby/compare/v1.3.11...v1.3.12) (2014-03-16)
 
 - Use MultiTest to handle assertions library selection (@tooky)
 - Adds full support for rails 4.1 / Minitest
 
-## [1.3.11](https://github.com/cucumber/cucumber-ruby/compare/v1.3.10...v1.3.11)
+## [1.3.11](https://github.com/cucumber/cucumber-ruby/compare/v1.3.10...v1.3.11) (2014-03-02)
 
 - Add Ruby 2.1 Support ([#644](https://github.com/cucumber/cucumber-ruby/pull/644) @tooky, @chrismdp)
 
-## [1.3.10](https://github.com/cucumber/cucumber-ruby/compare/v1.3.9...v1.3.10)
+## [1.3.10](https://github.com/cucumber/cucumber-ruby/compare/v1.3.9...v1.3.10) (2013-11-16)
 
 - Fixed "nil:NilClass (NoMethodError)" problem for auto-formatting ([599](https://github.com/cucumber/cucumber-ruby/pull/599) @jmcaffee)
 
-## [1.3.9](https://github.com/cucumber/cucumber-ruby/compare/v1.3.8...v1.3.9)
+## [1.3.9](https://github.com/cucumber/cucumber-ruby/compare/v1.3.8...v1.3.9) (2013-11-06)
 
 - Disable minitest autorun after loading support files (@tooky)
 - Add `Ast::Table#map_column` for non-mutating column mapping (@tooky)
 - Remove deprecation warnings on `Ast::Table` (@tooky)
 - Fixed ArgumentError for NoStepMatch#format_args ([587](https://github.com/cucumber/cucumber-ruby/pull/587) @jshraibman-mdsol)
 
-## [1.3.8](https://github.com/cucumber/cucumber-ruby/compare/v1.3.7...v1.3.8)
+## [1.3.8](https://github.com/cucumber/cucumber-ruby/compare/v1.3.7...v1.3.8) (2013-09-10)
 
 - Make the MultiJson dependency less restrictive (@tooky)
 
-## [1.3.7](https://github.com/cucumber/cucumber-ruby/compare/v1.3.6...v1.3.7)
+## [1.3.7](https://github.com/cucumber/cucumber-ruby/compare/v1.3.6...v1.3.7) (2013-09-06)
 
 - Fixed incorrect html formatter behaviour when background step fails
   ([520](https://github.com/cucumber/cucumber-ruby/issues/520),
@@ -978,20 +978,20 @@ all.
 - AST::Table#map_headers doesn't use #map_headers! anymore
   ([505](https://github.com/cucumber/cucumber-ruby/issues/528) @adbatista)
 
-## [1.3.6](https://github.com/cucumber/cucumber-ruby/compare/v1.3.5...v1.3.6)
+## [1.3.6](https://github.com/cucumber/cucumber-ruby/compare/v1.3.5...v1.3.6) (2013-08-09)
 
 - Html formatter fixed to not mark passes scenarios with tables as pending
   ([493](https://github.com/cucumber/cucumber-ruby/issues/493) Oleg Sukhodolsky)
 
-## [1.3.5](https://github.com/cucumber/cucumber-ruby/compare/v1.3.4...v1.3.5)
+## [1.3.5](https://github.com/cucumber/cucumber-ruby/compare/v1.3.4...v1.3.5) (2013-07-19)
 
 - Fix Rails 4 Minitest autorun problems. ([501](https://github.com/cucumber/cucumber-ruby/issues/501) @mattwynne)
 
-## [1.3.4](https://github.com/cucumber/cucumber-ruby/compare/v1.3.3...v1.3.4)
+## [1.3.4](https://github.com/cucumber/cucumber-ruby/compare/v1.3.3...v1.3.4) (2013-07-12)
 
 - JUnit formatter fixed to report skipped scenarios correctly ([496](https://github.com/cucumber/cucumber-ruby/issues/496) @ambirag)
 
-## [1.3.3](https://github.com/cucumber/cucumber-ruby/compare/v1.3.2...v1.3.3)
+## [1.3.3](https://github.com/cucumber/cucumber-ruby/compare/v1.3.2...v1.3.3) (2013-07-07)
 
 - Fix compatability with MiniTest 5.0 ([#456](https://github.com/cucumber/cucumber-ruby/issues/456) Matt Wynne)
 - Warn that Spork support is broken (Steve Tooke)
@@ -999,20 +999,20 @@ all.
   ([#492](https://github.com/cucumber/cucumber-ruby/issues/492) Matt Wynne)
 - Use new Rubygems API to look for bundler ([#448](https://github.com/cucumber/cucumber-ruby/issues/448) Matt Wynne)
 
-## [1.3.2](https://github.com/cucumber/cucumber-ruby/compare/v1.3.1...v1.3.2)
+## [1.3.2](https://github.com/cucumber/cucumber-ruby/compare/v1.3.1...v1.3.2) (2013-05-22)
 
 ### Bugfixes
 
 - Fixed ugly NoMethodError when a Scenario Outline has no Examples
   ([#438](https://github.com/cucumber/cucumber-ruby/issues/438) Steve Tooke)
 
-## [1.3.1](https://github.com/cucumber/cucumber-ruby/compare/v1.3.0...v1.3.1)
+## [1.3.1](https://github.com/cucumber/cucumber-ruby/compare/v1.3.0...v1.3.1) (2013-04-21)
 
 ### Bugfixes
 
 - Fixed typo which breaks unicode.rb on Windows (Oleg Sukhodolsky)
 
-## [1.3.0](https://github.com/cucumber/cucumber-ruby/compare/v1.2.5...v1.3.0)
+## [1.3.0](https://github.com/cucumber/cucumber-ruby/compare/v1.2.5...v1.3.0) (2013-04-21)
 
 ### New Features
 
@@ -1049,23 +1049,23 @@ all.
 - Better delegation to IO in Cucumber::Formatter::Interceptor::Pipe
   ([#312](https://github.com/cucumber/cucumber-ruby/issues/312) Oleg Sukhodolsky)
 
-## [1.2.5](https://github.com/cucumber/cucumber-ruby/compare/v1.2.3...v1.2.5)
+## [1.2.5](https://github.com/cucumber/cucumber-ruby/compare/v1.2.3...v1.2.5) (2013-04-08)
 
 - Upgrade Gherkin version to remove warnings when running on JRuby. ([#393](https://github.com/cucumber/cucumber-ruby/issues/393) Oleg Sukhodolsky)
 - Do not use TagExpression.eval() which is deprecated in Gherkin 2.11.7 ([#420](https://github.com/cucumber/cucumber-ruby/issues/420) Oleg Sukhodolsky)
 
-## 1.2.4
+## 1.2.4 (2013-04-07)
 
 Yanked. See ([#428](https://github.com/cucumber/cucumber-ruby/issues/428)).
 
-## [1.2.3](https://github.com/cucumber/cucumber-ruby/compare/v1.2.2...v1.2.3)
+## [1.2.3](https://github.com/cucumber/cucumber-ruby/compare/v1.2.2...v1.2.3) (2013-03-07)
 
 ### Bugfixes
 
 - Fix problem with rake task for jruby and ruby installed from packages on Ubuntu ([#386](https://github.com/cucumber/cucumber-ruby/issues/386), [#388](https://github.com/cucumber/cucumber-ruby/issues/388) @y-higuchi)
 - Fix embedding images in json ([#315](https://github.com/cucumber/cucumber-ruby/issues/315) Oleg Sukhodolsky)
 
-## [1.2.2](https://github.com/cucumber/cucumber-ruby/compare/v1.2.1...v1.2.2)
+## [1.2.2](https://github.com/cucumber/cucumber-ruby/compare/v1.2.1...v1.2.2) (2013-03-02)
 
 ### New Features
 
@@ -1086,13 +1086,13 @@ Yanked. See ([#428](https://github.com/cucumber/cucumber-ruby/issues/428)).
 - Fix exception in Html formatter with --expand mode and undefined steps ([#336](https://github.com/cucumber/cucumber-ruby/issues/336) Roberto Decurnex)
 - Fix Table.diff! problem with :surplus_row => false and interleaved surplus rows ([#220](https://github.com/cucumber/cucumber-ruby/issues/220))
 
-## [1.2.1](https://github.com/cucumber/cucumber-ruby/compare/v1.2.0...v1.2.1)
+## [1.2.1](https://github.com/cucumber/cucumber-ruby/compare/v1.2.0...v1.2.1) (2012-06-09)
 
 ### New Features
 
 - Updated to gherkin 2.11.0. (Aslak Hellesøy)
 
-## [1.2.0](https://github.com/cucumber/cucumber-ruby/compare/v1.1.9...v1.2.0)
+## [1.2.0](https://github.com/cucumber/cucumber-ruby/compare/v1.1.9...v1.2.0) (2012-05-07)
 
 ### Bugfixes
 
@@ -1111,13 +1111,13 @@ Yanked. See ([#428](https://github.com/cucumber/cucumber-ruby/issues/428)).
 - JUnit formatter, classname contains only the feature's name ([#193](https://github.com/cucumber/cucumber-ruby/issues/193) @litvinok)
 - Include the output $stderr and $stdout in JUnit formatted XML ([#259](https://github.com/cucumber/cucumber-ruby/issues/259) R. Tyler Croy)
 
-## [1.1.9](https://github.com/cucumber/cucumber-ruby/compare/v1.1.8...v1.1.9)
+## [1.1.9](https://github.com/cucumber/cucumber-ruby/compare/v1.1.8...v1.1.9) (2012-02-22)
 
 ### Bugfixes
 
 - Removed deprecation warning for `source_tag_names`. It's not deprecated anymore. (Aslak Hellesøy)
 
-## [1.1.8](https://github.com/cucumber/cucumber-ruby/compare/v1.1.7...v1.1.8)
+## [1.1.8](https://github.com/cucumber/cucumber-ruby/compare/v1.1.7...v1.1.8) (2012-02-19)
 
 ### Bugfixes
 
@@ -1127,13 +1127,13 @@ Yanked. See ([#428](https://github.com/cucumber/cucumber-ruby/issues/428)).
 
 - Don't pollute RbWorld with the AnsiEscapes methods ([#219](https://github.com/cucumber/cucumber-ruby/issues/219), [#221](https://github.com/cucumber/cucumber-ruby/pull/221) Ben Woosley)
 
-## [1.1.7](https://github.com/cucumber/cucumber-ruby/compare/v1.1.6...v1.1.7)
+## [1.1.7](https://github.com/cucumber/cucumber-ruby/compare/v1.1.6...v1.1.7) (2012-02-19)
 
 ### Bugfixes
 
 - Finish off backwards compatability fix for Capybara ([#229](https://github.com/cucumber/cucumber-ruby/pull/229) Cezary Baginski)
 
-## [1.1.6](https://github.com/cucumber/cucumber-ruby/compare/v1.1.5...v1.1.6)
+## [1.1.6](https://github.com/cucumber/cucumber-ruby/compare/v1.1.5...v1.1.6) (2012-02-18)
 
 ### New features
 
@@ -1146,7 +1146,7 @@ Yanked. See ([#428](https://github.com/cucumber/cucumber-ruby/issues/428)).
 - After some infantile bickering about a trivial bug that any hipster startup ruby programmer could have circumvented by using a fork with a fix,
   I finally sucked up to a horde of people and made HTML reports work again (I'm gonna rename them TPS reports). ([#203](https://github.com/cucumber/cucumber-ruby/pull/203) Jon Merrifield)
 
-## [1.1.5](https://github.com/cucumber/cucumber-ruby/compare/v1.1.4...v1.1.5)
+## [1.1.5](https://github.com/cucumber/cucumber-ruby/compare/v1.1.4...v1.1.5) (2012-02-17)
 
 ### New Features
 
@@ -1156,13 +1156,13 @@ Yanked. See ([#428](https://github.com/cucumber/cucumber-ruby/issues/428)).
 
 - Background fails, but build succeeds ([#205](https://github.com/cucumber/cucumber-ruby/issues/205) tcwitte)
 
-## [1.1.4](https://github.com/cucumber/cucumber-ruby/compare/v1.1.3...v1.1.4)
+## [1.1.4](https://github.com/cucumber/cucumber-ruby/compare/v1.1.3...v1.1.4) (2011-12-10)
 
 ### New Features
 
 - Upgrade to Gherkin 2.7.1 (Aslak Hellesøy)
 
-## [1.1.3](https://github.com/cucumber/cucumber-ruby/compare/v1.1.2...v1.1.3)
+## [1.1.3](https://github.com/cucumber/cucumber-ruby/compare/v1.1.2...v1.1.3) (2011-11-22)
 
 ### New Features
 
@@ -1176,7 +1176,7 @@ Yanked. See ([#428](https://github.com/cucumber/cucumber-ruby/issues/428)).
 - Retry when feature_element returns failed ([#172](https://github.com/cucumber/cucumber-ruby/pull/172) Charles Finkel)
 - Rerun formatter output does not include failing scenario outline examples ([#57](https://github.com/cucumber/cucumber-ruby/issues/57) Jan Brauer)
 
-## [1.1.2](https://github.com/cucumber/cucumber-ruby/compare/v1.1.1...v1.1.2)
+## [1.1.2](https://github.com/cucumber/cucumber-ruby/compare/v1.1.1...v1.1.2) (2011-11-09)
 
 ### Changed features
 
@@ -1197,25 +1197,25 @@ New format:
 
 Also see [Gherkin 2.6.0 History](https://github.com/cucumber/cucumber/blob/master/gherkin/History.md) for info about new `id` and `uri` elements in the JSON.
 
-## [1.1.0](https://github.com/cucumber/cucumber-ruby/compare/v1.0.6...v1.1.0)
+## [1.1.0](https://github.com/cucumber/cucumber-ruby/compare/v1.0.6...v1.1.0) (2011-09-22)
 
 ### Changed features
 
 - The JSON formatter output has changed. See [Gherkin 2.5.0 History](https://github.com/cucumber/gherkin/blob/master/CHANGELOG.md) (Aslak Hellesøy)
 
-## [1.0.6](https://github.com/cucumber/cucumber-ruby/compare/v1.0.5...v1.0.6)
+## [1.0.6](https://github.com/cucumber/cucumber-ruby/compare/v1.0.5...v1.0.6) (2011-09-13)
 
 ### Bugfixes
 
 - Work around rubygems/yaml utter retardedness ([#136](https://github.com/cucumber/cucumber-ruby/issues/136) Aslak Hellesøy)
 
-## [1.0.5](https://github.com/cucumber/cucumber-ruby/compare/v1.0.4...v1.0.5)
+## [1.0.5](https://github.com/cucumber/cucumber-ruby/compare/v1.0.4...v1.0.5) (2011-09-13)
 
 ### Bugfixes
 
 - Gemspec corrupted in 1.0.4 (I had to upgrade my rubygems to 1.8.10 to fix it). ([#136](https://github.com/cucumber/cucumber-ruby/issues/136) Aslak Hellesøy)
 
-## [1.0.4](https://github.com/cucumber/cucumber-ruby/compare/v1.0.3...v1.0.4)
+## [1.0.4](https://github.com/cucumber/cucumber-ruby/compare/v1.0.3...v1.0.4) (2011-09-11)
 
 ### Bugfixes
 
@@ -1225,7 +1225,7 @@ Also see [Gherkin 2.6.0 History](https://github.com/cucumber/cucumber/blob/maste
 - Patched unmatched message in HTML formatter. (Nikita)
 - Overriding a method that causes a NoMethodError when a Before hook is called on a feature run that has no scenarios. (ccthiel)
 
-## [1.0.3](https://github.com/cucumber/cucumber-ruby/compare/v1.0.2...v1.0.3)
+## [1.0.3](https://github.com/cucumber/cucumber-ruby/compare/v1.0.2...v1.0.3) (2011-09-07)
 
 ### Bugfixes
 
@@ -1235,7 +1235,7 @@ Also see [Gherkin 2.6.0 History](https://github.com/cucumber/cucumber/blob/maste
 
 - DocStrings now have a content_type ([#132](https://github.com/cucumber/cucumber-ruby/issues/132) Matt Wynne)
 
-## [1.0.2](https://github.com/cucumber/cucumber-ruby/compare/v1.0.1...v1.0.2)
+## [1.0.2](https://github.com/cucumber/cucumber-ruby/compare/v1.0.1...v1.0.2) (2011-07-17)
 
 ### Bugfixes
 
@@ -1249,7 +1249,7 @@ Also see [Gherkin 2.6.0 History](https://github.com/cucumber/cucumber/blob/maste
 
 - --no-source also excludes location from the summary. (Aslak Hellesøy)
 
-## [1.0.1](https://github.com/cucumber/cucumber-ruby/compare/v1.0.0...v1.0.1)
+## [1.0.1](https://github.com/cucumber/cucumber-ruby/compare/v1.0.0...v1.0.1) (2011-07-10)
 
 ### Bugfixes
 
@@ -1263,7 +1263,7 @@ Also see [Gherkin 2.6.0 History](https://github.com/cucumber/cucumber/blob/maste
 
 - If the CUCUMBER_TRUNCATE_OUTPUT environment variable is set, lines will be truncated. Used by the Cucumber book. (Aslak Hellesøy)
 
-## [1.0.0](https://github.com/cucumber/cucumber-ruby/compare/v0.10.6...v1.0.0)
+## [1.0.0](https://github.com/cucumber/cucumber-ruby/compare/v0.10.6...v1.0.0) (2011-06-20)
 
 Yipeeeeeeeee!
 
@@ -1273,7 +1273,7 @@ Yipeeeeeeeee!
 - Rake task exits with an error if rcov is true and we're on Ruby 1.9.x (Aslak Hellesøy)
 - Started implementation of cucumber-features (Mike Sassak, Julien Biezemans, Aslak Hellesøy)
 
-## [0.10.6](https://github.com/cucumber/cucumber-ruby/compare/v0.10.5...v0.10.6)
+## [0.10.6](https://github.com/cucumber/cucumber-ruby/compare/v0.10.5...v0.10.6) (2011-06-07)
 
 ### New Features
 
@@ -1283,7 +1283,7 @@ Yipeeeeeeeee!
 
 - Fixed a regression in the HTML formatter's #embed implementation (#77 Aslak Hellesøy)
 
-## [0.10.5](https://github.com/cucumber/cucumber-ruby/compare/v0.10.3...v0.10.5)
+## [0.10.5](https://github.com/cucumber/cucumber-ruby/compare/v0.10.3...v0.10.5) (2011-06-05)
 
 (0.10.4 was forgotten!)
 
@@ -1301,7 +1301,7 @@ Yipeeeeeeeee!
 - Fix for Gem.available? deprecation warning (#75 Jake Benilov)
 - Update URLs to reflect Cucumber's new location on Github (Jake Benilov)
 
-## [0.10.3](https://github.com/cucumber/cucumber-ruby/compare/v0.10.2...v0.10.3)
+## [0.10.3](https://github.com/cucumber/cucumber-ruby/compare/v0.10.2...v0.10.3) (2011-05-23)
 
 ### New Features
 
@@ -1311,13 +1311,13 @@ Yipeeeeeeeee!
 - Fix Table#rows cell ordering in ruby 1.8. (#47_github Brian Dunn)
 - JUnit Formatter: record skipped/pending/undefined scenario results (#655 meeee)
 
-## [0.10.2](https://github.com/cucumber/cucumber-ruby/compare/v0.10.1...v0.10.2)
+## [0.10.2](https://github.com/cucumber/cucumber-ruby/compare/v0.10.1...v0.10.2) (2011-03-20)
 
 ### Bugfixes
 
 - Neuter both MiniTest::Unit and Test::Unit's overzealous test runners. (Aslak Hellesøy)
 
-## [0.10.1](https://github.com/cucumber/cucumber-ruby/compare/v0.10.0...v0.10.1)
+## [0.10.1](https://github.com/cucumber/cucumber-ruby/compare/v0.10.0...v0.10.1) (2011-03-20)
 
 ### New Features
 
@@ -1339,7 +1339,7 @@ Yipeeeeeeeee!
 - Features files are sorted before they are executed, giving consistent results across different OSes (Guewen Baconnier)
 - Remove duplicate lines in backtraces in the HTML report (Jari Bakken)
 
-## [0.10.0](https://github.com/cucumber/cucumber-ruby/compare/v0.9.4...v0.10.0)
+## [0.10.0](https://github.com/cucumber/cucumber-ruby/compare/v0.9.4...v0.10.0) (2010-12-07)
 
 We're bumping the minor number in this release because there are some incompatible changes in the JSON support.
 This should not affect users. The major new feature in this release is ANSICON support for Windows users.
@@ -1358,7 +1358,7 @@ This should not affect users. The major new feature in this release is ANSICON s
 
 - JSON output now contains optional "match", "result" and "embeddings" elements underneath each step. (Aslak Hellesøy)
 
-## [0.9.4](https://github.com/cucumber/cucumber-ruby/compare/v0.9.3...v0.9.4)
+## [0.9.4](https://github.com/cucumber/cucumber-ruby/compare/v0.9.3...v0.9.4) (2010-11-06)
 
 ### Bugfixes
 
@@ -1368,7 +1368,7 @@ This should not affect users. The major new feature in this release is ANSICON s
 - Cucumber 0.9.3 prevents Test::Unit from running (#677 Aslak Hellesøy)
 - Performance degradation when running feature files with over 1000 steps (#675 Dimitri Geshef)
 
-## [0.9.3](https://github.com/cucumber/cucumber-ruby/compare/v0.9.2...v0.9.3)
+## [0.9.3](https://github.com/cucumber/cucumber-ruby/compare/v0.9.2...v0.9.3) (2010-10-24)
 
 ### Bugfixes
 
@@ -1377,19 +1377,19 @@ This should not affect users. The major new feature in this release is ANSICON s
 - Prevent MiniTest::Unit#autorun from running in at_exit hook. (Aslak Hellesøy)
 - Fixed incorect --help for --strict. It fails on both pending and undefined. (Aslak Hellesøy)
 
-## [0.9.2](https://github.com/cucumber/cucumber-ruby/compare/v0.9.1...v0.9.2)
+## [0.9.2](https://github.com/cucumber/cucumber-ruby/compare/v0.9.1...v0.9.2) (2010-10-04)
 
 ### Bugfixes
 
 - Too many open files - getcwd (#666 Aslak Hellesøy)
 
-## [0.9.1](https://github.com/cucumber/cucumber-ruby/compare/v0.9.0...v0.9.1)
+## [0.9.1](https://github.com/cucumber/cucumber-ruby/compare/v0.9.0...v0.9.1) (2010-10-01)
 
 ### Bugfixes
 
 - Just a minor internal change to make Cuke4Duke happy. (Aslak Hellesøy)
 
-## [0.9.0](https://github.com/cucumber/cucumber-ruby/compare/v0.8.5...v0.9.0)
+## [0.9.0](https://github.com/cucumber/cucumber-ruby/compare/v0.8.5...v0.9.0) (2010-09-21)
 
 Maintenance release for the new release of Gherkin 2.2.3.
 
@@ -1411,14 +1411,14 @@ Maintenance release for the new release of Gherkin 2.2.3.
 
 - Big refactoring of StepMother (Matt Wynne)
 
-## [0.8.5](https://github.com/cucumber/cucumber-ruby/compare/v0.8.4...v0.8.5)
+## [0.8.5](https://github.com/cucumber/cucumber-ruby/compare/v0.8.4...v0.8.5) (2010-07-14)
 
 ### Bugfixes
 
 - Location of stepdefs outside the project (in gems) are reported incorrectly. (#583 Aslak Hellesøy)
 - Cucumber::Rake::Task uses 'bundle exec' when using bundler (#626 John Firebaugh)
 
-## [0.8.4](https://github.com/cucumber/cucumber-ruby/compare/v0.8.3...v0.8.4)
+## [0.8.4](https://github.com/cucumber/cucumber-ruby/compare/v0.8.3...v0.8.4) (2010-07-12)
 
 ### Bugfixes
 
@@ -1429,7 +1429,7 @@ Maintenance release for the new release of Gherkin 2.2.3.
 - Detect limit for negative tags (#636 Aslak Hellesøy)
 - Support for RSpec 2 doubles (mocks and stubs) (Aslak Hellesøy)
 
-## [0.8.3](https://github.com/cucumber/cucumber-ruby/compare/v0.8.2...v0.8.3)
+## [0.8.3](https://github.com/cucumber/cucumber-ruby/compare/v0.8.2...v0.8.3) (2010-06-16)
 
 Just a quick bugfix release.
 
@@ -1437,7 +1437,7 @@ Just a quick bugfix release.
 
 - Scenario outlines that fail with exception exit process (Aslak Hellesøy)
 
-## [0.8.2](https://github.com/cucumber/cucumber-ruby/compare/v0.8.1...v0.8.2)
+## [0.8.2](https://github.com/cucumber/cucumber-ruby/compare/v0.8.1...v0.8.2) (2010-06-16)
 
 Bugfix release which most importantly fixes an issue with the gem's gemspec.
 
@@ -1452,7 +1452,7 @@ Bugfix release which most importantly fixes an issue with the gem's gemspec.
 
 - JavaScript to Hide/Expand Scenarios in HTML report (#621 stkenned)
 
-## [0.8.1](https://github.com/cucumber/cucumber-ruby/compare/v0.8.0...v0.8.1)
+## [0.8.1](https://github.com/cucumber/cucumber-ruby/compare/v0.8.0...v0.8.1) (2010-06-14)
 
 ### Bufixes
 
@@ -1462,7 +1462,7 @@ Bugfix release which most importantly fixes an issue with the gem's gemspec.
 
 - Undefined steps with integers (Given 3 cukes) will generate snippets like (Given /(\d+) cukes/). (Aslak Hellesøy)
 
-## [0.8.0](https://github.com/cucumber/cucumber-ruby/compare/v0.7.3...v0.8.0)
+## [0.8.0](https://github.com/cucumber/cucumber-ruby/compare/v0.7.3...v0.8.0) (2010-06-06)
 
 ### Bugfixes
 
@@ -1485,20 +1485,20 @@ Bugfix release which most importantly fixes an issue with the gem's gemspec.
 - Ruby snippets will use "([^"]_)" instead of "([^\"]_)"$/ - wasn't properly fixed in 0.7.1. (Aslak Hellesøy)
 - Preserve the order features files are passed and use this for execution order (#617 Joseph Wilk)
 
-## [0.7.3](https://github.com/cucumber/cucumber-ruby/compare/v0.7.2...v0.7.3)
+## [0.7.3](https://github.com/cucumber/cucumber-ruby/compare/v0.7.2...v0.7.3) (2010-05-17)
 
 ### New Features
 
 - Table cells can now contain escaped bars - \| and escaped backslashes - \\. (Gregory Hnatiuk, Aslak Hellesøy)
 - Added support for Around hooks. (#605 John Firebaugh)
 
-## [0.7.2](https://github.com/cucumber/cucumber-ruby/compare/v0.7.1...v0.7.2)
+## [0.7.2](https://github.com/cucumber/cucumber-ruby/compare/v0.7.1...v0.7.2) (2010-05-04)
 
 ### Bugfixes
 
 - REALLY add backwards compatibility fix (with deprecation warning) for legacy 0.6.4 formatters. (Aslak Hellesøy)
 
-## [0.7.1](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0...v0.7.1)
+## [0.7.1](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0...v0.7.1) (2010-05-03)
 
 ### Bugfixes
 
@@ -1508,32 +1508,32 @@ Bugfix release which most importantly fixes an issue with the gem's gemspec.
 
 - Ruby and Javascript snippets will use "([^"]_)" instead of "([^\"]_)"$/ (Aslak Hellesøy)
 
-## [0.7.0](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.8...v0.7.0)
+## [0.7.0](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.8...v0.7.0) (2010-05-02)
 
 This release is an important milestone for Cucumber. A new parser (the gherkin gem) parses feature
 files 50-100 times faster than with 0.6.x and previous releases. Make sure you read the upgrade
 instructions! http://wiki.github.com/aslakhellesoy/cucumber/upgrading
 
-## [0.7.0.beta.8](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.7...v0.7.0.beta.8)
+## [0.7.0.beta.8](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.7...v0.7.0.beta.8) (2010-04-29)
 
 ### Bugfixes
 
 - Inconsistent order of execution Background and Before in 0.7.0.beta.2 (#600 Mike Sassak)
 - Make sure both lexing and parsing errors are captured and reported with line number (Gregory Hnatiuk)
 
-## [0.7.0.beta.7](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.6...v0.7.0.beta.7)
+## [0.7.0.beta.7](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.6...v0.7.0.beta.7) (2010-04-28)
 
 ### Bugfixes
 
 - Depend on gherkin-1.0.22, which should now make things work on Windows and Ruby 1.8.x-1.9.x. (Aslak Hellesøy)
 
-## [0.7.0.beta.6](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.5...v0.7.0.beta.6)
+## [0.7.0.beta.6](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.5...v0.7.0.beta.6) (2010-04-28)
 
 ### Bugfixes
 
 - Fixed a small regression with pystrings and calling steps from stepdefs, introduced in a previous beta. (Aslak Hellesøy)
 
-## [0.7.0.beta.5](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.4...v0.7.0.beta.5)
+## [0.7.0.beta.5](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.4...v0.7.0.beta.5) (2010-04-27)
 
 ### New Features
 
@@ -1543,7 +1543,7 @@ instructions! http://wiki.github.com/aslakhellesoy/cucumber/upgrading
 
 - No more support for RSpec <= 1.2.3. (Aslak Hellesøy)
 
-## [0.7.0.beta.4](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.3...v0.7.0.beta.4)
+## [0.7.0.beta.4](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.3...v0.7.0.beta.4) (2010-04-23)
 
 ### New Features
 
@@ -1553,19 +1553,19 @@ instructions! http://wiki.github.com/aslakhellesoy/cucumber/upgrading
 
 - Gherkin is loaded via rubygems if it can't be found on the $LOAD_PATH. (Aslak Hellesøy)
 
-## [0.7.0.beta.3](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.2...v0.7.0.beta.3)
+## [0.7.0.beta.3](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.2...v0.7.0.beta.3) (2010-04-23)
 
 ### Changed Features
 
 - Step Definitions and calling steps from step definitions can again use And and But (was removed in 0.7.0.beta.2) (Aslak Hellesøy)
 
-## [0.7.0.beta.2](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.1...v0.7.0.beta.2)
+## [0.7.0.beta.2](https://github.com/cucumber/cucumber-ruby/compare/v0.7.0.beta.1...v0.7.0.beta.2) (2010-04-21)
 
 ### New Features
 
 - Depend on Gherkin 1.0.18, which has some bugfixes. (Aslak Hellesøy)
 
-## [0.7.0.beta.1](https://github.com/cucumber/cucumber-ruby/compare/v0.6.4...v0.7.0.beta.1)
+## [0.7.0.beta.1](https://github.com/cucumber/cucumber-ruby/compare/v0.6.4...v0.7.0.beta.1) (2010-04-20)
 
 Treetop is gone and replaced with Ragel. The new Ragel parser lives in the gherkin gem.
 Parse times are up to 100 times faster.
@@ -1578,7 +1578,7 @@ Parse times are up to 100 times faster.
 
 - New i18n translations now have to be contributed to the gherkin project.
 
-## [0.6.4](https://github.com/cucumber/cucumber-ruby/compare/v0.6.3...v0.6.4)
+## [0.6.4](https://github.com/cucumber/cucumber-ruby/compare/v0.6.3...v0.6.4) (2010-03-30)
 
 ### Bugfixes
 
@@ -1602,7 +1602,7 @@ Parse times are up to 100 times faster.
 - Switced to ISO 639-1 (language) and ISO 3166 alpha-2 (region - if applicable). Applies to Catalan,
   Swedish, Welsh, Romanian and Serbian. (Aslak Hellesøy)
 
-## [0.6.3](https://github.com/cucumber/cucumber-ruby/compare/v0.6.2...v0.6.3)
+## [0.6.3](https://github.com/cucumber/cucumber-ruby/compare/v0.6.2...v0.6.3) (2010-03-02)
 
 ### Bugfixes
 
@@ -1623,7 +1623,7 @@ Parse times are up to 100 times faster.
 - Add tags to begin/end scenario messages on wire protocol to support tagged hooks (#571 Matt Wynne)
 - Default timeouts to 120s for invoke, begin_scenario and end_scenario messages in wire protocol (#572 Matt Wynne)
 
-## [0.6.2](https://github.com/cucumber/cucumber-ruby/compare/v0.6.1...v0.6.2)
+## [0.6.2](https://github.com/cucumber/cucumber-ruby/compare/v0.6.1...v0.6.2) (2010-01-17)
 
 ### Bugfixes
 
@@ -1643,13 +1643,13 @@ Parse times are up to 100 times faster.
 
 - element_at and table_at have been removed. Use tableish in cucumber-rails instead. (Aslak Hellesœy)
 
-## [0.6.1](https://github.com/cucumber/cucumber-ruby/compare/v0.6.0...v0.6.1)
+## [0.6.1](https://github.com/cucumber/cucumber-ruby/compare/v0.6.0...v0.6.1) (2010-01-03)
 
 ### Bugfixes
 
 - Fixed broken console handling on Windows/JRuby that was introduced in 0.6.0. (Aslak Hellesøy)
 
-## [0.6.0](https://github.com/cucumber/cucumber-ruby/compare/v0.5.3...v0.6.0)
+## [0.6.0](https://github.com/cucumber/cucumber-ruby/compare/v0.5.3...v0.6.0) (2010-01-03)
 
 Bumping to 0.6.0 for this release since we're breaking backwards compatibility with tags.
 
@@ -1676,7 +1676,7 @@ Bumping to 0.6.0 for this release since we're breaking backwards compatibility w
 - All features (except 4) pass on 1.9.2 (but not on 1.9.1) (Aslak Hellesøy)
 - Add missing require statement in rerun formatter which broke RubyMine (Noah Sussman)
 
-## [0.5.3](https://github.com/cucumber/cucumber-ruby/compare/v0.5.2...v0.5.3)
+## [0.5.3](https://github.com/cucumber/cucumber-ruby/compare/v0.5.2...v0.5.3) (2009-12-22)
 
 Another small release today to please a sister project. This time Cuke4Nuke.
 
@@ -1684,7 +1684,7 @@ Another small release today to please a sister project. This time Cuke4Nuke.
 
 - Simplified wire protocol to mostly use success / fail responses (Matt Wynne)
 
-## [0.5.2](https://github.com/cucumber/cucumber-ruby/compare/v0.5.1...v0.5.2)
+## [0.5.2](https://github.com/cucumber/cucumber-ruby/compare/v0.5.1...v0.5.2) (2009-12-22)
 
 ### New Features
 
@@ -1696,7 +1696,7 @@ Another small release today to please a sister project. This time Cuke4Nuke.
 - Add #embed back to html formatter (#547 Brandon Faloona)
 - Refactored wire protocol code and added configurable timeout to allow for long running step definitions. (#546 Matt Wynne)
 
-## [0.5.1](https://github.com/cucumber/cucumber-ruby/compare/v0.5.0...v0.5.1)
+## [0.5.1](https://github.com/cucumber/cucumber-ruby/compare/v0.5.0...v0.5.1) (2009-12-16)
 
 Small bugfix release.
 
@@ -1704,7 +1704,7 @@ Small bugfix release.
 
 - Replaced dependency on json gem with an error message, so that the cucumber gem installs on JRuby. (Aslak Hellesøy)
 
-## [0.5.0](https://github.com/cucumber/cucumber-ruby/compare/v0.4.4...v0.5.0)
+## [0.5.0](https://github.com/cucumber/cucumber-ruby/compare/v0.4.4...v0.5.0) (2009-12-15)
 
 We're bumping to 0.5.0 for this release since all of the Rails code has now moved to a new gem - cucumber-rails.
 Please see History.txt in cucumber-rails for details about what's new on the Rails side.
@@ -1739,7 +1739,7 @@ Please see History.txt in cucumber-rails for details about what's new on the Rai
 - All Rails-related code is in a separate gem: cucumber-rails. Install that if you're working with Rails. (#483 Aslak Hellesøy)
 - --language is removed: http://wiki.github.com/aslakhellesoy/cucumber/spoken-languages (Aslak Hellesøy)
 
-## [0.4.4](https://github.com/cucumber/cucumber-ruby/compare/v0.4.3...v0.4.4)
+## [0.4.4](https://github.com/cucumber/cucumber-ruby/compare/v0.4.3...v0.4.4) (2009-11-13)
 
 What a bad day to make a release, but here goes.
 
@@ -1767,7 +1767,7 @@ What a bad day to make a release, but here goes.
 - $cucumber_interrupted is now Cucumber.wants_to_quit - avoid global variable, which gives warnings. (Aslak Hellesøy)
 - Examples keyword without a colon is deprecated loudly. Gherkin will not recognize it at all. (Gherkin #30 Mike Sassak)
 
-## [0.4.3](https://github.com/cucumber/cucumber-ruby/compare/v0.4.2...v0.4.3)
+## [0.4.3](https://github.com/cucumber/cucumber-ruby/compare/v0.4.2...v0.4.3) (2009-10-27)
 
 The exciting thing about this release is that the wire protocol is starting to take shape. This means you can
 now use Cucumber with .NET - writing step definitions in C#. And this is without having to use IronRuby at all!
@@ -1798,11 +1798,11 @@ As usual there are several small features and bug fixes.
 - JUnit formatter raises a more helpful error when run on a feature with no name. (#493 Matt Wynne)
 - Better Danish translation (Thorbjørn Ravn Andersen)
 
-## [0.4.2](https://github.com/cucumber/cucumber-ruby/compare/v0.4.1...v0.4.2)
+## [0.4.2](https://github.com/cucumber/cucumber-ruby/compare/v0.4.1...v0.4.2) (2009-10-14)
 
 Bugfix release. The 0.4.1 release was hosed when switching from Hoe to Jeweler.
 
-## [0.4.1](https://github.com/cucumber/cucumber-ruby/compare/v0.4.0...v0.4.1)
+## [0.4.1](https://github.com/cucumber/cucumber-ruby/compare/v0.4.0...v0.4.1) (2009-10-14)
 
 This is mostly a bugfix release. Some of Cucumber's own features have been fixed so they pass on more platforms,
 making it easier for people to contribute. The README.txt also describes how to get up and running with the
@@ -1833,7 +1833,7 @@ development environment.
 - Added StepMother#invoke(step_name, multiline_argument=nil) - needed by cuke4duke ticket #26 (Aslak Hellesøy)
 - StepDefinitionMethods is gone.
 
-## [0.4.0](https://github.com/cucumber/cucumber-ruby/compare/v0.3.104...v0.4.0)
+## [0.4.0](https://github.com/cucumber/cucumber-ruby/compare/v0.3.104...v0.4.0) (2009-10-09)
 
 The back to stable release. When we went from 0.3.11 to 0.3.90 we thought we were close to a 0.4.0 release. Then the community
 went nuts and a lot of great contributions came in. Some of those broke backwards compatibility, and we decided it would be
@@ -1884,7 +1884,7 @@ that will give you more information so you can solve any problems. If not, just 
 - Better backtraces for Ruby 1.8.7. (Jakob Skov-Pedersen)
 - String step definitions ( Given 'I have $number cucumbers' ) are escaped before being turned into regular expressions. (David Waite)
 
-## [0.3.104](https://github.com/cucumber/cucumber-ruby/compare/v0.3.103...v0.3.104)
+## [0.3.104](https://github.com/cucumber/cucumber-ruby/compare/v0.3.103...v0.3.104) (2009-09-27)
 
 This release has some minor changes to the command line and formatters. The biggest change is internally, paving
 the way for more programming language support in Cuke4Duke, which now supports step definitions written in Java, Scala,
@@ -1913,7 +1913,7 @@ Groovy, Clojure and Javascript!
 - The steps formatter has been renamed to stepdefs formatter. (Aslak Hellesøy)
 - The internal programming language API has changed, giving more power to the implementation. See #428. (Aslak Hellesøy)
 
-## [0.3.103](https://github.com/cucumber/cucumber-ruby/compare/v0.3.102...v0.3.103)
+## [0.3.103](https://github.com/cucumber/cucumber-ruby/compare/v0.3.102...v0.3.103) (2009-09-24)
 
 This release gives you back some of the control over the Rails environment that was accidentally taken away from you in the
 previous release.
@@ -1934,7 +1934,7 @@ Using this release on a Rails project requires a rerun of script/generate cucumb
 
 - The Formatter API has completely changed. Formatters are no longer a double-dispacth visitor - just a single-dispatch listener (#438 Matt Wynne)
 
-## [0.3.102](https://github.com/cucumber/cucumber-ruby/compare/v0.3.101...v0.3.102)
+## [0.3.102](https://github.com/cucumber/cucumber-ruby/compare/v0.3.101...v0.3.102) (2009-09-22)
 
 This release has some changes in the Rails support, so make sure you run "script/generate cucumber" after you upgrade.
 Other noteworthy new features are improved Hook, tags and Transform support, and as always - several smaller bug fixes.
@@ -1980,7 +1980,7 @@ your features to your customer for review!
 - Adding webrat steps for asserting content does or does not exist within a particular element
   (using webrat's within method) (Kieran Pilkington)
 
-## [0.3.100](https://github.com/cucumber/cucumber-ruby/compare/v0.3.99...v0.3.100)
+## [0.3.100](https://github.com/cucumber/cucumber-ruby/compare/v0.3.99...v0.3.100) (2009-09-08)
 
 The JavaZone release!
 
@@ -1994,7 +1994,7 @@ The JavaZone release!
 - Backtraces on JRuby are handled in a cleaner way when the exception comes from Java (NativeException). (Aslak Hellesøy)
 - When exceptions occur in a Before block the rest of the scenario is now skipped (#331 Matt Wynne)
 
-## [0.3.99](https://github.com/cucumber/cucumber-ruby/compare/v0.3.98...v0.3.99)
+## [0.3.99](https://github.com/cucumber/cucumber-ruby/compare/v0.3.98...v0.3.99) (2009-09-02)
 
 ### New Features
 
@@ -2004,7 +2004,7 @@ The JavaZone release!
 - New AfterConfiguration hook added; a block can be specified that takes Cucumber::Cli::Configuration (#423 Brent Snook)
 - Cucumber::Cli::Configuration#feature_dirs and #out_stream exposed as public attributes so that they may be used in AfterConfiguration hook (#423 Brent Snook)
 
-## [0.3.98](https://github.com/cucumber/cucumber-ruby/compare/v0.3.97...v0.3.98)
+## [0.3.98](https://github.com/cucumber/cucumber-ruby/compare/v0.3.97...v0.3.98) (2009-08-25)
 
 Just a small release to help Cuke4Duke, which will be presented at Agile2009
 in 2 days.
@@ -2014,7 +2014,7 @@ in 2 days.
 - Backtrace filtering now happens in StepInvocation class, meaning other languages (Cuke4Duke) can get backtraces stripped. (Aslak Hellesøy)
 - Cucumber::Ast::Table#map_headers now allows for a block that will convert all the headers. See docs for details. (Ben Mabey)
 
-## [0.3.97](https://github.com/cucumber/cucumber-ruby/compare/v0.3.96...v0.3.97)
+## [0.3.97](https://github.com/cucumber/cucumber-ruby/compare/v0.3.96...v0.3.97) (2009-08-23)
 
 The AA-FTT release. Creating a release for the AA-FTT meeting in Chicago so that we can play
 with the new language API and maybe knock out some better .NET support.
@@ -2036,7 +2036,7 @@ with the new language API and maybe knock out some better .NET support.
 - Changed the Programming Language API to support languages without "bleed through" (e.g. rubypython can't invoke ruby objs) (Aslak Hellesøy)
 - The Programming Language API manages hooks on the language level instead of on the step mother level (Aslak Hellesøy)
 
-## [0.3.96](https://github.com/cucumber/cucumber-ruby/compare/v0.3.95...v0.3.96)
+## [0.3.96](https://github.com/cucumber/cucumber-ruby/compare/v0.3.95...v0.3.96) (2009-08-15)
 
 This release doesn't have any significant new features or bug fixes, but there are big
 internal changes. This release has a new API for plugging in other programming languages.
@@ -2057,7 +2057,7 @@ be patched. Please upgrade to Spork 0.5.9 if you are using Spork.
 - --strict will cause an exit code 1 for missing and pending (used to be for missing only). (Mads Buus)
 - junit formatter doesn't report pending steps unless --strict is used. (Mads Buus)
 
-## [0.3.95](https://github.com/cucumber/cucumber-ruby/compare/v0.3.94...v0.3.95)
+## [0.3.95](https://github.com/cucumber/cucumber-ruby/compare/v0.3.94...v0.3.95) (2009-08-13)
 
 This release improves Webrat support for table-like HTML markup. Now you can easily turn the HTML
 elements table, dl, ol and ul elements into a 2D array. This is particularly useful for comparing
@@ -2087,7 +2087,7 @@ This release also fixes several bugs related to --drb (Spork) and profiles (cucu
 - element_at('table').to_table should be used instead of table_at('table').to_a. The old way is deprecated but still works. (Aslak Hellesøy)
 - element_at (and the depracated table_at) no longer takes a DOM id, only CSS selectors. Change "my_id" to "#my_id". (Aslak Hellesøy)
 
-## [0.3.94](https://github.com/cucumber/cucumber-ruby/compare/v0.3.93...v0.3.94)
+## [0.3.94](https://github.com/cucumber/cucumber-ruby/compare/v0.3.93...v0.3.94) (2009-08-06)
 
 Kanban take II.
 
@@ -2117,7 +2117,7 @@ You'll achieve better flow this way.
 - Document builtin formatters with --help. (#406 Aslak Hellesøy)
 - Added support for using regular expressions when mapping table headers. (Peter Williams)
 
-## [0.3.93](https://github.com/cucumber/cucumber-ruby/compare/v0.3.92...v0.3.93)
+## [0.3.93](https://github.com/cucumber/cucumber-ruby/compare/v0.3.92...v0.3.93) (2009-08-03)
 
 Highlights in this release: Improved profile handling (cucumber.yml) and a fix for cucumber hanging.
 
@@ -2134,7 +2134,7 @@ Highlights in this release: Improved profile handling (cucumber.yml) and a fix f
 - script/cucumber correctly loads the gem's binary if the plugin isn't installed.
 - Cucumber hangs waiting for Ctrl+C if an Error is raised. (#374 Aslak Hellesøy)
 
-## [0.3.92](https://github.com/cucumber/cucumber-ruby/compare/v0.3.91...v0.3.92)
+## [0.3.92](https://github.com/cucumber/cucumber-ruby/compare/v0.3.91...v0.3.92) (2009-07-29)
 
 This release has some minor improvements to the new Table.diff! functionality. For example,
 if you're using Webrat and you want to compare a feature table with a HTML table containing
@@ -2158,7 +2158,7 @@ links in one of the columns, you can do:
 
 - The 'default' profile is now ALWAYS used unless you specify another profile or use the -P or --no-profile flag. (#344 Ben Mabey)
 
-## [0.3.91](https://github.com/cucumber/cucumber-ruby/compare/v0.3.90...v0.3.91)
+## [0.3.91](https://github.com/cucumber/cucumber-ruby/compare/v0.3.90...v0.3.91) (2009-07-27)
 
 ### New Features
 
@@ -2167,7 +2167,7 @@ links in one of the columns, you can do:
 - Support limiting the number of feature elements with certain tags (#353 Joseph Wilk)
 - Table support for cuke4duke
 
-## [0.3.90](https://github.com/cucumber/cucumber-ruby/compare/v0.3.11...v0.3.90)
+## [0.3.90](https://github.com/cucumber/cucumber-ruby/compare/v0.3.11...v0.3.90) (2009-07-21)
 
 The Hot summer release
 
@@ -2271,7 +2271,7 @@ This release also has several bugfixes related to --format and Before/After hook
 - The data returned from Table#hashes and similar methods are frozen. Dup if you need to modify. (Aslak Hellesøy)
 - Visitor.visit_table_cell_value(value, col_width, status) is now visitor.visit_table_cell_value(value, status)
 
-## [0.3.11](https://github.com/cucumber/cucumber-ruby/compare/v0.3.10...v0.3.11)
+## [0.3.11](https://github.com/cucumber/cucumber-ruby/compare/v0.3.10...v0.3.11) (2009-06-05)
 
 This release just fixes a tiny bug in the formatter to fix an incompatibility
 with the latest RedMine release. It should have been included in 0.3.10, but
@@ -2281,7 +2281,7 @@ was forgotten.
 
 - Formatter API was broken in 0.3.9 (Roman Chernyatchik)
 
-## [0.3.10](https://github.com/cucumber/cucumber-ruby/compare/v0.3.9...v0.3.10)
+## [0.3.10](https://github.com/cucumber/cucumber-ruby/compare/v0.3.9...v0.3.10) (2009-06-05)
 
 The Spork Release!
 
@@ -2324,7 +2324,7 @@ This release also has some minor bugfixes related to RSpec and Rails interop.
 
 - The HTML formatter wraps examples in a div, and distinguishes between Scenario and Scenario Outline. (Aslak Hellesøy)
 
-## [0.3.9](https://github.com/cucumber/cucumber-ruby/compare/v0.3.8...v0.3.9)
+## [0.3.9](https://github.com/cucumber/cucumber-ruby/compare/v0.3.8...v0.3.9) (2009-05-27)
 
 Bugfix release for 0.3.8 released earlier today. 0.3.8 had a bug in the Rails cucumber
 generator which is fixed in 0.3.9.
@@ -2334,7 +2334,7 @@ generator which is fixed in 0.3.9.
 - Fix broken Rails cucumber generator (Tim Glen)
 - The Cucumber Rake task in non-fork mode will properly cause Rake to exit with 1 when Cucumber fails. (Aslak Hellesøy)
 
-## [0.3.8](https://github.com/cucumber/cucumber-ruby/compare/v0.3.7...v0.3.8)
+## [0.3.8](https://github.com/cucumber/cucumber-ruby/compare/v0.3.7...v0.3.8) (2009-05-27)
 
 This Cucumber version fixes several bugs related to Ruby on Rails and RSpec. If you
 use Cucumber with a Rails app we*strongly* recommend you bootstrap Cucumber again:
@@ -2358,7 +2358,7 @@ use Cucumber with a Rails app we*strongly* recommend you bootstrap Cucumber agai
 - Better coexistence with RSpec - Cucumber now*neuters* the part of RSpec that tries to parse ARGV.
 - The differ= exception is gone (#325, #340 Aslak Hellesøy)
 
-## [0.3.7](https://github.com/cucumber/cucumber-ruby/compare/v0.3.6...v0.3.7)
+## [0.3.7](https://github.com/cucumber/cucumber-ruby/compare/v0.3.6...v0.3.7) (2009-05-22)
 
 This is the "Help JetBrains RubyMine" release!
 
@@ -2373,7 +2373,7 @@ This is the "Help JetBrains RubyMine" release!
 - 'specs' folder needs to be renamed back to 'spec' (#339 Aslak Hellesøy)
 - CUCUMBER_OPTS doesn't work for cucumber rake tasks (#336 Aslak Hellesøy)
 
-## [0.3.6](https://github.com/cucumber/cucumber-ruby/compare/v0.3.5...v0.3.6)
+## [0.3.6](https://github.com/cucumber/cucumber-ruby/compare/v0.3.5...v0.3.6) (2009-05-20)
 
 Kanban! With this release you can tag features or scenarios that are work in progress
 with a tag and use the new --wip switch.
@@ -2393,7 +2393,7 @@ Another handy feature in this release is that you can package your own formatter
 - Gracefully handle exceptions in After block (#330 Matt Wynne)
 - Feature with only Background doesn't run hooks (#314, #329 Aslak Hellesøy)
 
-## [0.3.5](https://github.com/cucumber/cucumber-ruby/compare/v0.3.4...v0.3.5)
+## [0.3.5](https://github.com/cucumber/cucumber-ruby/compare/v0.3.4...v0.3.5) (2009-05-15)
 
 Let's make a new release today because two annoying bugs are fixed.
 
@@ -2401,7 +2401,7 @@ Let's make a new release today because two annoying bugs are fixed.
 
 - Allow feature element names to contain Gherkin keywords as long as they are not the first word on a newline (#319, #307 Joseph Wilk)
 
-## [0.3.4](https://github.com/cucumber/cucumber-ruby/compare/v0.3.3...v0.3.4)
+## [0.3.4](https://github.com/cucumber/cucumber-ruby/compare/v0.3.3...v0.3.4) (2009-05-14)
 
 A couple of great new features in this release. Running with Rake is faster than before,
 and there is a brand new JUnit formatter - great for Continuous Integration reports!
@@ -2448,7 +2448,7 @@ However, setting the RAILS_ENV is easy to forget, so I don't recommend relying o
   unless explicitly told to fork a new interpreter. This is to increase speed. You can
   force a new interpreter by setting fork=true or rcov=true in the task.
 
-## [0.3.3](https://github.com/cucumber/cucumber-ruby/compare/v0.3.2...v0.3.3)
+## [0.3.3](https://github.com/cucumber/cucumber-ruby/compare/v0.3.2...v0.3.3) (2009-05-10)
 
 Minor bugfix release, made specially for EuRuKo!
 
@@ -2462,7 +2462,7 @@ Minor bugfix release, made specially for EuRuKo!
 
 - New aliases: --no-source/-s, --name/-n (#317 Lonnon Foster)
 
-## [0.3.2](https://github.com/cucumber/cucumber-ruby/compare/v0.3.1...v0.3.2)
+## [0.3.2](https://github.com/cucumber/cucumber-ruby/compare/v0.3.1...v0.3.2) (2009-05-03)
 
 This release has some minor bug fixes and new features.
 Nothing major, but we need a release for RailsConf'09 in Las Vegas!
@@ -2480,7 +2480,7 @@ Nothing major, but we need a release for RailsConf'09 in Las Vegas!
 - Examples and the associated tables are indented one level deeper than Scenario Outline. (Aslak Hellesøy)
 - Added support for Examples selection when using --name. (#295 Joseph Wilk)
 
-## [0.3.1](https://github.com/cucumber/cucumber-ruby/compare/v0.3.0...v0.3.1)
+## [0.3.1](https://github.com/cucumber/cucumber-ruby/compare/v0.3.0...v0.3.1) (2009-04-26)
 
 This release has several minor bug fixes and new features. With the addition of Latvian and Hungarian Cucumber
 now supports 32(!!) languages.
@@ -2508,7 +2508,7 @@ now supports 32(!!) languages.
 
 - --scenario handle has been removed and replaced with --name which supports partial matches, regexp special characters, running named backgrounds (#295 Joseph Wilk)
 
-## [0.3.0](https://github.com/cucumber/cucumber-ruby/compare/v0.2.3...v0.3.0)
+## [0.3.0](https://github.com/cucumber/cucumber-ruby/compare/v0.2.3...v0.3.0) (2009-04-14)
 
 This release has some minor changes to the APIs, but big enough that a new major release is in order.
 The biggest change is the new semantics of the #World method. Previously you would call this method
@@ -2566,7 +2566,7 @@ http://wiki.github.com/aslakhellesoy/cucumber/using-rake#profiles
 - Table and PyString no longer hold status information. Each visitor subclass should store state in @state if needed.
 - \#visit_py_string no longer takes a status argument.
 
-## [0.2.3](https://github.com/cucumber/cucumber-ruby/compare/v0.2.2...v0.2.3)
+## [0.2.3](https://github.com/cucumber/cucumber-ruby/compare/v0.2.2...v0.2.3) (2009-03-30)
 
 This release sports 4 updated languages, slightly better help with snippets if you "quote" arguments
 in your steps. Windows/JRuby users can enjoy colours and you get some more sugar with Tables.
@@ -2588,7 +2588,7 @@ in your steps. Windows/JRuby users can enjoy colours and you get some more sugar
 - Fixed step name after step keyword without space (#265 Aslak Hellesøy)
 - Backtrace is back in HTML reports (Aslak Hellesøy)
 
-## [0.2.2](https://github.com/cucumber/cucumber-ruby/compare/v0.2.1...v0.2.2)
+## [0.2.2](https://github.com/cucumber/cucumber-ruby/compare/v0.2.1...v0.2.2) (2009-03-25)
 
 This release includes some minor changes to make Cucumber work with pure Java. Cucumber
 has already worked with Java for a while (using JRuby and step definitions in Ruby),
@@ -2597,7 +2597,7 @@ but now you can write step definitions in pure Java!
 Check out the Cucumber Java project for more details:
 http://github.com/aslakhellesoy/cucumber_java/tree/master
 
-## [0.2.1](https://github.com/cucumber/cucumber-ruby/compare/v0.2.0...v0.2.1)
+## [0.2.1](https://github.com/cucumber/cucumber-ruby/compare/v0.2.0...v0.2.1) (2009-03-25)
 
 This release fixes a few minor bugs and adds a couple of new features.
 
@@ -2619,7 +2619,7 @@ This release fixes a few minor bugs and adds a couple of new features.
 
 - -S/--step-definitions option introduced in 0.2.0 is removed. Use --format usage [--dry-run] [--no-color].
 
-## [0.2.0](https://github.com/cucumber/cucumber-ruby/compare/v0.1.16...v0.2.0)
+## [0.2.0](https://github.com/cucumber/cucumber-ruby/compare/v0.1.16...v0.2.0) (2009-03-18)
 
 This release sports a bunch of new and exciting features, as well a major rewrite of Cucumber's internals.
 The rewrite was done to address technical debt and to have a code base that is easier to evolve and maintain.
@@ -2703,7 +2703,7 @@ for multiline arguments are some of the highlights.
 - Pure Ruby features are no longer supported.
 - Remove --color option in autotest. Can be added manually in cucumber.yml (#215 Jean-Michel Garnier)
 
-## 0.1.16.4
+## 0.1.16.4 (2009-01-22)
 
 Bugfix release.
 
@@ -2729,7 +2729,7 @@ to this:
 - Better handling of ARGV (#169 David Chelimsky, Ben Mabey)
 - Compatibility with ruby-debug (do ARGV.dup in bin/cucumber so it can restart ruby with same args) (Aslak Hellesøy)
 
-## [0.1.16](https://github.com/cucumber/cucumber-ruby/compare/v0.1.15...v0.1.16)
+## [0.1.16](https://github.com/cucumber/cucumber-ruby/compare/v0.1.15...v0.1.16) (2009-01-18)
 
 This is a small bugfix release. The most notable improvement is compatibility with Webrat 0.4. Rails/Webrat users should
 upgrade both Cucumber and Webrat gems.
@@ -2747,7 +2747,7 @@ upgrade both Cucumber and Webrat gems.
 
 ### Removed features
 
-## [0.1.15](https://github.com/cucumber/cucumber-ruby/compare/v0.1.14...v0.1.15)
+## [0.1.15](https://github.com/cucumber/cucumber-ruby/compare/v0.1.14...v0.1.15) (2009-01-07)
 
 Bugfix release
 
@@ -2762,7 +2762,7 @@ Bugfix release
 - Better quoting of Scenario names in Autotest (Peter Jaros)
 - Added some small workarounds for unicode handling on Windows (Aslak Hellesøy)
 
-## [0.1.14](https://github.com/cucumber/cucumber-ruby/compare/v0.1.13...v0.1.14)
+## [0.1.14](https://github.com/cucumber/cucumber-ruby/compare/v0.1.13...v0.1.14) (2009-01-04)
 
 This is the first release of Cucumber that runs on Ruby 1.9. There are still some encoding-related issues
 with Arabic (ar), Japanese (ja) and Simplified Chinese (zh-CN). Patches are welcome. Other than that -
@@ -2782,7 +2782,7 @@ a couple of minor bug fixes and polishing.
 
 - The #binary= method is gone from the Rake task. It will always point to the binary in the current gem. (Aslak Hellesøy)
 
-## [0.1.13](https://github.com/cucumber/cucumber-ruby/compare/v0.1.12...v0.1.13)
+## [0.1.13](https://github.com/cucumber/cucumber-ruby/compare/v0.1.12...v0.1.13) (2008-12-20)
 
 It's time for some new features again. Output is now much better since you can use diffing, tweak
 the output colours and get the full --backtrace if you want. Managing your support/\* files became
@@ -2819,7 +2819,7 @@ Enjoy!
 
 ### Removed features
 
-## [0.1.12](https://github.com/cucumber/cucumber-ruby/compare/v0.1.11...v0.1.12)
+## [0.1.12](https://github.com/cucumber/cucumber-ruby/compare/v0.1.11...v0.1.12) (2008-12-04)
 
 This is the "getting serious with IronRuby release" - largely based on
 "Patrick Gannon":http://www.patrickgannon.net/archive/2008/10/23/bdd-style-feature-tests-using-ironruby-and-rspeccucumber.aspx's
@@ -2837,7 +2837,7 @@ blog entry.
 
 None
 
-## [0.1.11](https://github.com/cucumber/cucumber-ruby/compare/v0.1.10...v0.1.11)
+## [0.1.11](https://github.com/cucumber/cucumber-ruby/compare/v0.1.10...v0.1.11) (2008-12-02)
 
 Bugfix release with a couple of minor additional features to the command line options.
 
@@ -2858,7 +2858,7 @@ Bugfix release with a couple of minor additional features to the command line op
 
 - The cucumber gem no longer depends on the rspec gem. It must be downloaded manually if RSpec is used. (Jeff Rafter)
 
-## [0.1.10](https://github.com/cucumber/cucumber-ruby/compare/v0.1.9...v0.1.10)
+## [0.1.10](https://github.com/cucumber/cucumber-ruby/compare/v0.1.9...v0.1.10) (2008-11-25)
 
 This release mostly has smaller bugfixes. The most significant new feature is how
 line numbers are specified. You can now run multiple features at specific lines numbers like this:
@@ -2891,7 +2891,7 @@ This will run foo.feature at line 15 and bar.feature at line 6, 45 and 111.
 - Step definition without a block being treated as pending (#64 Joseph Wilk)
 - The --line option has been removed. Use the new file.feature:line format instead.
 
-## [0.1.9](https://github.com/cucumber/cucumber-ruby/compare/v0.1.8...v0.1.9)
+## [0.1.9](https://github.com/cucumber/cucumber-ruby/compare/v0.1.8...v0.1.9) (2008-11-12)
 
 With this release Cucumber supports 19 (!) natural languages:
 
@@ -2975,7 +2975,7 @@ spaces removed too.
 
 ### Removed features
 
-## [0.1.8](https://github.com/cucumber/cucumber-ruby/compare/v0.1.7...v0.1.8)
+## [0.1.8](https://github.com/cucumber/cucumber-ruby/compare/v0.1.7...v0.1.8) (2008-10-18)
 
 This release extends the support for tables. PLEASE NOTE THAT TABLES ARE STILL EXPERIMENTAL.
 In previous releases it has been possible to use tables to define "more examples" of a scenario in
@@ -3059,7 +3059,7 @@ The step definitions for such multiline steps must define an extra block argumen
 
 - Added new --out option to make it easier to specify output from Rake and cucumber.yml
 
-## [0.1.7](https://github.com/cucumber/cucumber-ruby/compare/v0.1.6...v0.1.7)
+## [0.1.7](https://github.com/cucumber/cucumber-ruby/compare/v0.1.6...v0.1.7) (2008-10-05)
 
 This release fixes a few bugs and adds some new features. The most notable features are:
 
@@ -3114,6 +3114,6 @@ a plain text step is defined. Not anymore! Cucumber will now output this:
 - Added --no-source option to display step definition location next to step text (#26, Joseph Wilk, Aslak Hellesøy)
 - Added more Webrat steps (#25, Tim Glen)
 
-## [0.1.6](https://github.com/cucumber/cucumber-ruby/compare/f3292f4023a707099d02602b2bd6c4ca3cec6820...v0.1.6)
+## [0.1.6](https://github.com/cucumber/cucumber-ruby/compare/f3292f4023a707099d02602b2bd6c4ca3cec6820...v0.1.6) (2008-10-01)
 
 First gem release!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ---
 
-## [In GIT](https://github.com/cucumber/cucumber-ruby/compare/v7.0.0...main) (2021-07-19)
+## [In GIT](https://github.com/cucumber/cucumber-ruby/compare/v7.0.0...main)
 
 ### Added
 
@@ -43,6 +43,10 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 ### Fixed
 
 ### Changed
+
+- Added release dates to CHANGELOG.md.
+  ([1543](https://github.com/cucumber/cucumber-ruby/pull/1573)
+  [AudTheCodeWitch](https://github.com/AudTheCodeWitch))
 
 ### Removed
 


### PR DESCRIPTION
# Description

This PR adds dates for all releases documented in CHANGELOG.md.

Fixes #1543 

## Type of change

Please delete options that are not relevant.

- Refactoring (improvements to code design or tooling that don't change behaviour)

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [x] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] RDoc comments have been updated
- [x] CHANGELOG.md has been updated
