### PR TITLE
bugfix: crash when `Cucumber::Messages::Group#children` is `nil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 > This is currently not consumed anywhere, but will become the building blocks for the future of cucumber formatters
 > which we hope to begin migrating to in the start of 2026
 
+### Fixed
+- Fix crash when `Cucumber::Messages::Group#children` is `nil`
+
 ## [10.2.0] - 2025-12-10
 ### Changed
 - Permit the latest version of the `cucumber-html-formatter` (v22.0.0+)

--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -143,7 +143,7 @@ module Cucumber
         Cucumber::Messages::Group.new(
           start: group.start,
           value: group.value,
-          children: group.children.map { |child| argument_group_to_message(child) }
+          children: group.children&.map { |child| argument_group_to_message(child) }
         )
       end
 


### PR DESCRIPTION
# Description

This change fixes the `undefined method 'map' for nil (NoMethodError)` for `cucumber-10.2.0/lib/cucumber/formatter/message_builder.rb:144`: `'Cucumber::Formatter::MessageBuilder#argument_group_to_message'` caused by:

* Dec 11, 2025: https://github.com/cucumber/cucumber-ruby/pull/1805 allows to pull `cucumber-cucumber-expressions` `19.0.0`

* Jan 21, 2026: https://github.com/cucumber/messages/pull/370 introduce a breaking change that allows the `children` field of `Cucumber::Messages::Group` to be `nil`

* Jan 21, 2026: https://github.com/cucumber/cucumber-expressions/pull/387 `ruby/lib/cucumber/cucumber_expressions/group_builder.rb` sets the `children` to `nil` if `empty?`

* Jan 26, 2026: The `cucumber-cucumber-expressions` `19.0.0` gem released and will be pulled in by `cucumber` `10.2.0` that raises the error

The fix is simply accept the `nil` value for `Cucumber::Messages::Group#children`.

## Alternative fix

* Revert the part in https://github.com/cucumber/cucumber-ruby/pull/1805 that sets `cucumber-cucumber-expressions` to `< 20`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [x] CHANGELOG.md has been updated
