### PR TITLE
V11 - Event Migration to Envelopes -> GherkinSourceRead

### DIFF
--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -87,16 +87,10 @@ module Cucumber
         # TODO: Handle GherkinSourceParsed
       end
 
-      def on_gherkin_source_read(event)
-        message = Cucumber::Messages::Envelope.new(
-          source: Cucumber::Messages::Source.new(
-            uri: event.path,
-            data: event.body,
-            media_type: 'text/x.cucumber.gherkin+plain'
-          )
-        )
-
-        output_envelope(message)
+      def on_gherkin_source_read(_event)
+        :no_op
+        # This is now emitted at the required source (Single event listener - cucumber/runtime.rb#features)
+        # It does not need to be emitted here as well
       end
 
       def on_hook_test_step_created(event)

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -136,6 +136,19 @@ module Cucumber
       @features ||= feature_files.map do |path|
         source = NormalisedEncodingFile.read(path)
         @configuration.notify :gherkin_source_read, path, source
+
+        # TODO: Move this into `Cucumber::Core::Gherkin::Document#to_envelope`
+        to_envelope =
+          Cucumber::Messages::Envelope.new(
+            source: Cucumber::Messages::Source.new(
+              uri: path,
+              data: source,
+              media_type: 'text/x.cucumber.gherkin+plain'
+            )
+          )
+
+        @configuration.notify :envelope, to_envelope
+
         Cucumber::Core::Gherkin::Document.new(path, source)
       end
     end


### PR DESCRIPTION
# Description

This is the first of many PR's that will aim to migrate out the complexity of `MessageBuilder` so that the raw events being emitted are that of Envelope's with the requisite info.

As such this will remove the need to emit events and then convert them.

This will see us create a series of `#to_envelope` methods in the requisite places here or in core

## Type of change

Please delete options that are not relevant.

- Refactoring (improvements to code design or tooling that don't change behaviour)
- New feature (non-breaking change which adds new behaviour)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
