### PR TITLE
Reintroduce cleaned up 9.2.1 into `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ that need to rely on procedural loading / reloading of files should use method i
 - Tag Expressions using legacy syntax that were handled / sanitized are no longer done so
 (This applies to both regular usage and internal testing)
 - Removed support for Ruby 2.7 ([luke-hill](https://github.com/luke-hill))
+- Unindentation support for snippet generator / tests (Heredocs are much better now) ([luke-hill](https://github.com/luke-hill))
 
 ## [9.2.1] - 2025-01-12
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ that need to rely on procedural loading / reloading of files should use method i
 
 ### Fixed
 - Fixed an issue where a change to one example in compatibility testing wasn't fully adhered to ([luke-hill](https://github.com/luke-hill))
-- Fixed an issue for Ruby 3.4.0 where a default hash instantiation was being picked up as keyword arguments  ([Jon Rowe](https://github.com/JonRowe))
 
 ### Removed
 - `StepDefinitionLight` associated methods. The class itself is present but deprecated
@@ -35,7 +34,7 @@ that need to rely on procedural loading / reloading of files should use method i
 
 ## [9.2.1] - 2025-01-12
 ### Fixed
-- Fixed an issue for Ruby 3.4.0 where a default hash instantiation was being picked up as keyword arguments  ([Jon Rowe](https://github.com/JonRowe))
+- Fixed an issue for Ruby 3.4+ where a default hash instantiation was being picked up as keyword arguments ([Jon Rowe](https://github.com/JonRowe))
 
 ## [9.2.0] - 2024-03-19
 ### Changed
@@ -181,7 +180,8 @@ can use the immutable versions instead: `DataTable#map_column` and
 ([#1590](https://github.com/cucumber/cucumber-ruby/pull/1590))
 - Removed support for Ruby 2.5 and JRuby 9.2.
 
-[Unreleased]: https://github.com/cucumber/cucumber-ruby/compare/v9.2.0...HEAD
+[Unreleased]: https://github.com/cucumber/cucumber-ruby/compare/v9.2.1...HEAD
+[9.2.1]: https://github.com/cucumber/cucumber-ruby/compare/v9.2.0...v9.2.1
 [9.2.0]: https://github.com/cucumber/cucumber-ruby/compare/v9.1.2...v9.2.0
 [9.1.2]: https://github.com/cucumber/cucumber-ruby/compare/v9.1.1...v9.1.2
 [9.1.1]: https://github.com/cucumber/cucumber-ruby/compare/v9.1.0...v9.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ that need to rely on procedural loading / reloading of files should use method i
 (This applies to both regular usage and internal testing)
 - Removed support for Ruby 2.7 ([luke-hill](https://github.com/luke-hill))
 
+## [9.2.1] - 2025-01-12
+### Fixed
+- Fixed an issue for Ruby 3.4.0 where a default hash instantiation was being picked up as keyword arguments  ([Jon Rowe](https://github.com/JonRowe))
+
 ## [9.2.0] - 2024-03-19
 ### Changed
 - Updated cucumber dependencies (Specifically cucumber-core) ([luke-hill](https://github.com/luke-hill))

--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -76,8 +76,8 @@ module Cucumber
         def eof; end
       end
 
-      # This is a Hash being initialized with a default value of a Hash, DO NOT REFORMAT TO REMOVE {}
-      # Future versions [3.4.0+] of ruby will interpret these as keywords and break.
+      # This is a Hash being initialized with a default value of a Hash
+      # DO NOT REFORMAT TO REMOVE {} - Ruby 3.4+ will interpret these as keywords and cucumber will not work
       NULL_CONVERSIONS = Hash.new({ strict: false, proc: ->(cell_value) { cell_value } }).freeze
 
       # @param data [Core::Test::DataTable] the data for the table

--- a/spec/cucumber/glue/snippet_spec.rb
+++ b/spec/cucumber/glue/snippet_spec.rb
@@ -23,97 +23,101 @@ module Cucumber
         @cucumber_expression_generator = CucumberExpressions::CucumberExpressionGenerator.new(@registry)
       end
 
-      def unindented(snippet)
-        indent(snippet.split("\n")[1..-2].join("\n"), -10)
-      end
-
       describe Snippet::Regexp do
         let(:snippet_class) { described_class }
         let(:snippet_text) { snippet.to_s }
 
         it 'wraps snippet patterns in parentheses' do
           @step_text = 'A "string" with 4 spaces'
+          cucumber_output = <<~CUKE.chomp
+            Given(/^A "([^"]*)" with (\\d+) spaces$/) do |arg1, arg2|
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
 
-          expect(snippet_text).to eq unindented(%{
-          Given(/^A "([^"]*)" with (\\d+) spaces$/) do |arg1, arg2|
-            pending # Write code here that turns the phrase above into concrete actions
-          end
-          })
+          expect(snippet_text).to eq(cucumber_output)
         end
 
         it 'recognises numbers in name and make according regexp' do
           @step_text = 'Cloud 9 yeah'
+          cucumber_output = <<~CUKE.chomp
+            Given(/^Cloud (\\d+) yeah$/) do |arg1|
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
 
-          expect(snippet_text).to eq unindented(%{
-          Given(/^Cloud (\\d+) yeah$/) do |arg1|
-            pending # Write code here that turns the phrase above into concrete actions
-          end
-          })
+          expect(snippet_text).to eq(cucumber_output)
         end
 
         it 'recognises a mix of ints, strings and why not a table too' do
           @step_text = 'I have 9 "awesome" cukes in 37 "boxes"'
           @multiline_argument = Core::Test::DataTable.new([[]])
+          cucumber_output = <<~CUKE.chomp
+            Given(/^I have (\\d+) "([^"]*)" cukes in (\\d+) "([^"]*)"$/) do |arg1, arg2, arg3, arg4, table|
+              # table is a Cucumber::MultilineArgument::DataTable
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
 
-          expect(snippet_text).to eq unindented(%{
-          Given(/^I have (\\d+) "([^"]*)" cukes in (\\d+) "([^"]*)"$/) do |arg1, arg2, arg3, arg4, table|
-            # table is a Cucumber::MultilineArgument::DataTable
-            pending # Write code here that turns the phrase above into concrete actions
-          end
-          })
+          expect(snippet_text).to eq(cucumber_output)
         end
 
         it 'recognises quotes in name and make according regexp' do
           @step_text = 'A "first" arg'
+          cucumber_output = <<~CUKE.chomp
+            Given(/^A "([^"]*)" arg$/) do |arg1|
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
 
-          expect(snippet_text).to eq unindented(%{
-          Given(/^A "([^"]*)" arg$/) do |arg1|
-            pending # Write code here that turns the phrase above into concrete actions
-          end
-          })
+          expect(snippet_text).to eq(cucumber_output)
         end
 
         it 'recognises several quoted words in name and make according regexp and args' do
           @step_text = 'A "first" and "second" arg'
+          cucumber_output = <<~CUKE.chomp
+            Given(/^A "([^"]*)" and "([^"]*)" arg$/) do |arg1, arg2|
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
 
-          expect(snippet_text).to eq unindented(%{
-          Given(/^A "([^"]*)" and "([^"]*)" arg$/) do |arg1, arg2|
-            pending # Write code here that turns the phrase above into concrete actions
-          end
-          })
+          expect(snippet_text).to eq(cucumber_output)
         end
 
         it 'does not use quote group when there are no quotes' do
           @step_text = 'A first arg'
+          cucumber_output = <<~CUKE.chomp
+            Given(/^A first arg$/) do
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
 
-          expect(snippet_text).to eq unindented(%{
-          Given(/^A first arg$/) do
-            pending # Write code here that turns the phrase above into concrete actions
-          end
-          })
+          expect(snippet_text).to eq(cucumber_output)
         end
 
         it 'is helpful with tables' do
           @step_text = 'A "first" arg'
           @multiline_argument = Core::Test::DataTable.new([[]])
+          cucumber_output = <<~CUKE.chomp
+            Given(/^A "([^"]*)" arg$/) do |arg1, table|
+              # table is a Cucumber::MultilineArgument::DataTable
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
 
-          expect(snippet_text).to eq unindented(%{
-          Given(/^A "([^"]*)" arg$/) do |arg1, table|
-            # table is a Cucumber::MultilineArgument::DataTable
-            pending # Write code here that turns the phrase above into concrete actions
-          end
-          })
+          expect(snippet_text).to eq(cucumber_output)
         end
 
         it 'is helpful with doc string' do
           @step_text = 'A "first" arg'
           @multiline_argument = MultilineArgument.from('', Core::Test::Location.new(''))
+          cucumber_output = <<~CUKE.chomp
+            Given(/^A "([^"]*)" arg$/) do |arg1, doc_string|
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
 
-          expect(snippet_text).to eq unindented(%{
-          Given(/^A "([^"]*)" arg$/) do |arg1, doc_string|
-            pending # Write code here that turns the phrase above into concrete actions
-          end
-          })
+          expect(snippet_text).to eq(cucumber_output)
         end
       end
 
