### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/cucumber-ruby.yml
+++ b/.github/workflows/cucumber-ruby.yml
@@ -25,6 +25,8 @@ jobs:
         exclude:
           - ruby: '2.5'
             os: windows-latest
+          - ruby: '3.1'
+            os: windows-latest
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/cucumber-ruby.yml
+++ b/.github/workflows/cucumber-ruby.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ['2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
         include:
           - os: ubuntu-latest
             ruby: jruby-9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   ([PR#1594](https://github.com/cucumber/cucumber-ruby/pull/1594)
    [Issue#1592](https://github.com/cucumber/cucumber-ruby/issues/1592))
 
+- Added Ruby 3.1 to the CI matrix.
+  ([PR#1607](https://github.com/cucumber/cucumber-ruby/pull/1607))
+
 ### Removed
 
 - `AfterConfiguration` has been removed. Please use `InstallPlugin` or `BeforeAll` instead.


### PR DESCRIPTION
# Description

Because Ruby 3.1.0 is now in general release, it makes sense to add Ruby 3.1 to the CI matrix

## Type of change

Please delete options that are not relevant.

- Refactoring (improvements to code design or tooling that don't change behaviour)


# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [X] Tests have been added for any changes to behaviour of the code
- [X] New and existing tests are passing locally and on CI
- [X] `bundle exec rubocop` reports no offenses
- [X] RDoc comments have been updated
- [x] CHANGELOG.md has been updated
