### PR TITLE
Fix NoMethodError that is raised when the environment variable CUCUMBER_COLORS is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
-* When the environment variable CUCUMBER_COLORS is set, its value is used instead of raising a NoMethodError.
+* Cucumber may raise NoMethodError when CUCUMBER_COLORS environment was set ([PR#1641](https://github.com/cucumber/cucumber-ruby/pull/1641/) [s2k](https://github.com/s2k))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
+* When the environment variable CUCUMBER_COLORS is set, its value is used instead of raising a NoMethodError.
+
 ### Changed
 
 ### Removed

--- a/lib/cucumber/formatter/ansicolor.rb
+++ b/lib/cucumber/formatter/ansicolor.rb
@@ -94,6 +94,17 @@ module Cucumber
       end
       apply_custom_colors(ENV['CUCUMBER_COLORS']) if ENV['CUCUMBER_COLORS']
 
+      # Provide an instance method of the same name, in case users are using it.
+
+      # Apply the custom color scheme
+      #
+      # example:
+      #
+      #   apply_custom_colors('passed=white')
+      def apply_custom_colors(colors)
+        ANSIColor.apply_custom_colors(colors)
+      end
+
       # Define the color-named methods required by Term::ANSIColor.
       #
       # Examples:

--- a/lib/cucumber/formatter/ansicolor.rb
+++ b/lib/cucumber/formatter/ansicolor.rb
@@ -94,17 +94,6 @@ module Cucumber
       end
       apply_custom_colors(ENV['CUCUMBER_COLORS']) if ENV['CUCUMBER_COLORS']
 
-      # Provide an instance method of the same name, in case users are using it.
-
-      # Apply the custom color scheme
-      #
-      # example:
-      #
-      #   apply_custom_colors('passed=white')
-      def apply_custom_colors(colors)
-        ANSIColor.apply_custom_colors(colors)
-      end
-
       # Define the color-named methods required by Term::ANSIColor.
       #
       # Examples:

--- a/lib/cucumber/formatter/ansicolor.rb
+++ b/lib/cucumber/formatter/ansicolor.rb
@@ -86,7 +86,7 @@ module Cucumber
       # example:
       #
       #   apply_custom_colors('passed=white')
-      def apply_custom_colors(colors)
+      def self.apply_custom_colors(colors)
         colors.split(':').each do |pair|
           a = pair.split('=')
           ALIASES[a[0]] = a[1]

--- a/spec/cucumber/formatter/ansicolor_spec.rb
+++ b/spec/cucumber/formatter/ansicolor_spec.rb
@@ -36,7 +36,7 @@ module Cucumber
 
       context 'with custom color scheme' do
         before do
-          ANSIColor.apply_custom_colors('passed=red,bold')
+          apply_custom_colors('passed=red,bold')
         end
 
         after do
@@ -48,7 +48,7 @@ module Cucumber
         end
 
         def reset_colours_to_default
-          ANSIColor.apply_custom_colors('passed=green')
+          apply_custom_colors('passed=green')
         end
       end
     end

--- a/spec/cucumber/formatter/ansicolor_spec.rb
+++ b/spec/cucumber/formatter/ansicolor_spec.rb
@@ -36,7 +36,7 @@ module Cucumber
 
       context 'with custom color scheme' do
         before do
-          apply_custom_colors('passed=red,bold')
+          ANSIColor.apply_custom_colors('passed=red,bold')
         end
 
         after do
@@ -48,7 +48,7 @@ module Cucumber
         end
 
         def reset_colours_to_default
-          apply_custom_colors('passed=green')
+          ANSIColor.apply_custom_colors('passed=green')
         end
       end
     end


### PR DESCRIPTION
# Description

This fixes a NoMethodError exception that is raised, when the environment variable `CUCUMBER_COLORS` is set, by allowing `apply_custom_colors` to be called right after its definition in `Cucumber::Formatter::ANSIColor`.

Defining the method as a class method of the module allows it to be called in the module itself.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
