### PR TITLE
Change DataTable#map_column 'strict' argument to a keyword argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 - In `DataTable#map_column`, Changed the `strict` argument into a keyword argument.
   See [UPGRADING.md](./UPGRADING.md#upgrading-to-800).
-  ([Issue#1592](https://github.com/cucumber/cucumber-ruby/issues/1592))
+  ([PR#1594](https://github.com/cucumber/cucumber-ruby/pull/1594)
+   [Issue#1592](https://github.com/cucumber/cucumber-ruby/issues/1592))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Changed
 
+- In `DataTable#map_column`, Changed the `strict` argument into a keyword argument.
+  See [UPGRADING.md](./UPGRADING.md#upgrading-to-800).
+  ([Issue#1592](https://github.com/cucumber/cucumber-ruby/issues/1592))
+
 ### Removed
 
 - `AfterConfiguration` has been removed. Please use `InstallPlugin` or `BeforeAll` instead.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -104,6 +104,24 @@ Cucumber::Cli::Main.new(
 ).execute!
 ```
 
+## DataTable#map_column `strict` argument
+
+The `strict` argument for the `map_column` method has changed to a keyword argument.
+
+### Before 8.0.0
+
+```ruby
+table.map_column('column', false).do |value|
+end
+```
+
+### With cucumber 8.0.0
+
+```ruby
+table.map_column('column', strict: false).do |value|
+end
+```
+
 # Upgrading to 7.1.0
 
 ## The wire protocol

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -274,13 +274,11 @@ module Cucumber
       #     end
       #   end
       #
-      # rubocop:disable Style/OptionalBooleanParameter # the optional boolean parameter is kept for retrocompatibility
-      def map_column(column_name, strict = true, &conversion_proc)
+      def map_column(column_name, strict: true, &conversion_proc)
         conversion_procs = @conversion_procs.dup
         conversion_procs[column_name.to_s] = { strict: strict, proc: conversion_proc }
         self.class.new(Core::Test::DataTable.new(raw), conversion_procs, @header_mappings.dup, @header_conversion_proc)
       end
-      # rubocop:enable Style/OptionalBooleanParameter
 
       # Compares +other_table+ to self. If +other_table+ contains columns
       # and/or rows that are not in self, new columns/rows are added at the

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -87,14 +87,14 @@ module Cucumber
 
         it 'should pass silently if a mapped column does not exist in non-strict mode' do
           expect do
-            new_table = @table.map_column('two', false, &:to_i)
+            new_table = @table.map_column('two', strict: false, &:to_i)
             new_table.hashes
           end.not_to raise_error
         end
 
         it 'should fail if a mapped column does not exist in strict mode' do
           expect do
-            new_table = @table.map_column('two', true, &:to_i)
+            new_table = @table.map_column('two', strict: true, &:to_i)
             new_table.hashes
           end.to raise_error('The column named "two" does not exist')
         end
@@ -161,7 +161,7 @@ module Cucumber
                                    %w[two 22222]
                                  ])
           t2 = table.map_headers({ 'two' => 'Two' }, &:upcase)
-                    .map_column('two', false, &:to_i)
+                    .map_column('two', strict: false, &:to_i)
           expect(t2.rows_hash).to eq('ONE' => '1111', 'Two' => 22_222)
         end
       end


### PR DESCRIPTION
# Description

Fixes #1592 

## Type of change

Please delete options that are not relevant.

- Breaking change (will cause existing functionality to not
  work as expected)

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] RDoc comments have been updated
- [x] CHANGELOG.md has been updated
