### PR TITLE
Add rule to renovate config to examine gemspec too

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,16 @@
   "extends": [
     "config:base",
     ":disableDependencyDashboard"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^*.gemspec"],
+      "matchStrings": [
+        "^.*add.*dependency.*['\"](?<depName>.*?)['\"],.*['\"](?<currentValue>.*?)['\"].*"
+      ],
+      "depNameTemplate": "gemspec",
+      "datasourceTemplate": "rubygems",
+      "versioningTemplate": "ruby"
+    }
   ]
 }


### PR DESCRIPTION
# Description

* add a custom [regex manager](https://docs.renovatebot.com/modules/manager/regex/) to the `renovate.json` config which allows Renovate to detect dependencies in `.gemspec` files.

Fixes #1637 

## Type of change

- Refactoring (improvements to code design or tooling that don't change behaviour)