### PR TITLE
gemspec: add runtime dependencies on base64, bigdecimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ## [Unreleased]
 ### Changed
+- Added gems `base64`, `bigdecimal` as dependencies ([olleolleolle](https://github.com/olleolleolle))
 - Updated `cucumber-compatibility-kit` to v16 ([luke-hill](https://github.com/luke-hill))
 - Changed compatibility testing to fully lean on external assets instead of duplicating them ([luke-hill](https://github.com/luke-hill))
 

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
   s.required_rubygems_version = '>= 3.2.8'
 
+  s.add_dependency 'base64'
+  s.add_dependency 'bigdecimal'
   s.add_dependency 'builder', '~> 3.2'
   s.add_dependency 'cucumber-ci-environment', '> 9', '< 11'
   s.add_dependency 'cucumber-core', '> 13', '< 14'


### PR DESCRIPTION
# Description

This PR adds dependencies in the `Gemfile` on gems which are referred to in the code, but which in Ruby 3.4 will not be bundled with Ruby.

If absent, and relying on the bundled-with-Ruby gems, these gems emit warnings in our test suite.

See #1757 

## Type of change

Please delete options that are not relevant.

- Refactoring (improvements to code design or tooling that don't change behaviour)

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [x] CHANGELOG.md has been updated
