### PR TITLE
New option '--retry-total' as a circuit breaker for option '--retry'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 ## [Unreleased](https://github.com/cucumber/cucumber-ruby/compare/v8.0.0...main)
 
 ### Added
+* Add option `--retry-total` ([PR#](https://github.com/cucumber/cucumber-ruby/pull/1669))
 
 ### Fixed
 

--- a/features/docs/cli/retry_failing_tests.feature
+++ b/features/docs/cli/retry_failing_tests.feature
@@ -95,3 +95,31 @@ Feature: Retry failing tests
 
       3 scenarios (2 flaky, 1 passed)
       """
+
+  Scenario: Retry each test but suspend retrying after 2 failing tests, so later tests are not retried
+    Given a scenario "Fails-forever-1" that fails
+    And a scenario "Fails-forever-2" that fails
+    When I run `cucumber -q --retry 1 --retry-total 2 --format summary`
+    Then it should fail with:
+      """
+      5 scenarios (4 failed, 1 passed)
+      """
+    And it should fail with:
+      """
+      Fails-forever-1
+        Fails-forever-1 ✗
+        Fails-forever-1 ✗
+
+      Fails-forever-2
+        Fails-forever-2 ✗
+        Fails-forever-2 ✗
+
+      Fails-once feature
+        Fails-once ✗
+
+      Fails-twice feature
+        Fails-twice ✗
+
+      Solid
+        Solid ✓
+      """

--- a/features/lib/step_definitions/scenarios_and_steps.rb
+++ b/features/lib/step_definitions/scenarios_and_steps.rb
@@ -30,26 +30,26 @@ end
 Given('a scenario {string} that passes') do |name|
   create_feature(name) do
     create_scenario(name) do
-      '  Given it passes'
+      "  Given it passes in #{name}"
     end
   end
 
   write_file(
     "features/step_definitions/#{name}_steps.rb",
-    step_definition('/^it passes$/', 'expect(true).to be true')
+    step_definition("/^it passes in #{name}$/", 'expect(true).to be true')
   )
 end
 
 Given('a scenario {string} that fails') do |name|
   create_feature(name) do
     create_scenario(name) do
-      '  Given it fails'
+      "  Given it fails in #{name}"
     end
   end
 
   write_file(
     "features/step_definitions/#{name}_steps.rb",
-    step_definition('/^it fails$/', 'expect(false).to be true')
+    step_definition("/^it fails in #{name}$/", 'expect(false).to be true')
   )
 end
 
@@ -58,14 +58,14 @@ Given('a scenario {string} that fails once, then passes') do |full_name|
 
   create_feature("#{full_name} feature") do
     create_scenario(full_name) do
-      '  Given it fails once, then passes'
+      "  Given it fails once, then passes in #{full_name}"
     end
   end
 
   write_file(
     "features/step_definitions/#{name}_steps.rb",
     step_definition(
-      '/^it fails once, then passes$/',
+      "/^it fails once, then passes in #{full_name}$/",
       [
         "$#{name} += 1",
         "expect($#{name}).to be > 1"
@@ -84,14 +84,14 @@ Given('a scenario {string} that fails twice, then passes') do |full_name|
 
   create_feature("#{full_name} feature") do
     create_scenario(full_name) do
-      '  Given it fails twice, then passes'
+      "  Given it fails twice, then passes in #{full_name}"
     end
   end
 
   write_file(
     "features/step_definitions/#{name}_steps.rb",
     step_definition(
-      '/^it fails twice, then passes$/',
+      "/^it fails twice, then passes in #{full_name}$/",
       [
         "$#{name} ||= 0",
         "$#{name} += 1",

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -56,11 +56,12 @@ module Cucumber
       NO_PROFILE_LONG_FLAG = '--no-profile'.freeze
       FAIL_FAST_FLAG = '--fail-fast'.freeze
       RETRY_FLAG = '--retry'.freeze
+      RETRY_TOTAL_FLAG = '--retry-total'.freeze
       OPTIONS_WITH_ARGS = [
         '-r', '--require', '--i18n-keywords', '-f', '--format', '-o',
         '--out', '-t', '--tags', '-n', '--name', '-e', '--exclude',
-        PROFILE_SHORT_FLAG, PROFILE_LONG_FLAG, RETRY_FLAG, '-l',
-        '--lines', '--port', '-I', '--snippet-type'
+        PROFILE_SHORT_FLAG, PROFILE_LONG_FLAG, RETRY_FLAG, RETRY_TOTAL_FLAG,
+        '-l', '--lines', '--port', '-I', '--snippet-type'
       ].freeze
       ORDER_TYPES = %w[defined random].freeze
       TAG_LIMIT_MATCHER = /(?<tag_name>@\w+):(?<limit>\d+)/x
@@ -108,6 +109,7 @@ module Cucumber
           opts.on('-j DIR', '--jars DIR', 'Load all the jars under DIR') { |jars| load_jars(jars) } if Cucumber::JRUBY
 
           opts.on("#{RETRY_FLAG} ATTEMPTS", *retry_msg) { |v| set_option :retry, v.to_i }
+          opts.on("#{RETRY_TOTAL_FLAG} TESTS", *retry_total_msg) { |v| set_option :retry_total, v.to_i }
           opts.on('--i18n-languages', *i18n_languages_msg) { list_languages_and_exit }
           opts.on('--i18n-keywords LANG', *i18n_keywords_msg) { |lang| language lang }
           opts.on(FAIL_FAST_FLAG, 'Exit immediately following the first failing scenario') { set_option :fail_fast }
@@ -269,6 +271,13 @@ Specify SEED to reproduce the shuffling from a previous run.
 
       def retry_msg
         ['Specify the number of times to retry failing tests (default: 0)']
+      end
+
+      def retry_total_msg
+        [
+          'The total number of failing test after which retrying of tests is suspended.',
+          'Example: --retry-total 10 -> Will stop retrying tests after 10 failing tests.'
+        ]
       end
 
       def name_msg
@@ -543,6 +552,7 @@ Specify SEED to reproduce the shuffling from a previous run.
         end
 
         @options[:retry] = other_options[:retry] if @options[:retry].zero?
+        @options[:retry_total] = other_options[:retry_total] if @options[:retry_total].infinite?
 
         self
       end
@@ -616,7 +626,8 @@ Specify SEED to reproduce the shuffling from a previous run.
           snippets: true,
           source: true,
           duration: true,
-          retry: 0
+          retry: 0,
+          retry_total: Float::INFINITY
         }
       end
     end

--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -78,6 +78,10 @@ module Cucumber
       @options[:retry]
     end
 
+    def retry_total_tests
+      @options[:retry_total]
+    end
+
     def guess?
       @options[:guess]
     end
@@ -273,7 +277,8 @@ module Cucumber
         snippets: true,
         source: true,
         duration: true,
-        event_bus: Cucumber::Events.make_event_bus
+        event_bus: Cucumber::Events.make_event_bus,
+        retry_total: Float::INFINITY
       }
     end
 

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -379,6 +379,26 @@ module Cucumber
               end
             end
           end
+
+          context '--retry-total TESTS' do
+            context '--retry-total option not defined on the command line' do
+              it 'uses the --retry-total option from the profile' do
+                given_cucumber_yml_defined_as('foo' => '--retry-total 2')
+                options.parse!(%w[-p foo])
+
+                expect(options[:retry_total]).to be 2
+              end
+            end
+
+            context '--retry-total option defined on the command line' do
+              it 'ignores the --retry-total option from the profile' do
+                given_cucumber_yml_defined_as('foo' => '--retry-total 2')
+                options.parse!(%w[--retry-total 1 -p foo])
+
+                expect(options[:retry_total]).to be 1
+              end
+            end
+          end
         end
 
         context '-P or --no-profile' do
@@ -437,6 +457,20 @@ module Cucumber
           it 'sets the options[:retry] value' do
             after_parsing('--retry 4') do
               expect(options[:retry]).to eql 4
+            end
+          end
+        end
+
+        context '--retry-total TESTS' do
+          it 'is INFINITY by default' do
+            after_parsing('') do
+              expect(options[:retry_total]).to eql Float::INFINITY
+            end
+          end
+
+          it 'sets the options[:retry_total] value' do
+            after_parsing('--retry 3 --retry-total 10') do
+              expect(options[:retry_total]).to eql 10
             end
           end
         end


### PR DESCRIPTION
# Description

This PR adds a new option `--retry-total` which can be used in conjunction with the existing option `--retry`.

`--retry-total` acts as a circuit breaker in case a larger number of tests are failing, and it comes apparent that the problem introduced is not the usual 'flakiness' that `--retry` deals with. For example, when a bad commit leads to many tests failing it is very inefficient and slow to retry all these tests. The same is true if a temporary infrastructure problem causes all tests to fail.

In our test suite of 24'000 tests, we observe a predictable number of tests being randomly flakey. This number is below 5 and therefore we would set `--retry 3 --retry-total 5`. In case of a bad commit with e.g. 3000 tests failing we would save the effort and time to repeat all of them 3 times.

## Type of change

- New feature (non-breaking change which adds new behaviour)

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [x] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] RDoc comments have been updated
- [x] CHANGELOG.md has been updated
