### PR TITLE
Remove unused 3rd arg from Cli::Main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Removed
 
+- Removed former unused `stdin` argument from `Cli::Main`. That may impact your code
+  if you use cucumber API `Cucumber::Cli::Main`. See [UPGRADING.md](./UPGRADING.md#upgrading-to-800).
+  ([PR#1588](https://github.com/cucumber/cucumber-ruby/pull/1588)
+   [Issue#1581](https://github.com/cucumber/cucumber-ruby/issues/1581))
+
 ### Security fixes
 
 ### Deprecated

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,38 @@
+# Upgrading to 8.0.0
+
+## `Cucumber::Cli::Main` former `stdin` argument
+
+The second argument of `Cucumber::Cli::Main` - which was formerly named `stdin` -
+has been removed.
+
+### Before cucumber 8.0.0
+
+You would have used `Cucumber::Cli::Main` with a dummy parameter:
+
+```ruby
+Cucumber::Cli::Main.new(
+      argument_list,
+      nil, # <-- this is a former unused `stdin` parameter
+      @stdout,
+      @stderr,
+      @kernel
+).execute!
+```
+
+### With cucumber 8.0.0
+
+The argument has been removed from the initializer so the dummy parameter is not
+required anymore:
+
+```ruby
+Cucumber::Cli::Main.new(
+      argument_list,
+      @stdout,
+      @stderr,
+      @kernel
+).execute!
+```
+
 # Upgrading to 7.1.0
 
 ## The wire protocol

--- a/features/lib/support/command_line.rb
+++ b/features/lib/support/command_line.rb
@@ -85,7 +85,6 @@ class CucumberCommand < CommandLine
 
     Cucumber::Cli::Main.new(
       argument_list,
-      nil,
       @stdout,
       @stderr,
       @kernel
@@ -126,7 +125,6 @@ class RakeCommand < CommandLine
       .and_wrap_original do |_, *args|
         Cucumber::Cli::Main.new(
           args[0],
-          nil,
           @stdout,
           @stderr,
           @kernel

--- a/lib/cucumber/cli/main.rb
+++ b/lib/cucumber/cli/main.rb
@@ -14,12 +14,7 @@ module Cucumber
         end
       end
 
-      # The second argument is there for retrocompatibility
-      # Removing it will require a breaking change
-      # But it is actually responsible for a rubycop offense: too many optional parameters
-      # As we don't want to deactivate that cop globally, we disable it just for the
-      # following.
-      def initialize(args, _ = nil, out = $stdout, err = $stderr, kernel = Kernel) # rubocop:disable Metrics/ParameterLists
+      def initialize(args, out = $stdout, err = $stderr, kernel = Kernel)
         @args   = args
         @out    = out
         @err    = err

--- a/spec/cucumber/cli/main_spec.rb
+++ b/spec/cucumber/cli/main_spec.rb
@@ -12,11 +12,10 @@ module Cucumber
       end
 
       let(:args)   { [] }
-      let(:stdin)  { StringIO.new }
       let(:stdout) { StringIO.new }
       let(:stderr) { StringIO.new }
       let(:kernel) { double(:kernel) }
-      subject { Main.new(args, stdin, stdout, stderr, kernel) }
+      subject { Main.new(args, stdout, stderr, kernel) }
 
       describe '#execute!' do
         context 'passed an existing runtime' do


### PR DESCRIPTION
# Description

Remove the former unused stdin argument from Cli::Main.

Fixes #1581 

## Type of change

- Breaking change (will cause existing functionality to not
  work as expected)

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] CHANGELOG.md has been updated
