### PR TITLE
Avoid warning by explicit new dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ## [Unreleased]
 ### Changed
-- Updated cucumber dependencies  ([jeromeag](https://github.com/jerome))
+- Added dependencies that will no longer be part of the ruby stdlib ([jeromeag](https://github.com/jerome))
 - Updated `cucumber-compatibility-kit` to v16 ([luke-hill](https://github.com/luke-hill))
 - Changed compatibility testing to fully lean on external assets instead of duplicating them ([luke-hill](https://github.com/luke-hill))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ## [Unreleased]
 ### Changed
+- Updated cucumber dependencies  ([jeromeag](https://github.com/jerome))
 - Updated `cucumber-compatibility-kit` to v16 ([luke-hill](https://github.com/luke-hill))
 - Changed compatibility testing to fully lean on external assets instead of duplicating them ([luke-hill](https://github.com/luke-hill))
 

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
   s.required_rubygems_version = '>= 3.2.8'
 
-  s.add_dependency 'base64', '~> 0'
+  s.add_dependency 'base64', '~> 0.2'
   s.add_dependency 'builder', '~> 3.2'
   s.add_dependency 'cucumber-ci-environment', '> 9', '< 11'
   s.add_dependency 'cucumber-core', '> 13', '< 14'
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cucumber-html-formatter', '> 20.3', '< 22'
   s.add_dependency 'cucumber-messages', '> 19', '< 26'
   s.add_dependency 'diff-lcs', '~> 1.5'
-  s.add_dependency 'logger', '~> 1'
+  s.add_dependency 'logger', '~> 1.6'
   s.add_dependency 'mini_mime', '~> 1.1'
   s.add_dependency 'multi_test', '~> 1.1'
   s.add_dependency 'sys-uname', '~> 1.2'

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
   s.required_rubygems_version = '>= 3.2.8'
 
+  s.add_dependency 'base64', '~> 0'
   s.add_dependency 'builder', '~> 3.2'
   s.add_dependency 'cucumber-ci-environment', '> 9', '< 11'
   s.add_dependency 'cucumber-core', '> 13', '< 14'
@@ -30,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cucumber-html-formatter', '> 20.3', '< 22'
   s.add_dependency 'cucumber-messages', '> 19', '< 26'
   s.add_dependency 'diff-lcs', '~> 1.5'
+  s.add_dependency 'logger', '~> 1'
   s.add_dependency 'mini_mime', '~> 1.1'
   s.add_dependency 'multi_test', '~> 1.1'
   s.add_dependency 'sys-uname', '~> 1.2'


### PR DESCRIPTION
- base64 will no longer be part of the default gems starting from Ruby 3.4.0
- logger will no longer be part of the default gems starting from Ruby 3.5.0

# Description

New explicit dependencies to avoid warnings:

- lib/cucumber.rb:7: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.

- lib/cucumber/formatter/message.rb:4: warning: base64 was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.


## Type of change

Please delete options that are not relevant.

- Refactoring (improvements to code design or tooling that don't change behaviour)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds new behaviour)
- Breaking change (will cause existing functionality to not
  work as expected)
- This change requires an update of [cucumber.io/docs](https://cucumber.io/docs)
- If your change may impact future contributors, explain it here, and remember to update README.md and CONTRIBUTING.md accordingly.

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

# Checklist:

- [ ] - Not applicable - Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no **new** offenses
- [ ] - Not applicable - RDoc comments have been updated
- [x] CHANGELOG.md has been updated
