### PR TITLE
Replace mime-types gem with mini_mime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Changed
 * Update dependency cucumber-gherkin to v26 ([#1688](https://github.com/cucumber/cucumber-ruby/pull/1688))
+* Replace dependency [mime-types](https://rubygems.org/gems/mime-types)
+  with [mini_mime](https://rubygems.org/gems/mini_mime)
+  ([#1695](https://github.com/cucumber/cucumber-ruby/pull/1695))
 
 ### Deprecated
 

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cucumber-html-formatter', '>= 19.1', '< 21.0'
   s.add_dependency 'cucumber-messages', '>= 18', '< 22'
   s.add_dependency 'diff-lcs', '~> 1.5', '>= 1.5.0'
-  s.add_dependency 'mime-types', '~> 3.4', '>= 3.4.1'
+  s.add_dependency 'mini_mime', '~> 1.0'
   s.add_dependency 'multi_test', '~> 1.1', '>= 1.1.0'
   s.add_dependency 'sys-uname', '~> 1.2', '>= 1.2.2'
 

--- a/lib/cucumber/glue/proto_world.rb
+++ b/lib/cucumber/glue/proto_world.rb
@@ -3,7 +3,7 @@
 require 'cucumber/gherkin/formatter/ansi_escapes'
 require 'cucumber/core/test/data_table'
 require 'cucumber/deprecate'
-require 'mime/types'
+require 'mini_mime'
 
 module Cucumber
   module Glue
@@ -92,7 +92,7 @@ module Cucumber
         return super unless File.file?(file)
 
         content = File.read(file, mode: 'rb')
-        media_type = MIME::Types.type_for(file).first if media_type.nil?
+        media_type = MiniMime.lookup_by_filename(file)&.content_type if media_type.nil?
 
         super(content, media_type.to_s)
       rescue StandardError


### PR DESCRIPTION
## Description

[mini_mime](https://github.com/discourse/mini_mime) is a minimal mime type library that's more performant and uses less memory than the `mime-types` gem.

It has replaced `mime-types` in several projects:

* `rails` →  `actionmailer` → `mail` gem: https://github.com/mikel/mail/pull/1059
* `capybara` https://github.com/teamcapybara/capybara/pull/1884
* `httparty` https://github.com/jnunemaker/httparty/pull/769

Using it as a dependency of `cucumber`, downstream projects would be able to reuse the same dependency that is already available in most Rails apps, instead of pulling in an extra `mime-types` dependency.

### Type of change


- Refactoring (of dependencies) (improvements to code design or tooling that don't change behaviour)

## Checklist

- [x] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] RDoc comments have been updated
- [x] CHANGELOG.md has been updated
