### PR TITLE
Simplify Gemfile so dependabot can parse it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,8 @@ gem 'rubocop', '~> 1.22', '= 1.30.1'
 gem 'rubocop-packaging', '~> 0.3', '= 0.5.1'
 
 # To hack on Cucumber together with any of these libraries, uncomment the line below:
-#gem 'cucumber-core', path: '../cucumber-ruby-core'
-#gem 'cucumber-cucumber-expressions', path: '../cucumber-expressions/ruby'
-#gem 'cucumber-gherkin', path: '../common/gherkin/ruby'
-#gem 'cucumber-html-formatter', path: '../html-formatter/ruby'
-#gem 'cucumber-messages', path: '../common/messages/ruby'
+# gem 'cucumber-core', path: '../cucumber-ruby-core'
+# gem 'cucumber-cucumber-expressions', path: '../cucumber-expressions/ruby'
+# gem 'cucumber-gherkin', path: '../common/gherkin/ruby'
+# gem 'cucumber-html-formatter', path: '../html-formatter/ruby'
+# gem 'cucumber-messages', path: '../common/messages/ruby'

--- a/Gemfile
+++ b/Gemfile
@@ -4,16 +4,12 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-if ENV['CUCUMBER_RUBY_CORE']
-  gem 'cucumber-core', path: ENV['CUCUMBER_RUBY_CORE']
-elsif !ENV['CUCUMBER_USE_RELEASED_GEMS']
-  gem 'cucumber-core', github: 'cucumber/cucumber-ruby-core', branch: 'main'
-end
-
-gem 'cucumber-expressions', path: ENV['CUCUMBER_EXPRESSIONS_RUBY'] if ENV['CUCUMBER_EXPRESSIONS_RUBY']
-gem 'cucumber-gherkin', path: ENV['GHERKIN_RUBY'] if ENV['GHERKIN_RUBY']
-gem 'cucumber-html-formatter', path: ENV['CUCUMBER_HTML_FORMATTER_RUBY'] if ENV['CUCUMBER_HTML_FORMATTER_RUBY']
-gem 'cucumber-messages', path: ENV['CUCUMBER_MESSAGES_RUBY'] if ENV['CUCUMBER_MESSAGES_RUBY']
-
 gem 'rubocop', '~> 1.22', '= 1.30.1'
 gem 'rubocop-packaging', '~> 0.3', '= 0.5.1'
+
+# To hack on Cucumber together with any of these libraries, uncomment the line below:
+#gem 'cucumber-core', path: '../cucumber-ruby-core'
+#gem 'cucumber-cucumber-expressions', path: '../cucumber-expressions/ruby'
+#gem 'cucumber-gherkin', path: '../common/gherkin/ruby'
+#gem 'cucumber-html-formatter', path: '../html-formatter/ruby'
+#gem 'cucumber-messages', path: '../common/messages/ruby'


### PR DESCRIPTION
# Description

I've been working on trying to resolve https://github.com/cucumber/cucumber-ruby/issues/1637 and trying a different tack using Dependabot rather than Renovate.

In order to get Dependabot to parse our dependencies, we need to simplify the Gemfile to plain text.

This seems to work, [based on a test I did in my fork](https://github.com/mattwynne/cucumber-ruby/network/updates/389434839). It's even created a couple of PRs (https://github.com/mattwynne/cucumber-ruby/pull/2, https://github.com/mattwynne/cucumber-ruby/pull/3).

The downside is that we lose this fancy ability to configure our development environments. To me this feels like a good trade-off, as we can still un-comment these lines locally if we need to work on a particular library in conjunction with this one. I went for having them commented out by default as I feel like that's the lowest barrier to entry for a new developer checking out the code.

Fixed #1637 

## Type of change

- Refactoring (improvements to code design or tooling that don't change behaviour)
