### PR TITLE
Show failed step details in summary formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) for more info on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Fixed
+- Show failed step error details in the summary formatter output.
 
 ## [11.1.0] - 2026-06-02
 ### Added

--- a/features/docs/formatters/summary_formatter.feature
+++ b/features/docs/formatters/summary_formatter.feature
@@ -1,7 +1,8 @@
 Feature: Spec formatter
 
   This formatter mimics the output from tools like RSpec or Mocha, giving an
-  overview of each feature and scenario but omitting the steps.
+  overview of each feature and scenario while omitting passing step details.
+  Failed steps still include enough exception detail to debug the failure.
 
   Background:
     Given the standard step definitions
@@ -22,6 +23,12 @@ Feature: Spec formatter
     Test
       Passing ✓
       Failing ✗
+
+    (::) failed steps (::)
+
+     (RuntimeError)
+    ./features/step_definitions/steps.rb:4:in `/^this step fails$/'
+    features/test.feature:6:in `this step fails'
 
     Failing Scenarios:
     cucumber features/test.feature:5 # Scenario: Failing

--- a/lib/cucumber/formatter/summary.rb
+++ b/lib/cucumber/formatter/summary.rb
@@ -4,12 +4,13 @@ require 'cucumber/formatter/io'
 require 'cucumber/formatter/console'
 require 'cucumber/formatter/console_counts'
 require 'cucumber/formatter/console_issues'
+require 'cucumber/formatter/backtrace_filter'
 require 'cucumber/core/test/result'
 require 'cucumber/formatter/ast_lookup'
 
 module Cucumber
   module Formatter
-    # Summary formatter, outputting only feature / scenario titles
+    # Summary formatter, outputting feature / scenario titles plus failure details
     class Summary
       include Io
       include Console
@@ -20,6 +21,7 @@ module Cucumber
         @ast_lookup = AstLookup.new(config)
         @counts = ConsoleCounts.new(@config)
         @issues = ConsoleIssues.new(@config, @ast_lookup)
+        @failed_results = []
         @start_time = Time.now
 
         @config.on_event :test_case_started do |event|
@@ -31,9 +33,14 @@ module Cucumber
           print_result event.result
         end
 
+        @config.on_event :test_step_finished do |event|
+          collect_failed_result(event.test_step, event.result)
+        end
+
         @config.on_event :test_run_finished do |_event|
           duration = Time.now - @start_time
           @io.puts
+          print_elements(@failed_results, :failed, 'steps')
           print_statistics(duration, @config, @counts, @issues)
         end
       end
@@ -60,6 +67,13 @@ module Cucumber
 
       def print_result(result)
         @io.puts format_string(result, result.to_sym)
+      end
+
+      def collect_failed_result(test_step, result)
+        return if test_step.hook?
+
+        result = result.with_filtered_backtrace(Cucumber::Formatter::BacktraceFilter)
+        @failed_results << result if result.failed?
       end
     end
   end


### PR DESCRIPTION
## Description

Fixes #1513.

The summary formatter currently lists the failing scenario but does not print the failed step's exception details. This adds the same failed-step detail block that the progress formatter already uses, including the filtered exception backtrace, while keeping the summary formatter's scenario-level output unchanged.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Verification

- `bundle exec cucumber features/docs/formatters/summary_formatter.feature --publish-quiet`
- `bundle exec cucumber features/docs/formatters/summary_formatter.feature features/docs/formatters/progress_formatter.feature --publish-quiet`
- `bundle exec rubocop`
- `bundle exec rake`
- `CI=1 bundle exec rake`
- `git diff --check`
- `review-fix-loop`: no discrete correctness issues

GitHub Actions status: the upstream workflow runs currently show `action_required` for this fork branch, so CI has not run yet. I left the local/CI checklist item unchecked until those jobs are approved and pass.

## Checklist

- [x] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] RDoc comments have been updated
- [x] CHANGELOG.md has been updated
