### PR TITLE
Fix error backtrace formatting on Ruby 3.4+

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ['3.0', '3.1', '3.2', '3.3']
+        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4']
         include:
           - os: ubuntu-latest
             ruby: jruby-9.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ that need to rely on procedural loading / reloading of files should use method i
 
 ### Fixed
 - Fixed an issue where a change to one example in compatibility testing wasn't fully adhered to ([luke-hill](https://github.com/luke-hill))
+- Fixed Ruby 3.4+ issue where error backtraces weren't being formatted. ([#1771](https://github.com/cucumber/cucumber-ruby/pull/1771) [orien](https://github.com/orien))
 
 ### Removed
 - `StepDefinitionLight` associated methods. The class itself is present but deprecated

--- a/features/docs/extending_cucumber/custom_formatter.feature
+++ b/features/docs/extending_cucumber/custom_formatter.feature
@@ -45,7 +45,7 @@ Feature: Custom Formatter
           def initialize(config, options)
             @io = config.out_stream
             config.on_event :test_run_finished do |event|
-              @io.print options.inspect
+              @io.print options.to_json
             end
           end
         end
@@ -54,5 +54,5 @@ Feature: Custom Formatter
     When I run `cucumber features/f.feature --format MyCustom::Formatter,foo=bar,one=two --publish-quiet`
     Then it should pass with exactly:
     """
-    {"foo"=>"bar", "one"=>"two"}
+    {"foo":"bar","one":"two"}
     """

--- a/lib/cucumber/formatter/backtrace_filter.rb
+++ b/lib/cucumber/formatter/backtrace_filter.rb
@@ -43,8 +43,10 @@ module Cucumber
 
         if ::ENV['CUCUMBER_TRUNCATE_OUTPUT']
           # Strip off file locations
+          regexp = RUBY_VERSION >= '3.4' ? /(.*):in '/ : /(.*):in `/
           filtered = filtered.map do |line|
-            line =~ /(.*):in `/ ? Regexp.last_match(1) : line
+            match = regexp.match(line)
+            match ? match[1] : line
           end
         end
 

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -68,13 +68,16 @@ OUTPUT
 
           define_steps do
             When('an object is logged') do
-              log(a: 1, b: 2, c: 3)
+              object = Object.new
+              def object.to_s
+                '<test-object>'
+              end
+              log(object)
             end
           end
 
-          it 'attached the string version on the object' do
-            expected_string = RUBY_VERSION >= '3.4' ? '{a: 1, b: 2, c: 3}' : '{:a=>1, :b=>2, :c=>3}'
-            expect(@out.string).to include expected_string
+          it 'prints the stringified version of the object as a log message' do
+            expect(@out.string).to include('<test-object>')
           end
         end
 

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -91,22 +91,15 @@ OUTPUT
 
           define_steps do
             When('{word} {word} {word}') do |subject, verb, complement|
-              log "subject: #{subject}", "verb: #{verb}", "complement: #{complement}", subject: subject, verb: verb, complement: complement
+              log "subject: #{subject}", "verb: #{verb}", "complement: #{complement}"
             end
           end
 
           it 'logs each parameter independently' do
-            expected_hash =
-              if RUBY_VERSION >= '3.4'
-                '{subject: "monkey", verb: "eats", complement: "banana"}'
-              else
-                '{:subject=>"monkey", :verb=>"eats", :complement=>"banana"}'
-              end
             expect(@out.string).to include [
               '      subject: monkey',
               '      verb: eats',
-              '      complement: banana',
-              "      #{expected_hash}"
+              '      complement: banana'
             ].join("\n")
           end
         end

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -83,24 +83,24 @@ OUTPUT
 
         describe 'when logging multiple items on one call' do
           define_feature <<-FEATURE
-        Feature: Banana party
+        Feature: Logging multiple entries
 
-          Scenario: Monkey eats banana
-            When monkey eats banana
+          Scenario: Logging multiple entries
+            When logging multiple entries
           FEATURE
 
           define_steps do
-            When('{word} {word} {word}') do |subject, verb, complement|
-              log "subject: #{subject}", "verb: #{verb}", "complement: #{complement}"
+            When('logging multiple entries') do
+              log 'entry one', 'entry two', 'entry three'
             end
           end
 
-          it 'logs each parameter independently' do
-            expect(@out.string).to include [
-              '      subject: monkey',
-              '      verb: eats',
-              '      complement: banana'
-            ].join("\n")
+          it 'logs each entry independently' do
+            expect(@out.string).to include([
+              '      entry one',
+              '      entry two',
+              '      entry three'
+            ].join("\n"))
           end
         end
 

--- a/spec/cucumber/glue/proto_world_spec.rb
+++ b/spec/cucumber/glue/proto_world_spec.rb
@@ -72,8 +72,9 @@ OUTPUT
             end
           end
 
-          it 'attached the styring version on the object' do
-            expect(@out.string).to include '{:a=>1, :b=>2, :c=>3}'
+          it 'attached the string version on the object' do
+            expected_string = RUBY_VERSION >= '3.4' ? '{a: 1, b: 2, c: 3}' : '{:a=>1, :b=>2, :c=>3}'
+            expect(@out.string).to include expected_string
           end
         end
 
@@ -92,11 +93,17 @@ OUTPUT
           end
 
           it 'logs each parameter independently' do
+            expected_hash =
+              if RUBY_VERSION >= '3.4'
+                '{subject: "monkey", verb: "eats", complement: "banana"}'
+              else
+                '{:subject=>"monkey", :verb=>"eats", :complement=>"banana"}'
+              end
             expect(@out.string).to include [
               '      subject: monkey',
               '      verb: eats',
               '      complement: banana',
-              '      {:subject=>"monkey", :verb=>"eats", :complement=>"banana"}'
+              "      #{expected_hash}"
             ].join("\n")
           end
         end


### PR DESCRIPTION
# Description

## Context

Cucumber performs filtering and formatting on error backtraces before displaying them in terminal output.

When running on Ruby 3.4, the backtrace filtering and formatting is not working. This is defect is caused by the new backtrace format introduced in Ruby 3.4.

See:
- https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/
- https://bugs.ruby-lang.org/issues/16495
- https://bugs.ruby-lang.org/issues/19117

## Change

Update the `Cucumber::Glue::InvokeInWorld` and `Cucumber::Formatter::BacktraceFilter` classes to support both styles of backtraces.

Fixes #1770

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [x] CHANGELOG.md has been updated
