### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
     'changelog_uri' => 'https://github.com/cucumber/cucumber-ruby/blob/main/CHANGELOG.md',
     'documentation_uri' => 'https://www.rubydoc.info/github/cucumber/cucumber-ruby/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/cukes',
+    'rubygems_mfa_required' => 'true',
     'source_code_uri' => 'https://github.com/cucumber/cucumber-ruby'
   }
 


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/
