### PR TITLE
Warn user when using space-separated string with cucumber_opts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -135,6 +135,9 @@ Style/AccessModifierDeclarations:
 Style/ClassAndModuleChildren:
   Enabled: false
 
+Style/ClassEqualityComparison:
+  Enabled: true
+
 Style/Documentation:
   Enabled: false
 
@@ -150,3 +153,6 @@ Style/StderrPuts:
 Style/RegexpLiteral:
   EnforcedStyle: slashes
   AllowInnerSlashes: true
+
+Style/YodaCondition:
+  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Added
 
-- Add support for TruffleRuby 
-  ([PR#1612](https://github.com/cucumber/cucumber-ruby/pull/1612) 
+- Add a *WARNING* message when using a space-separated string with cucumber_opts
+  ([PR#](https://github.com/cucumber/cucumber-ruby/pull/1624)
+   [Issue#1614](https://github.com/cucumber/cucumber-ruby/issues/1614))
+
+- Add support for TruffleRuby
+  ([PR#1612](https://github.com/cucumber/cucumber-ruby/pull/1612)
    [gogainda](https://github.com/gogainda))
 
 ### Fixed

--- a/lib/cucumber/formatter/io.rb
+++ b/lib/cucumber/formatter/io.rb
@@ -61,7 +61,7 @@ module Cucumber
       end
 
       def ensure_file(path, name)
-        raise "You *must* specify --out FILE for the #{name} formatter" unless String == path.class
+        raise "You *must* specify --out FILE for the #{name} formatter" unless path.instance_of? String
         raise "I can't write #{name} to a directory - it has to be a file" if File.directory?(path)
         raise "I can't write #{name} to a file in the non-existing directory #{File.dirname(path)}" unless File.directory?(File.dirname(path))
 
@@ -69,7 +69,7 @@ module Cucumber
       end
 
       def ensure_dir(path, name)
-        raise "You *must* specify --out DIR for the #{name} formatter" unless String == path.class
+        raise "You *must* specify --out DIR for the #{name} formatter" unless path.instance_of? String
         raise "I can't write #{name} reports to a file - it has to be a directory" if File.file?(path)
 
         FileUtils.mkdir_p(path) unless File.directory?(path)

--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -36,7 +36,7 @@ module Cucumber
         attr_reader :args
 
         def initialize(libs, cucumber_opts, feature_files)
-          raise 'libs must be an Array when running in-process' unless Array == libs.class
+          raise 'libs must be an Array when running in-process' unless libs.instance_of? Array
 
           libs.reverse_each { |lib| $LOAD_PATH.unshift(lib) }
           @args = (
@@ -113,7 +113,7 @@ module Cucumber
       attr_reader :cucumber_opts
 
       def cucumber_opts=(opts) # :nodoc:
-        unless String == opts.class
+        unless opts.instance_of? String
           @cucumber_opts = opts
           return
         end

--- a/lib/cucumber/rake/task.rb
+++ b/lib/cucumber/rake/task.rb
@@ -113,7 +113,15 @@ module Cucumber
       attr_reader :cucumber_opts
 
       def cucumber_opts=(opts) # :nodoc:
-        @cucumber_opts = String == opts.class ? opts.split(' ') : opts
+        unless String == opts.class
+          @cucumber_opts = opts
+          return
+        end
+
+        @cucumber_opts = opts.split(' ')
+        return if @cucumber_opts.length <= 1
+
+        $stderr.puts 'WARNING: consider using an array rather than a space-delimited string with cucumber_opts to avoid undesired behavior.'
       end
 
       # Whether or not to fork a new ruby interpreter. Defaults to true. You may gain

--- a/spec/cucumber/rake/task_spec.rb
+++ b/spec/cucumber/rake/task_spec.rb
@@ -25,9 +25,23 @@ module Cucumber
           it { expect(subject.cucumber_opts).to be opts }
         end
 
+        context 'when set via string' do
+          let(:opts) { 'foo=bar' }
+          it { expect(subject.cucumber_opts).to eq %w[foo=bar] }
+        end
+
         context 'when set via space-delimited string' do
           let(:opts) { 'foo bar' }
+
           it { expect(subject.cucumber_opts).to eq %w[foo bar] }
+
+          it 'emits a warning to suggest using arrays rather than string' do
+            expect { subject.cucumber_opts = opts }.to output(
+              a_string_including(
+                'WARNING: consider using an array rather than a space-delimited string with cucumber_opts to avoid undesired behavior.'
+              )
+            ).to_stderr
+          end
         end
       end
 


### PR DESCRIPTION
# Description

Fixes #1614 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds new behaviour)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

