### PR TITLE
Fix 1595: make sure to extend the world with a valid module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
+- Fix usage of namespaced modules across multiple scenarios
+  ([PR#1603](https://github.com/cucumber/cucumber-ruby/pull/1603)
+   [Issue#1595](https://github.com/cucumber/cucumber-ruby/issues/1595))
+
 - Do not serialize Messages::Hook#tag_expression if it is empty.
   ([PR#1579](https://github.com/cucumber/cucumber-ruby/pull/1579))
 

--- a/features/docs/writing_support_code/world.feature
+++ b/features/docs/writing_support_code/world.feature
@@ -95,6 +95,45 @@ Feature: World
     When I run `cucumber features/f.feature`
     Then it should pass
 
+  Scenario: A world is existing over multiple scenarios
+    Given a file named "features/support/helpers.rb" with:
+      """
+      module Helpers
+        def helper_method
+          42
+        end
+      end
+
+      World(my_namespace: Helpers)
+      """
+    And a file named "features/step_definitions/step.rb" with:
+      """
+      Then /^my_namespace is not nil$/ do
+        expect(my_namespace).not_to be_nil
+      end
+
+      Then /^the helper method is called$/ do
+        expect(my_namespace.helper_method).to eql(42)
+      end
+      """
+    And a file named "features/f.feature" with:
+      """
+      Feature: Calling a method
+        Scenario: The namespace exists
+          Then my_namespace is not nil
+        Scenario: I call a method from a namespace
+          Then the helper method is called
+        Scenario: The namespace still exists
+          Then my_namespace is not nil
+        Scenario: I still call a method from a namespace
+          Then the helper method is called
+      """
+    When I run `cucumber features/f.feature`
+    Then it should pass with:
+      """
+      4 scenarios (4 passed)
+      """
+
   Scenario: A world is extended using multiple modules with different namespaces
     Given a file named "features/support/helpers.rb" with:
       """

--- a/features/docs/writing_support_code/world.feature
+++ b/features/docs/writing_support_code/world.feature
@@ -121,17 +121,15 @@ Feature: World
       Feature: Calling a method
         Scenario: The namespace exists
           Then my_namespace is not nil
-        Scenario: I call a method from a namespace
-          Then the helper method is called
+          And the helper method is called
         Scenario: The namespace still exists
           Then my_namespace is not nil
-        Scenario: I still call a method from a namespace
-          Then the helper method is called
+          And the helper method is called
       """
     When I run `cucumber features/f.feature`
     Then it should pass with:
       """
-      4 scenarios (4 passed)
+      2 scenarios (2 passed)
       """
 
   Scenario: A world is extended using multiple modules with different namespaces

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -185,14 +185,13 @@ module Cucumber
             modules.each do |namespace, world_modules|
               world_modules.each do |world_module|
                 variable_name = "@__#{namespace}_world"
+                inner_world = instance_variable_get(variable_name) || Object.new
 
-                inner_world = if self.class.respond_to?(namespace)
-                                instance_variable_get(variable_name)
-                              else
-                                Object.new
-                              end
-                instance_variable_set(variable_name,
-                                      inner_world.extend(world_module))
+                instance_variable_set(
+                  variable_name,
+                  inner_world.extend(world_module)
+                )
+
                 self.class.send(:define_method, namespace) do
                   instance_variable_get(variable_name)
                 end

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -138,8 +138,8 @@ module Cucumber
           # TODO: pass these in when building the module, instead of mutating them later
           # Extend the World with user-defined modules
           def add_modules!(world_modules, namespaced_world_modules)
-            add_world_modules!(world_modules)
-            add_namespaced_modules!(namespaced_world_modules)
+            add_world_modules!(world_modules) if world_modules.any?
+            add_namespaced_modules!(namespaced_world_modules) if namespaced_world_modules.any?
           end
 
           define_method(:step) do |name, raw_multiline_arg = nil|
@@ -201,6 +201,8 @@ module Cucumber
 
           # @private
           def stringify_namespaced_modules
+            return '' if @__namespaced_modules.nil?
+
             @__namespaced_modules.map { |k, v| "#{v.join(',')} (as #{k})" }.join('+')
           end
         end


### PR DESCRIPTION
# Description

Fixes #1595

Make sure to extend the World with a valid Object rather than extending it with something we think is valid but may not be.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] CHANGELOG.md has been updated
