### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |s|
     'changelog_uri' => 'https://github.com/cucumber/cucumber-ruby/blob/main/CHANGELOG.md',
     'documentation_uri' => 'https://www.rubydoc.info/github/cucumber/cucumber-ruby/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/cukes',
-    'source_code_uri' => 'https://github.com/cucumber/cucumber-ruby'
+    'source_code_uri' => 'https://github.com/cucumber/cucumber-ruby',
+    'funding_uri' => 'https://opencollective.com/cucumber'
   }
 
   s.required_ruby_version = '>= 3.0'


### PR DESCRIPTION
I noticed that the project already has a FUNDING.yml. This PR adds the `funding_uri` to your gemspec to help increase visibility using the `bundle fund` command in Bundler.