### PR TITLE
V11 - Event Migration to Envelopes -> TestRunHookStarted & TestRunHookFinished

### DIFF
--- a/lib/cucumber/configuration.rb
+++ b/lib/cucumber/configuration.rb
@@ -285,6 +285,10 @@ module Cucumber
       @id_generator ||= Cucumber::Messages::Helpers::IdGenerator::UUID.new
     end
 
+    def test_run_started_id
+      @test_run_started_id ||= id_generator.new_id
+    end
+
     private
 
     def default_features_paths

--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -16,7 +16,7 @@ module Cucumber
         @repository = Cucumber::Repository.new
         @query = Cucumber::Query.new(@repository)
 
-        @test_run_started_id = config.id_generator.new_id
+        @test_run_started_id = config.test_run_started_id
 
         # Fake Query objects
         @test_case_by_step_id = {}

--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -80,6 +80,12 @@ module Cucumber
       private
 
       def on_envelope(event)
+        # We do not have the requisite id for TestRunHookStarted#test_run_started_id at this point in time, so we
+        # will update the message live before updating the repository
+
+        event.envelope.test_run_hook_started&.tap do |message|
+          message.instance_variable_set(:@test_run_started_id, @test_run_started_id)
+        end
         output_envelope(event.envelope)
       end
 
@@ -202,43 +208,16 @@ module Cucumber
         output_envelope(message)
       end
 
-      def on_test_run_hook_started(event)
-        @current_test_run_hook_started_id = @config.id_generator.new_id
-
-        message = Cucumber::Messages::Envelope.new(
-          test_run_hook_started: Cucumber::Messages::TestRunHookStarted.new(
-            id: @current_test_run_hook_started_id,
-            hook_id: event.hook.id,
-            test_run_started_id: @test_run_started_id,
-            timestamp: time_to_timestamp(Time.now)
-          )
-        )
-
-        output_envelope(message)
+      def on_test_run_hook_started(_event)
+        :no_op
+        # This is now emitted at the required source (Single event listener - cucumber/glue/registry_and_more.rb#invoke_run_hook)
+        # It does not need to be emitted here as well
       end
 
-      def on_test_run_hook_finished(event)
-        result = event.test_result
-        result_message = result.to_message
-
-        if result.failed?
-          result_message = Cucumber::Messages::TestStepResult.new(
-            status: result_message.status,
-            duration: result_message.duration,
-            message: create_error_message(result.exception),
-            exception: create_exception_object(result, result.exception)
-          )
-        end
-
-        message = Cucumber::Messages::Envelope.new(
-          test_run_hook_finished: Cucumber::Messages::TestRunHookFinished.new(
-            test_run_hook_started_id: @current_test_run_hook_started_id,
-            timestamp: time_to_timestamp(Time.now),
-            result: result_message
-          )
-        )
-
-        output_envelope(message)
+      def on_test_run_hook_finished(_event)
+        :no_op
+        # This is now emitted at the required source (Single event listener - cucumber/glue/registry_and_more.rb#invoke_run_hook)
+        # It does not need to be emitted here as well
       end
 
       def on_test_step_created(event)

--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -80,12 +80,6 @@ module Cucumber
       private
 
       def on_envelope(event)
-        # We do not have the requisite id for TestRunHookStarted#test_run_started_id at this point in time, so we
-        # will update the message live before updating the repository
-
-        event.envelope.test_run_hook_started&.tap do |message|
-          message.instance_variable_set(:@test_run_started_id, @test_run_started_id)
-        end
         output_envelope(event.envelope)
       end
 

--- a/lib/cucumber/glue/registry_and_more.rb
+++ b/lib/cucumber/glue/registry_and_more.rb
@@ -210,7 +210,7 @@ module Cucumber
           test_run_hook_started: Cucumber::Messages::TestRunHookStarted.new(
             id: id,
             hook_id: hook.id,
-            test_run_started_id: 'unknown - to be set in message builder',
+            test_run_started_id: @configuration.test_run_started_id,
             timestamp: time_to_timestamp(Time.now)
           )
         )

