### PR TITLE
Introducing Cucumber Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Test cucumber](https://github.com/cucumber/cucumber-ruby/actions/workflows/test.yaml/badge.svg)](https://github.com/cucumber/cucumber-ruby/actions/workflows/test.yaml)
 [![Code Climate](https://codeclimate.com/github/cucumber/cucumber-ruby.svg)](https://codeclimate.com/github/cucumber/cucumber-ruby)
 [![Coverage Status](https://coveralls.io/repos/cucumber/cucumber-ruby/badge.svg?branch=main)](https://coveralls.io/r/cucumber/cucumber-ruby?branch=main)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Cucumber%20Guru-006BFF)](https://gurubase.io/g/cucumber)
 
 Cucumber is a tool for running automated tests written in plain language. Because they're
 written in plain language, they can be read by anyone on your team. Because they can be


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Cucumber Guru](https://gurubase.io/g/cucumber) to Gurubase. Cucumber Guru uses the data from this repo and data from the [docs](https://cucumber.io/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Cucumber Guru", which highlights that Cucumber now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Cucumber Guru in Gurubase, just let me know that's totally fine.
