### PR TITLE
bugfix: Handle blank media types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) for more info on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Prevent messages (And any consuming formatters), from not handling unknown (base64), media types ([#1796](https://github.com/cucumber/cucumber-ruby/pull/1796) [luke-hill](https://github.com/luke-hill))
 
 ## [10.1.0] - 2025-08-20
 ### Changed

--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -53,20 +53,16 @@ module Cucumber
           file_name: filename
         }
 
-        if media_type.start_with?('text/')
+        if media_type&.start_with?('text/')
           attachment_data[:content_encoding] = Cucumber::Messages::AttachmentContentEncoding::IDENTITY
           attachment_data[:body] = src
         else
           body = src.respond_to?(:read) ? src.read : src
-
           attachment_data[:content_encoding] = Cucumber::Messages::AttachmentContentEncoding::BASE64
           attachment_data[:body] = Base64.strict_encode64(body)
         end
 
-        message = Cucumber::Messages::Envelope.new(
-          attachment: Cucumber::Messages::Attachment.new(**attachment_data)
-        )
-
+        message = Cucumber::Messages::Envelope.new(attachment: Cucumber::Messages::Attachment.new(**attachment_data))
         output_envelope(message)
       end
 


### PR DESCRIPTION
# Description

Handle blank media type better when using base64 images

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
