### PR TITLE
Suppress RSspec deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 - Use `required_rubygems_version` instead of `rubygems_version`([PR#1629](https://github.com/cucumber/cucumber-ruby/pull/1629))
 
+- Suppress RSspec deprecation warnings([PR#1631](https://github.com/cucumber/cucumber-ruby/pull/1631))
+
 ### Changed
 
 ### Removed

--- a/examples/i18n/it/features/step_definitions/calcolatrice_steps.rb
+++ b/examples/i18n/it/features/step_definitions/calcolatrice_steps.rb
@@ -24,5 +24,5 @@ When('premo somma') do
 end
 
 Then(/il risultato deve essere (\d*)/) do |result|
-  @result.should == result.to_i
+  expect(@result).to eq(result.to_i)
 end

--- a/examples/i18n/no/features/step_definitions/kalkulator_steps.rb
+++ b/examples/i18n/no/features/step_definitions/kalkulator_steps.rb
@@ -11,5 +11,5 @@ Når('jeg summerer') do
 end
 
 Så(/skal resultatet være (\d*)/) do |result|
-  @result.should == result.to_i
+  expect(@result).to eq(result.to_i)
 end

--- a/examples/i18n/pt/features/step_definitions/calculadora_steps.rb
+++ b/examples/i18n/pt/features/step_definitions/calculadora_steps.rb
@@ -14,5 +14,5 @@ Quando('eu aperto o botão de soma') do
 end
 
 Então(/o resultado na calculadora deve ser (\d*)/) do |result|
-  @result.should == result.to_i
+  expect(@result).to eq(result.to_i)
 end

--- a/examples/i18n/ro/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/ro/features/step_definitions/calculator_steps.rb
@@ -21,5 +21,5 @@ Cand('apăs tasta Egal') do
 end
 
 Atunci(/ecranul trebuie să afişeze (\d*)/) do |result|
-  @result.should == result.to_i
+  expect(@result).to eq(result.to_i)
 end

--- a/examples/i18n/ru/features/step_definitions/calculator_steps.rb
+++ b/examples/i18n/ru/features/step_definitions/calculator_steps.rb
@@ -15,7 +15,7 @@ end
 end
 
 То('результатом должно быть число {float}') do |результат|
-  calc.result.should == результат
+  expect(calc.result).to eq(результат)
 end
 
 Допустим('я сложил {int} и {int}') do |слагаемое1, слагаемое2|

--- a/examples/i18n/sv/features/step_definitions/kalkulator_steps.rb
+++ b/examples/i18n/sv/features/step_definitions/kalkulator_steps.rb
@@ -24,5 +24,5 @@ When 'jag summerar' do
 end
 
 Then(/ska resultatet vara (\d+)/) do |result|
-  @result.should == result.to_i
+  expect(@result).to eq(result.to_i)
 end

--- a/examples/rspec_doubles/features/step_definitions/calvin_steps.rb
+++ b/examples/rspec_doubles/features/step_definitions/calvin_steps.rb
@@ -10,7 +10,7 @@ end
 
 Given(/^I have a cardboard box$/) do
   transmogrifier = double('transmogrifier')
-  transmogrifier.should_receive(:transmogrify)
+  expect(transmogrifier).to receive(:transmogrify)
   @box = CardboardBox.new(transmogrifier)
 end
 

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -117,7 +117,7 @@ Defined profiles in cucumber.yml:
   * json_report
           END_OF_MESSAGE
 
-          expect(-> { config.parse!(%w[--profile i_do_not_exist]) }).to raise_error(ProfileNotFound, expected_message)
+          expect { config.parse!(%w[--profile i_do_not_exist]) }.to raise_error(ProfileNotFound, expected_message)
         end
 
         it 'allows profiles to be defined in arrays' do
@@ -161,7 +161,7 @@ Defined profiles in cucumber.yml:
 
             expected_error = /The 'foo' profile in cucumber.yml was blank.  Please define the command line arguments for the 'foo' profile in cucumber.yml./
 
-            expect(-> { config.parse!(%w[--profile foo]) }).to raise_error(expected_error)
+            expect { config.parse!(%w[--profile foo]) }.to raise_error(expected_error)
           end
         end
 
@@ -170,7 +170,7 @@ Defined profiles in cucumber.yml:
 
           expected_error = /cucumber\.yml was not found/
 
-          expect(-> { config.parse!(%w[--profile i_do_not_exist]) }).to raise_error(expected_error)
+          expect { config.parse!(%w[--profile i_do_not_exist]) }.to raise_error(expected_error)
         end
 
         it 'issues a helpful error message when cucumber.yml is blank or malformed' do
@@ -179,7 +179,7 @@ Defined profiles in cucumber.yml:
           ['', 'sfsadfs', "--- \n- an\n- array\n", '---dddfd'].each do |bad_input|
             given_cucumber_yml_defined_as(bad_input)
 
-            expect(-> { config.parse!([]) }).to raise_error(expected_error_message)
+            expect { config.parse!([]) }.to raise_error(expected_error_message)
 
             reset_config
           end
@@ -191,14 +191,14 @@ Defined profiles in cucumber.yml:
           given_cucumber_yml_defined_as('input that causes an exception in YAML loading')
 
           expect(YAML).to receive(:load).and_raise(ArgumentError)
-          expect(-> { config.parse!([]) }).to raise_error(expected_error_message)
+          expect { config.parse!([]) }.to raise_error(expected_error_message)
         end
 
         it 'issues a helpful error message when cucumber.yml can not be parsed by ERB' do
           expected_error_message = /cucumber.yml was found, but could not be parsed with ERB.  Please refer to cucumber's documentation on correct profile usage./
           given_cucumber_yml_defined_as('<% this_fails %>')
 
-          expect(-> { config.parse!([]) }).to raise_error(expected_error_message)
+          expect { config.parse!([]) }.to raise_error(expected_error_message)
         end
       end
 
@@ -297,12 +297,12 @@ Defined profiles in cucumber.yml:
       end
 
       it 'does not accept multiple --format options when both use implicit STDOUT' do
-        expect(-> { config.parse!(%w[--format pretty --format progress]) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
+        expect { config.parse!(%w[--format pretty --format progress]) }.to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
       end
 
       it 'does not accept multiple --format options when both use implicit STDOUT (using profile with no formatters)' do
         given_cucumber_yml_defined_as('default' => ['-q'])
-        expect(-> { config.parse!(%w[--format pretty --format progress]) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
+        expect { config.parse!(%w[--format pretty --format progress]) }.to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
       end
 
       it 'accepts same --format options with implicit STDOUT, and keep only one' do
@@ -313,12 +313,12 @@ Defined profiles in cucumber.yml:
 
       it 'does not accept multiple --out streams pointing to the same place' do
         expected_error = 'All but one formatter must use --out, only one can print to each stream (or STDOUT)'
-        expect(-> { config.parse!(%w[--format pretty --out file1 --format progress --out file1]) }).to raise_error(expected_error)
+        expect { config.parse!(%w[--format pretty --out file1 --format progress --out file1]) }.to raise_error(expected_error)
       end
 
       it 'does not accept multiple --out streams pointing to the same place (one from profile, one from command line)' do
         given_cucumber_yml_defined_as('default' => ['-f', 'progress', '--out', 'file1'])
-        expect(-> { config.parse!(%w[--format pretty --out file1]) }).to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
+        expect { config.parse!(%w[--format pretty --out file1]) }.to raise_error('All but one formatter must use --out, only one can print to each stream (or STDOUT)')
       end
 
       it 'associates --out to previous --format' do

--- a/spec/cucumber/formatter/junit_spec.rb
+++ b/spec/cucumber/formatter/junit_spec.rb
@@ -175,7 +175,7 @@ module Cucumber
           FEATURE
 
           it 'raises an exception' do
-            expect(-> { run_defined_feature }).to raise_error(Junit::UnNamedFeatureError)
+            expect { run_defined_feature }.to raise_error(Junit::UnNamedFeatureError)
           end
         end
 

--- a/spec/cucumber/glue/registry_and_more_spec.rb
+++ b/spec/cucumber/glue/registry_and_more_spec.rb
@@ -174,7 +174,7 @@ or http://wiki.github.com/cucumber/cucumber/a-whole-new-world.
 )
           dsl.World { {} }
 
-          expect(-> { dsl.World { [] } }).to raise_error(Glue::MultipleWorld, /#{expected_error}/)
+          expect { dsl.World { [] } }.to raise_error(Glue::MultipleWorld, /#{expected_error}/)
         end
       end
 

--- a/spec/cucumber/glue/step_definition_spec.rb
+++ b/spec/cucumber/glue/step_definition_spec.rb
@@ -101,7 +101,7 @@ module Cucumber
           step 'Inside'
         end
 
-        expect(-> { run_step 'Outside' }).to raise_error(Cucumber::UndefinedDynamicStep)
+        expect { run_step 'Outside' }.to raise_error(Cucumber::UndefinedDynamicStep)
       end
 
       it 'raises UndefinedDynamicStep when an undefined step is parsed dynamically' do
@@ -111,7 +111,7 @@ module Cucumber
           )
         end
 
-        expect(-> { run_step 'Outside' }).to raise_error(Cucumber::UndefinedDynamicStep)
+        expect { run_step 'Outside' }.to raise_error(Cucumber::UndefinedDynamicStep)
       end
 
       it 'raises UndefinedDynamicStep when an undefined step with doc string is parsed dynamically' do
@@ -124,7 +124,7 @@ module Cucumber
           )
         end
 
-        expect(-> { run_step 'Outside' }).to raise_error(Cucumber::UndefinedDynamicStep)
+        expect { run_step 'Outside' }.to raise_error(Cucumber::UndefinedDynamicStep)
       end
 
       it 'raises UndefinedDynamicStep when an undefined step with data table is parsed dynamically' do
@@ -136,7 +136,7 @@ module Cucumber
           )
         end
 
-        expect(-> { run_step 'Outside' }).to raise_error(Cucumber::UndefinedDynamicStep)
+        expect { run_step 'Outside' }.to raise_error(Cucumber::UndefinedDynamicStep)
       end
 
       it 'allows forced pending' do
@@ -144,14 +144,14 @@ module Cucumber
           pending('Do me!')
         end
 
-        expect(-> { run_step 'Outside' }).to raise_error(Cucumber::Pending, 'Do me!')
+        expect { run_step 'Outside' }.to raise_error(Cucumber::Pending, 'Do me!')
       end
 
       it 'raises ArityMismatchError when the number of capture groups differs from the number of step arguments' do
         dsl.Given(/No group: \w+/) do |arg|
         end
 
-        expect(-> { run_step 'No group: arg' }).to raise_error(Cucumber::Glue::ArityMismatchError)
+        expect { run_step 'No group: arg' }.to raise_error(Cucumber::Glue::ArityMismatchError)
       end
 
       it 'does not modify the step_match arg when arg is modified in a step' do
@@ -162,7 +162,7 @@ module Cucumber
         step_name = 'My car is white'
         step_args = step_match(step_name).args
 
-        expect(-> { run_step step_name }).not_to change { step_args.first } # rubocop:disable Lint/AmbiguousBlockAssociation
+        expect { run_step step_name }.not_to change { step_args.first } # rubocop:disable Lint/AmbiguousBlockAssociation
       end
 
       context 'with ParameterType' do

--- a/spec/cucumber/step_match_search_spec.rb
+++ b/spec/cucumber/step_match_search_spec.rb
@@ -46,7 +46,7 @@ You can run again with --guess to make Cucumber be more smart about it
         dsl.Given(/Three (.*) mice/) { |disability| }
         dsl.Given(/Three blind (.*)/) { |animal| }
 
-        expect(-> { search.call('Three blind mice').first }).to raise_error(Ambiguous, /#{expected_error}/)
+        expect { search.call('Three blind mice').first }.to raise_error(Ambiguous, /#{expected_error}/)
       end
 
       describe 'when --guess is used' do
@@ -62,14 +62,14 @@ spec/cucumber/step_match_search_spec.rb:\\d+:in `/Three cute (.*)/'
           dsl.Given(/Three (.*) mice/) { |disability| }
           dsl.Given(/Three cute (.*)/) { |animal| }
 
-          expect(-> { search.call('Three cute mice').first }).to raise_error(Ambiguous, /#{expected_error}/)
+          expect { search.call('Three cute mice').first }.to raise_error(Ambiguous, /#{expected_error}/)
         end
 
         it 'does not raise Ambiguous error when multiple step definitions match' do
           dsl.Given(/Three (.*) mice/) { |disability| }
           dsl.Given(/Three (.*)/) { |animal| }
 
-          expect(-> { search.call('Three blind mice').first }).not_to raise_error
+          expect { search.call('Three blind mice').first }.not_to raise_error
         end
 
         it 'picks right step definition when an equal number of capture groups' do

--- a/spec/cucumber/world/pending_spec.rb
+++ b/spec/cucumber/world/pending_spec.rb
@@ -13,15 +13,15 @@ module Cucumber
     end
 
     it 'raises a Pending if no block is supplied' do
-      expect(-> { @world.pending 'TODO' }).to raise_error(Cucumber::Pending, /TODO/)
+      expect { @world.pending 'TODO' }.to raise_error(Cucumber::Pending, /TODO/)
     end
 
     it 'raises a Pending if a supplied block fails as expected' do
-      expect(lambda do
+      expect do
         @world.pending 'TODO' do
           raise 'oops'
         end
-      end).to raise_error(Cucumber::Pending, /TODO/)
+      end.to raise_error(Cucumber::Pending, /TODO/)
     end
 
     it 'raises a Pending if a supplied block fails as expected with a double' do
@@ -37,7 +37,7 @@ module Cucumber
     end
 
     it 'raises a Pending if a supplied block starts working' do
-      expect(-> { @world.pending 'TODO' }).to raise_error(Cucumber::Pending, /TODO/)
+      expect { @world.pending 'TODO' }.to raise_error(Cucumber::Pending, /TODO/)
     end
   end
 end


### PR DESCRIPTION
# Description

This PR suppresses the following RSpec deprecation warnings.

* Pass a block instead of a lambda to `expect`
  ```
  The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to change `step_args.first`` not `expect(value).to change `step_args.first``
  ```

* Replace deprecated `should` with RSpec3's `expect`
  ```
  DEPRECATION: Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /Users/runner/work/cucumber-ruby/cucumber-ruby/examples/i18n/sv/features/step_definitions/kalkulator_steps.rb:27:in `block in <top (required)>'.
  ```

## Type of change

- Refactoring (improvements to code design or tooling that don't change behaviour)

# Checklist:

- [ ] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [x] CHANGELOG.md has been updated
