### PR TITLE
Refactor/v11 push test case ready message earlier

### DIFF
--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -24,7 +24,6 @@ module Cucumber
 
         # Fake Query objects
         @test_case_by_step_id = {}
-        @pickle_id_by_test_case_id = {}
         @pickle_id_step_by_test_step_id = {}
         @hook_id_by_test_step_id = {}
 
@@ -115,12 +114,10 @@ module Cucumber
       end
 
       def on_test_case_created(event)
-        @pickle_id_by_test_case_id[event.test_case.id] = event.pickle.id
-
         message = Cucumber::Messages::Envelope.new(
           test_case: Cucumber::Messages::TestCase.new(
             id: event.test_case.id,
-            pickle_id: fake_query_pickle_id(event.test_case),
+            pickle_id: event.pickle.id,
             test_steps: event.test_case.test_steps.map { |step| test_step_to_message(step) },
             test_run_started_id: @test_run_started_id
           )
@@ -412,12 +409,6 @@ module Cucumber
         return @hook_id_by_test_step_id[test_step.id] if @hook_id_by_test_step_id.key?(test_step.id)
 
         raise TestStepUnknownError, "No hook found for #{test_step.id} }. Known: #{@hook_id_by_test_step_id.keys}"
-      end
-
-      def fake_query_pickle_id(test_case)
-        return @pickle_id_by_test_case_id[test_case.id] if @pickle_id_by_test_case_id.key?(test_case.id)
-
-        raise TestCaseUnknownError, "No pickle found for #{test_case.id} }. Known: #{@pickle_id_by_test_case_id.keys}"
       end
     end
   end

--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -123,9 +123,6 @@ module Cucumber
           )
         )
 
-        # TODO: This may be a redundant update. But for now we're leaving this in whilst we're in the transitory phase
-        @repository.update(message)
-
         output_envelope(message)
       end
 

--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -116,9 +116,7 @@ module Cucumber
 
       def on_test_case_created(event)
         @pickle_id_by_test_case_id[event.test_case.id] = event.pickle.id
-      end
 
-      def on_test_case_ready(event)
         message = Cucumber::Messages::Envelope.new(
           test_case: Cucumber::Messages::TestCase.new(
             id: event.test_case.id,
@@ -132,6 +130,11 @@ module Cucumber
         @repository.update(message)
 
         output_envelope(message)
+      end
+
+      def on_test_case_ready(_event)
+        # We now publish all the relevant information and data in the `on_test_case_created` handler
+        :no_op
       end
 
       def on_test_case_started(event)


### PR DESCRIPTION
# Description

Push Test Case Ready message earlier in the handler chain to remove one fake query

## Type of change

Please delete options that are not relevant.

- Refactoring (improvements to code design or tooling that don't change behaviour)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
