### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/cucumber-ruby.yml
+++ b/.github/workflows/cucumber-ruby.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
         include:
           - os: ubuntu-latest
             ruby: jruby-9.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - release/*
 
 jobs:
-
   pre-release-check:
     name: Perform checks before releasing
     runs-on: ubuntu-latest
@@ -23,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
         include:
           - os: ubuntu-latest
             ruby: jruby-9.3

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1']
+        ruby-version: ["3.2"]
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Run tests
-      run: bundle exec rake rubocop
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run tests
+        run: bundle exec rake rubocop

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Later in this document, bundler is considered being used so all commands are usi
 
 ### Supported platforms
 
+- Ruby 3.2
 - Ruby 3.1
 - Ruby 3.0
 - Ruby 2.7


### PR DESCRIPTION
# Description

This PR is add Ruby 3.2 to the CI matrix
Because Ruby 3.2.0 is now in general release, it makes sense to add Ruby 3.2 to the CI matrix.

https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/

## Type of change

- Refactoring (improvements to code design or tooling that don't change behaviour)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [x] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [-] RDoc comments have been updated
- [x] CHANGELOG.md has been updated
