### PR TITLE
Define undefinedparametertype event as an envelope at source

### DIFF
--- a/lib/cucumber/formatter/message_builder.rb
+++ b/lib/cucumber/formatter/message_builder.rb
@@ -42,8 +42,6 @@ module Cucumber
         config.on_event :test_step_created, &method(:on_test_step_created)
         config.on_event :test_step_started, &method(:on_test_step_started)
         config.on_event :test_step_finished, &method(:on_test_step_finished)
-
-        config.on_event :undefined_parameter_type, &method(:on_undefined_parameter_type)
       end
 
       def attach(src, media_type, filename)
@@ -246,17 +244,6 @@ module Cucumber
             test_case_started_id: find_test_case_started_by_test_case.id,
             test_step_result: result_message,
             timestamp: time_to_timestamp(Time.now)
-          )
-        )
-
-        @config.event_bus.envelope(message)
-      end
-
-      def on_undefined_parameter_type(event)
-        message = Cucumber::Messages::Envelope.new(
-          undefined_parameter_type: Cucumber::Messages::UndefinedParameterType.new(
-            name: event.type_name,
-            expression: event.expression
           )
         )
 

--- a/lib/cucumber/glue/registry_and_more.rb
+++ b/lib/cucumber/glue/registry_and_more.rb
@@ -102,14 +102,12 @@ module Cucumber
       def register_rb_step_definition(string_or_regexp, proc_or_sym, options)
         step_definition = StepDefinition.new(@configuration.id_generator.new_id, self, string_or_regexp, proc_or_sym, options)
         @step_definitions << step_definition
-        @configuration.notify :step_definition_registered, step_definition
-        @configuration.notify :envelope, step_definition.to_envelope
+        @configuration.notify(:step_definition_registered, step_definition)
+        @configuration.notify(:envelope, step_definition.to_envelope)
         step_definition
       rescue Cucumber::CucumberExpressions::UndefinedParameterTypeError => e
-        # TODO: add a way to extract the parameter type directly from the error.
-        type_name = e.message.match(/^Undefined parameter type ['|{](.*)['|}].?$/)[1]
-
-        @configuration.notify :undefined_parameter_type, type_name, string_or_regexp
+        @configuration.notify(:undefined_parameter_type, e.undefined_parameter_type_name, string_or_regexp)
+        @configuration.notify(:envelope, e.to_envelope(string_or_regexp))
       end
 
       def build_rb_world_factory(world_modules, namespaced_world_modules, proc)


### PR DESCRIPTION
# Description

Simple one to get one more event type to envelope at source

## Type of change

Please delete options that are not relevant.

- Refactoring (improvements to code design or tooling that don't change behaviour)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
