### PR TITLE
Drop Ruby 2.6 support

### DIFF
--- a/.github/workflows/cucumber-ruby.yml
+++ b/.github/workflows/cucumber-ruby.yml
@@ -19,7 +19,7 @@ jobs:
         ruby: ["2.7", "3.0", "3.1", "3.2"]
         include:
           - os: ubuntu-latest
-            ruby: jruby-9.3
+            ruby: jruby-9.4
           - os: ubuntu-latest
             ruby: truffleruby-head
 

--- a/.github/workflows/cucumber-ruby.yml
+++ b/.github/workflows/cucumber-ruby.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
         include:
           - os: ubuntu-latest
             ruby: jruby-9.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
         include:
           - os: ubuntu-latest
             ruby: jruby-9.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         ruby: ["2.7", "3.0", "3.1", "3.2"]
         include:
           - os: ubuntu-latest
-            ruby: jruby-9.3
+            ruby: jruby-9.4
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   NewCops: disable
   # Keep this inline with the lowest ruby-* version in circleci/config.yml and
   # the version in the gemspec
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   # Cop names are not displayed in offense messages by default. Change behavior
   # by overriding DisplayCopNames, or by giving the `-D/--display-cop-names`
   # option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 - Cucumber may raise NoMethodError when CUCUMBER_COLORS environment was set ([PR#1641](https://github.com/cucumber/cucumber-ruby/pull/1641/) [s2k](https://github.com/s2k))
 
 ### Removed
+- Removed support for Ruby 2.6 ([PR#1699](https://github.com/cucumber/cucumber-ruby/pull/1699))
 
 ## [8.0.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 - Cucumber may raise NoMethodError when CUCUMBER_COLORS environment was set ([PR#1641](https://github.com/cucumber/cucumber-ruby/pull/1641/) [s2k](https://github.com/s2k))
 
 ### Removed
-- Removed support for Ruby 2.6 ([PR#1699](https://github.com/cucumber/cucumber-ruby/pull/1699))
+- Removed support for Ruby 2.6 and JRuby 9.3 ([PR#1699](https://github.com/cucumber/cucumber-ruby/pull/1699))
 
 ## [8.0.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Later in this document, bundler is considered being used so all commands are usi
 - Ruby 3.1
 - Ruby 3.0
 - Ruby 2.7
-- Ruby 2.6
 - TruffleRuby 22.0.0+
 - JRuby (with [some limitations](https://github.com/cucumber/cucumber-ruby/blob/main/docs/jruby-limitations.md))
   - 9.3 >= 9.3.1 (there is a known issue with JRuby 9.3.0. More info can

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ Later in this document, bundler is considered being used so all commands are usi
 - Ruby 2.7
 - TruffleRuby 22.0.0+
 - JRuby (with [some limitations](https://github.com/cucumber/cucumber-ruby/blob/main/docs/jruby-limitations.md))
-  - 9.3 >= 9.3.1 (there is a known issue with JRuby 9.3.0. More info can
-    be found in the [PR#1571](https://github.com/cucumber/cucumber-ruby/pull/1571).)
+  - 9.4
 
 ### Ruby on Rails
 

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   }
 
   # Keep in sync with .circleci/config.yml & .rubocop.yml
-  s.required_ruby_version = '>= 2.6'
+  s.required_ruby_version = '>= 2.7'
   s.add_dependency 'builder', '~> 3.2', '>= 3.2.4'
   s.add_dependency 'cucumber-ci-environment', '~> 9.0', '>= 9.0.4'
   s.add_dependency 'cucumber-core', '~> 11.0', '>= 11.0.0'


### PR DESCRIPTION
# Description

Drop support for Ruby 2.6. Adresses  #1693

## Type of change
- Reducing technical debt

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request. - Done :heavy_check_mark: 

## Note to other contributors
This PR might fix the red build here: https://github.com/cucumber/cucumber-ruby/pull/1689

## Update required of cucumber.io/docs

Changes are not required in cucumber.io/docs

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [x] Tests have been added for any changes to behaviour of the code - _not needed_
- [x] New and existing tests are passing locally and on CI - _tested locally, i was not able to trigger the CI. But it should work, we are only removing the language version from matrix_
- [x] `bundle exec rubocop` reports no offenses
- [x] RDoc comments have been updated - _not needed_
- [x] CHANGELOG.md has been updated
