### PR TITLE
Bugfix/html formatter

### DIFF
--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -198,9 +198,7 @@ module Cucumber
 
       def on_test_step_finished(event)
         test_case = @test_case_by_step_id[event.test_step.id]
-        result = event
-                 .result
-                 .with_filtered_backtrace(Cucumber::Formatter::BacktraceFilter)
+        result = event.result.with_filtered_backtrace(Cucumber::Formatter::BacktraceFilter)
 
         result_message = result.to_message
         if result.failed? || result.pending?
@@ -234,7 +232,13 @@ module Cucumber
       def create_exception_object(result, message_element)
         return unless result.failed?
 
-        Cucumber::Messages::Exception.from_h({ type: message_element.class, message: message_element.message })
+        Cucumber::Messages::Exception.from_h(
+          {
+            type: message_element.class,
+            message: message_element.message,
+            stack_trace: message_element.backtrace
+          }
+        )
       end
 
       def on_test_case_finished(event)

--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -225,8 +225,7 @@ module Cucumber
       end
 
       def create_error_message(message_element)
-        message = "#{message_element.message} (#{message_element.class})"
-        ([message] + message_element.backtrace).join("\n")
+        ["#{message_element.message} (#{message_element.class})", message_element.backtrace].join("\n")
       end
 
       def create_exception_object(result, message_element)

--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -232,12 +232,10 @@ module Cucumber
       def create_exception_object(result, message_element)
         return unless result.failed?
 
-        Cucumber::Messages::Exception.from_h(
-          {
-            type: message_element.class,
-            message: message_element.message,
-            stack_trace: message_element.backtrace
-          }
+        Cucumber::Messages::Exception.new(
+          type: message_element.class,
+          message: message_element.message,
+          stack_trace: message_element.backtrace.join("\n")
         )
       end
 


### PR DESCRIPTION
# Description

Fix up the message builder for exception. Ensuring that html-formatter (Amongst others), has the correct object structure in the new messages version/s

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
