### PR TITLE
fix: Fix potential NME when converting ParameterType to envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 - Use the new internal `cucumber-query` structure for the `rerun` formatter
 > This is a very large refactor, but should not change any behaviour. The `cucumber-query` structure is a new internal structure that is designed to be used by formatters to query
 > the state of the test run in a more intuitive way.
-> 
+>
 > The `rerun` formatter was chosen as the first formatter to migrate to this new structure as it is one of the simpler
 > formatters and will allow us to test the new structure in a real-world scenario.
 - Updated `cucumber-compatibility-kit` to v22
@@ -36,6 +36,8 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   ([#1844](https://github.com/cucumber/cucumber-ruby/pull/1844) [luke-hill](https://github.com/luke-hill))
 - Fixed an issue where the default flags derived in the `Options` and `Configuration` classes were not congruent
   ([#1846](https://github.com/cucumber/cucumber-ruby/pull/1846)) [luke-hill](https://github.com/luke-hill))
+- Fixed an issue where NoMethodError could be raised when declaring a parameter-type that used bound methods
+  ([#1789](https://github.com/cucumber/cucumber-ruby/pull/1789))
 
 ## [10.2.0] - 2025-12-10
 ### Changed

--- a/lib/cucumber/glue/registry_and_more.rb
+++ b/lib/cucumber/glue/registry_and_more.rb
@@ -202,11 +202,19 @@ module Cucumber
             regular_expressions: parameter_type.regexps.map(&:to_s),
             prefer_for_regular_expression_match: parameter_type.prefer_for_regexp_match,
             use_for_snippets: parameter_type.use_for_snippets,
-            source_reference: Cucumber::Messages::SourceReference.new(
-              uri: parameter_type.transformer.source_location[0],
-              location: Cucumber::Messages::Location.new(line: parameter_type.transformer.source_location[1])
-            )
+            source_reference: source_reference_for(parameter_type.transformer)
           )
+        )
+      end
+
+      def source_reference_for(transformer)
+        # #source_location may return nil if no definition was found
+        # This is the case for transformers created using method(sym) or similar
+        return nil if transformer.source_location.nil?
+
+        Cucumber::Messages::SourceReference.new(
+          uri: transformer.source_location[0],
+          location: Cucumber::Messages::Location.new(line: transformer.source_location[1])
         )
       end
 

--- a/spec/cucumber/glue/registry_and_more_spec.rb
+++ b/spec/cucumber/glue/registry_and_more_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'cucumber/glue/registry_and_more'
+require 'cucumber/cucumber_expressions/parameter_type'
 require 'support/fake_objects'
 
 module Cucumber
@@ -172,6 +173,60 @@ module Cucumber
           allow(scenario).to receive(:accept_hook?).with(a).and_return(true)
           allow(scenario).to receive(:accept_hook?).with(b).and_return(false)
           expect(registry.hooks_for(:around, scenario)).to eq([a])
+        end
+      end
+    end
+
+    RSpec.describe RegistryAndMore do
+      let(:registry) { described_class.new(double, configuration) }
+      let(:configuration) { Configuration.new({}) }
+
+      describe '#parameter_type_envelope' do
+        subject(:envelope) { registry.send(:parameter_type_envelope, parameter_type) }
+
+        let(:parameter_type) { CucumberExpressions::ParameterType.new(name, regexp, type, transformer, use_for_snippets, prefer_for_regexp_match) }
+        let(:id) { '279e0f28-c91b-4de2-89c0-e7fbc2a15406' }
+        let(:name) { 'person' }
+        let(:regexp) { /"[^"]+"/ }
+        let(:type) { String }
+        let(:transformer) { ->(s) { s } }
+        let(:use_for_snippets) { false }
+        let(:prefer_for_regexp_match) { true }
+
+        before do
+          allow(configuration.id_generator).to receive(:new_id).and_return(id)
+        end
+
+        it 'produces an envelope with the expected contents' do
+          expect(envelope).to be_a Cucumber::Messages::Envelope
+          expect(envelope.parameter_type).to be_a Cucumber::Messages::ParameterType
+          expect(envelope.parameter_type).to have_attributes(
+            id: '279e0f28-c91b-4de2-89c0-e7fbc2a15406',
+            name: 'person',
+            regular_expressions: [%("[^"]+")],
+            prefer_for_regular_expression_match: true,
+            use_for_snippets: false
+          )
+        end
+
+        context 'when provided a ParameterType with transformer being a lambda' do
+          let(:transformer) { ->(s) { s } }
+
+          it 'includes the lambda source-location in the envelope' do
+            expect(envelope.parameter_type.source_reference).to be_a Cucumber::Messages::SourceReference
+            expect(envelope.parameter_type.source_reference).to have_attributes(
+              uri: transformer.source_location[0],
+              location: have_attributes(line: transformer.source_location[1])
+            )
+          end
+        end
+
+        context 'when provided a ParameterType with transformer being a bound method, which has no source location' do
+          let(:transformer) { String.method(:new) }
+
+          it 'does not include the source-location in the envelope' do
+            expect(envelope.parameter_type.source_reference).to be_nil
+          end
         end
       end
     end


### PR DESCRIPTION
# Description

Sets `source_reference` to `nil` if the parameter type transformer does not provide a valid source location, i.e. is `nil`.

Fixes #1788

## Type of change

Bug fix (non-breaking change which fixes an issue)
# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
