### PR TITLE
Remove unknown hash keyword arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 - Fixed an issue where a change to one example in compatibility testing wasn't fully adhered to ([luke-hill](https://github.com/luke-hill))
+- Fixed an issue for Ruby 3.4.0 where a default hash instantiation was being picked up as keyword arguments  ([Jon Rowe](https://github.com/JonRowe))
 
 ### Removed
 - Removed support for Ruby 2.7 ([luke-hill](https://github.com/luke-hill))

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -75,7 +75,9 @@ module Cucumber
         def eof; end
       end
 
-      NULL_CONVERSIONS = Hash.new(strict: false, proc: ->(cell_value) { cell_value }).freeze
+      # This is a Hash being initialized with a default value of a Hash, DO NOT REFORMAT TO REMOVE {}
+      # Future versions [3.4.0+] of ruby will interpret these as keywords and break.
+      NULL_CONVERSIONS = Hash.new({ strict: false, proc: ->(cell_value) { cell_value } }).freeze
 
       # @param data [Core::Test::DataTable] the data for the table
       # @param conversion_procs [Hash] see map_column


### PR DESCRIPTION
# Description

Ruby head adds a capacity keyword option to Hash which causes other keywords passed to `Hash.new` to be validated, this causes an error when running Cucumber 9.2.0 on ruby-head (example from an [rspec-expectations build](https://github.com/rspec/rspec-expectations/actions/runs/9930979288/job/27430326483?pr=1471)):

```
/home/runner/work/rspec-expectations/rspec-expectations/bin/cucumber
<internal:hash>:37:in 'initialize': unknown keywords: :strict, :proc (ArgumentError)
	from /home/runner/work/rspec-expectations/rspec-expectations/bundle/ruby/3.4.0+0/gems/cucumber-9.2.0/lib/cucumber/multiline_argument/data_table.rb:78:in 'Class#new'
```

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
