### PR TITLE
Fix "Hash.new with kwargs" error in Ruby 3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 - Fixed an issue where a change to one example in compatibility testing wasn't fully adhered to ([luke-hill](https://github.com/luke-hill))
+- Fixed a Hash.new with kwargs error on Ruby 3.4 (warning on Ruby 3.3) ([#1761](https://github.com/cucumber/cucumber-ruby/pull/1761))
 
 ### Removed
 - Removed support for Ruby 2.7 ([luke-hill](https://github.com/luke-hill))

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -75,7 +75,7 @@ module Cucumber
         def eof; end
       end
 
-      NULL_CONVERSIONS = Hash.new(strict: false, proc: ->(cell_value) { cell_value }).freeze
+      NULL_CONVERSIONS = Hash.new({ strict: false, proc: ->(cell_value) { cell_value } }).freeze
 
       # @param data [Core::Test::DataTable] the data for the table
       # @param conversion_procs [Hash] see map_column


### PR DESCRIPTION
# Description

Calling Hash.new with keyword arguments has been removed in Ruby 3.4, and it's warned to "use Hash.new({ key: value }) instead" in Ruby 3.3.
Please see https://bugs.ruby-lang.org/issues/19236 for more details about this change.

So here's a patch that fixes the warning and error below:

Ruby 3.3
```
warning: Calling Hash.new with keyword arguments is deprecated and will be removed in Ruby 3.4; use Hash.new({ key: value }) instead
```

Ruby 3.4
```
unknown keywords: :strict, :proc (ArgumentError)
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] CHANGELOG.md has been updated