--- a/lib/cucumber/glue/registry_and_more.rb
+++ b/lib/cucumber/glue/registry_and_more.rb
@@ -4,6 +4,8 @@ require 'cucumber/cucumber_expressions/parameter_type_registry'
 require 'cucumber/cucumber_expressions/cucumber_expression'
 require 'cucumber/cucumber_expressions/regular_expression'
 require 'cucumber/cucumber_expressions/cucumber_expression_generator'
+require 'cucumber/messages/helpers/time_conversion'
+
 require 'cucumber/glue/dsl'
 require 'cucumber/glue/snippet'
 require 'cucumber/glue/hook'
@@ -47,6 +49,8 @@ module Cucumber
     # TODO: This class has too many responsibilities, split off
     class RegistryAndMore
       attr_reader :current_world, :step_definitions
+
+      include Cucumber::Messages::Helpers::TimeConversion
 
       all_keywords = ::Gherkin::DIALECTS.keys.map do |dialect_name|
         dialect = ::Gherkin::Dialect.for(dialect_name)
@@ -182,14 +186,73 @@ module Cucumber
 
       def invoke_run_hook(hook, pseudo_method)
         @configuration.notify(:test_run_hook_started, hook)
+
+        current_test_run_hook_started_id = @configuration.id_generator.new_id
+        started_envelope = test_run_hook_started_envelope(hook, current_test_run_hook_started_id)
+        @configuration.notify(:envelope, started_envelope)
+
         timer = Core::Test::Timer.new.start
         begin
           hook.invoke(pseudo_method, [])
           @configuration.notify(:test_run_hook_finished, hook, Core::Test::Result::Passed.new(timer.duration))
+          finished_envelope = test_run_hook_finished_envelope(hook, Core::Test::Result::Passed.new(timer.duration), current_test_run_hook_started_id)
+          @configuration.notify(:envelope, finished_envelope)
         rescue StandardError => e
           @configuration.notify(:test_run_hook_finished, hook, Core::Test::Result::Failed.new(timer.duration, e))
+          finished_envelope = test_run_hook_finished_envelope(hook, Core::Test::Result::Failed.new(timer.duration, e), current_test_run_hook_started_id)
+          @configuration.notify(:envelope, finished_envelope)
           raise
         end
+      end
+
+      def test_run_hook_started_envelope(hook, id)
+        Cucumber::Messages::Envelope.new(
+          test_run_hook_started: Cucumber::Messages::TestRunHookStarted.new(
+            id: id,
+            hook_id: hook.id,
+            test_run_started_id: 'unknown - to be set in message builder',
+            timestamp: time_to_timestamp(Time.now)
+          )
+        )
+      end
+
+      def test_run_hook_finished_envelope(_hook, test_result, test_run_hook_started_id)
+        result = test_result
+        result_message = result.to_message
+
+        if result.failed?
+          result_message = Cucumber::Messages::TestStepResult.new(
+            status: result_message.status,
+            duration: result_message.duration,
+            message: create_error_message(result.exception),
+            exception: create_exception_object(result, result.exception)
+          )
+        end
+
+        Cucumber::Messages::Envelope.new(
+          test_run_hook_finished: Cucumber::Messages::TestRunHookFinished.new(
+            test_run_hook_started_id: test_run_hook_started_id,
+            timestamp: time_to_timestamp(Time.now),
+            result: result_message
+          )
+        )
+      end
+
+      def create_error_message(message_element)
+        <<~ERROR_MESSAGE
+          #{message_element.message} (#{message_element.class})
+          #{message_element.backtrace}
+        ERROR_MESSAGE
+      end
+
+      def create_exception_object(result, message_element)
+        return unless result.failed?
+
+        Cucumber::Messages::Exception.new(
+          type: message_element.class,
+          message: message_element.message,
+          stack_trace: message_element.backtrace.join("\n")
+        )
       end
 
       def parameter_type_envelope(parameter_type)


### PR DESCRIPTION
# Description

This migrates 2 more events to be dual-emitting and emitting both the old-style event and the new-style envelope

## Type of change

Please delete options that are not relevant.

- Refactoring (improvements to code design or tooling that don't change behaviour)
- New feature (non-breaking change which adds new behaviour)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
