### PR TITLE
bugfix: Handle Cucumber-Wire issue when parameter type cannot be specified on Envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   All logic contained in [compatibility](./compatibility) ([luke-hill](https://github.com/luke-hill))
 
 ### Fixed
+- Fix a situation whereby the step definition message will omit the parameter-type name when it cannot be inferred
+  (This fixes an issue in cucumber-wire when passing legacy steps down the wire)
+  ([#1746](https://github.com/cucumber/cucumber-ruby/pull/1746) [luke-hill](https://github.com/luke-hill))
 
 ### Removed
 

--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -132,7 +132,7 @@ module Cucumber
         @step_definitions_by_test_step.step_match_arguments(step).map do |argument|
           Cucumber::Messages::StepMatchArgument.new(
             group: argument_group_to_message(argument.group),
-            parameter_type_name: argument.parameter_type.name
+            parameter_type_name: parameter_type_name(argument)
           )
         end
       end
@@ -143,6 +143,10 @@ module Cucumber
           value: group.value,
           children: group.children.map { |child| argument_group_to_message(child) }
         )
+      end
+
+      def parameter_type_name(step_match_argument)
+        step_match_argument.parameter_type&.name if step_match_argument.respond_to?(:parameter_type)
       end
 
       def on_test_run_started(*)


### PR DESCRIPTION
# Description

Attempts to fix [Handle NME from cucumber-wire](https://github.com/cucumber/cucumber-ruby-wire/issues/56)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