@@ -121,11 +125,13 @@ module Cucumber
         let(:snippet_class) { described_class }
 
         it 'renders snippet as unwrapped regular expression' do
-          expect(snippet.to_s).to eq unindented(%(
-          Given /^we have a missing step$/ do
-            pending # Write code here that turns the phrase above into concrete actions
-          end
-          ))
+          cucumber_output = <<~CUKE.chomp
+            Given /^we have a missing step$/ do
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
+
+          expect(snippet.to_s).to eq(cucumber_output)
         end
       end
 
@@ -133,11 +139,13 @@ module Cucumber
         let(:snippet_class) { described_class }
 
         it 'renders snippet as percent-style regular expression' do
-          expect(snippet.to_s).to eq unindented(%(
-          Given %r{^we have a missing step$} do
-            pending # Write code here that turns the phrase above into concrete actions
-          end
-          ))
+          cucumber_output = <<~CUKE.chomp
+            Given %r{^we have a missing step$} do
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
+
+          expect(snippet.to_s).to eq(cucumber_output)
         end
       end
 
@@ -163,12 +171,14 @@ module Cucumber
                                             false
                                           ))
 
-          expect(snippet.to_s).to eq unindented(%{
-          Given('I have {float} {cucumis} in my belly') do |float, cucumis|
-          # Given('I have {float} {veg} in my belly') do |float, veg|
-            pending # Write code here that turns the phrase above into concrete actions
-          end
-          })
+          cucumber_output = <<~CUKE.chomp
+            Given('I have {float} {cucumis} in my belly') do |float, cucumis|
+            # Given('I have {float} {veg} in my belly') do |float, veg|
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
+
+          expect(snippet.to_s).to eq(cucumber_output)
         end
       end
     end

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -33,7 +33,7 @@ module Cucumber
       end
 
       describe '#symbolic_hashes' do
-        it 'coverts data table to an array of hashes with symbols as keys' do
+        it 'converts data table to an array of hashes with symbols as keys' do
           ast_table = Cucumber::Core::Test::DataTable.new([['foo', 'Bar', 'Foo Bar'], %w[1 22 333]])
           data_table = described_class.new(ast_table)
 


### PR DESCRIPTION
# Description

Fixes up any remaining items into `main` from the 9.2 backported fix
Also fix up some associated code nearby to do with unindenting (This should now all be removed)

## Type of change

Please delete options that are not relevant.

- Refactoring (improvements to code design or tooling that don't change behaviour)
- Bug fix (non-breaking change which fixes an issue)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
