### PR TITLE
Bump CCK conformance to v26

### DIFF
--- a/compatibility/cck_spec.rb
+++ b/compatibility/cck_spec.rb
@@ -13,19 +13,17 @@ require 'cucumber/compatibility_kit'
 RSpec.describe 'CCK', :cck do
   let(:cucumber_command) { 'bundle exec cucumber --publish-quiet --profile none --format message' }
 
-  # CCK v24 conformance
-  # OVERALL: 111 examples, 2 failures, 109 passed
-  # SANITIZED: 108 examples, 0 failures, 108 passed
+  # CCK v26 conformance
+  # OVERALL: 114 examples, 2 failures, 112 passed
+  # SANITIZED: 111 examples, 0 failures, 111 passed
 
   items_to_fix =
     %w[
       test-run-exception
-      hooks-skipped
-      skipped
     ]
   _failing, passing = Cucumber::CompatibilityKit.gherkin.partition { |name| items_to_fix.include?(name) }
 
-  _failing.each do |example_name|
+  passing.each do |example_name|
     describe "'#{example_name}' example" do
       include_examples 'cucumber compatibility kit' do
         let(:example) { example_name }

--- a/compatibility/cck_spec.rb
+++ b/compatibility/cck_spec.rb
@@ -20,10 +20,12 @@ RSpec.describe 'CCK', :cck do
   items_to_fix =
     %w[
       test-run-exception
+      hooks-skipped
+      skipped
     ]
   _failing, passing = Cucumber::CompatibilityKit.gherkin.partition { |name| items_to_fix.include?(name) }
 
-  passing.each do |example_name|
+  _failing.each do |example_name|
     describe "'#{example_name}' example" do
       include_examples 'cucumber compatibility kit' do
         let(:example) { example_name }

--- a/compatibility/features/hooks-skipped/hooks-skipped_steps.rb
+++ b/compatibility/features/hooks-skipped/hooks-skipped_steps.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+Before do
+  # no-op
+end
+
+Before('@skip-before') do
+  skip_this_scenario('')
+end
+
+Before do
+  # no-op
+end
+
+When('a normal step') do
+  # no-op
+end
+
+When('a step that skips') do
+  skip_this_scenario('')
+end
+
+After do
+  # no-op
+end
+
+After('@skip-after') do
+  skip_this_scenario('')
+end
+
+After do
+  # no-op
+end

--- a/compatibility/features/skipped/skipped_steps.rb
+++ b/compatibility/features/skipped/skipped_steps.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-Before('@skip') do
-  skip_this_scenario('')
-end
-
 Given('a step that does not skip') do
   # no-op
 end

--- a/cucumber.gemspec
+++ b/cucumber.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_test', '~> 1.1'
   s.add_dependency 'sys-uname', '~> 1.5'
 
-  s.add_development_dependency 'cucumber-compatibility-kit', '~> 24.0'
+  s.add_development_dependency 'cucumber-compatibility-kit', '~> 26.0'
   # Only needed whilst we are testing the formatters. Can be removed once we remove tests for those
   s.add_development_dependency 'nokogiri', '~> 1.15'
   s.add_development_dependency 'rake', '~> 13.2'


### PR DESCRIPTION
# Description

This now does another incremental bump from CCKv24 -> CCKv26

## Type of change

- Refactoring (improvements to code design or tooling that don't change behaviour)

No new functionalities or features were added to facilitate the upgrade from CCKv24 to CCKv26.

Not yet decided on when this should enter the codebase. For now the PR is raised just to evaluate CI is all green. Likely to hit sometime in the 11.x versions - probably around 11.3

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [x] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
