### PR TITLE
Use `required_rubygems_version` instead of `rubygems_version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
+- Use `required_rubygems_version` instead of `rubygems_version`([PR#1629](https://github.com/cucumber/cucumber-ruby/pull/1629))
+
 ### Changed
 
 ### Removed

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -49,8 +49,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test', '~> 1.1', '>= 1.1.0'
   s.add_development_dependency 'sinatra', '~> 2.1', '>= 2.1.0'
 
-  s.rubygems_version = '>= 1.6.1'
-  s.files            = Dir[
+  s.required_rubygems_version = '>= 1.6.1'
+  s.files = Dir[
     'CHANGELOG.md',
     'CONTRIBUTING.md',
     'README.md',


### PR DESCRIPTION
# Description

This is the same change made in https://github.com/cucumber/cucumber-rails/pull/533.

`rubygems_version` is used, probably a mistake for `required_rubygems_version`.
Because `rubygems_version` should not be set.
refs: https://github.com/rubygems/rubygems/blob/2faada63ae65d8559bcba9e083f3c35ba6c18fdc/lib/rubygems/specification.rb#L536-L541

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [x] CHANGELOG.md has been updated
