### PR TITLE
Escape apostrophes in generated snippets

### DIFF
--- a/lib/cucumber/glue/snippet.rb
+++ b/lib/cucumber/glue/snippet.rb
@@ -110,9 +110,11 @@ module Cucumber
 
         def quoted_expression_source(expr)
           source = expr.source
-          return "'#{source.gsub(/['\\]/) { |char| "\\#{char}" }}'" unless source.include?("'")
 
-          "\"#{source.gsub(/["\\]/) { |char| "\\#{char}" }}\""
+          return "'#{source}'" unless source.include?("'")
+
+          escaped_source = source.gsub(/["\\#]/) { |char| "\\#{char}" }
+          "\"#{escaped_source}\""
         end
 
         def self.description

--- a/lib/cucumber/glue/snippet.rb
+++ b/lib/cucumber/glue/snippet.rb
@@ -91,7 +91,7 @@ module Cucumber
         def to_s
           header = generated_expressions.each_with_index.map do |expr, i|
             prefix = i.zero? ? '' : '# '
-            "#{prefix}#{code_keyword}('#{expr.source}') do#{parameters(expr)}"
+            "#{prefix}#{code_keyword}('#{escaped_expression_source(expr)}') do#{parameters(expr)}"
           end.join("\n")
 
           body = <<~DOC.chomp
@@ -106,6 +106,10 @@ module Cucumber
           parameter_names = expr.parameter_names
           multiline_argument.append_block_parameter_to(parameter_names)
           parameter_names.empty? ? '' : " |#{parameter_names.join(', ')}|"
+        end
+
+        def escaped_expression_source(expr)
+          expr.source.gsub(/['\\]/) { |char| "\\#{char}" }
         end
 
         def self.description

--- a/lib/cucumber/glue/snippet.rb
+++ b/lib/cucumber/glue/snippet.rb
@@ -111,7 +111,7 @@ module Cucumber
         def quoted_expression_source(expr)
           source = expr.source
 
-          return "'#{source}'" unless source.include?("'")
+          return "'#{source.gsub(/\\/) { |char| "\\#{char}" }}'" unless source.include?("'")
 
           escaped_source = source.gsub(/["\\#]/) { |char| "\\#{char}" }
           "\"#{escaped_source}\""

--- a/lib/cucumber/glue/snippet.rb
+++ b/lib/cucumber/glue/snippet.rb
@@ -91,7 +91,7 @@ module Cucumber
         def to_s
           header = generated_expressions.each_with_index.map do |expr, i|
             prefix = i.zero? ? '' : '# '
-            "#{prefix}#{code_keyword}('#{escaped_expression_source(expr)}') do#{parameters(expr)}"
+            "#{prefix}#{code_keyword}(#{quoted_expression_source(expr)}) do#{parameters(expr)}"
           end.join("\n")
 
           body = <<~DOC.chomp
@@ -108,8 +108,11 @@ module Cucumber
           parameter_names.empty? ? '' : " |#{parameter_names.join(', ')}|"
         end
 
-        def escaped_expression_source(expr)
-          expr.source.gsub(/['\\]/) { |char| "\\#{char}" }
+        def quoted_expression_source(expr)
+          source = expr.source
+          return "'#{source.gsub(/['\\]/) { |char| "\\#{char}" }}'" unless source.include?("'")
+
+          "\"#{source.gsub(/["\\]/) { |char| "\\#{char}" }}\""
         end
 
         def self.description

--- a/spec/cucumber/glue/snippet_spec.rb
+++ b/spec/cucumber/glue/snippet_spec.rb
@@ -180,6 +180,17 @@ module Cucumber
 
           expect(snippet.to_s).to eq(cucumber_output)
         end
+
+        it 'escapes apostrophes in generated cucumber expression snippets' do
+          @step_text = "Lucy hears Sean's message"
+          cucumber_output = <<~CUKE.chomp
+            Given('Lucy hears Sean\\'s message') do
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
+
+          expect(snippet.to_s).to eq(cucumber_output)
+        end
       end
     end
   end

--- a/spec/cucumber/glue/snippet_spec.rb
+++ b/spec/cucumber/glue/snippet_spec.rb
@@ -181,10 +181,10 @@ module Cucumber
           expect(snippet.to_s).to eq(cucumber_output)
         end
 
-        it 'escapes apostrophes in generated cucumber expression snippets' do
+        it 'uses double quotes when generated cucumber expression snippets contain apostrophes' do
           @step_text = "Lucy hears Sean's message"
           cucumber_output = <<~CUKE.chomp
-            Given('Lucy hears Sean\\'s message') do
+            Given("Lucy hears Sean's message") do
               pending # Write code here that turns the phrase above into concrete actions
             end
           CUKE

--- a/spec/cucumber/glue/snippet_spec.rb
+++ b/spec/cucumber/glue/snippet_spec.rb
@@ -181,7 +181,7 @@ module Cucumber
           expect(snippet.to_s).to eq(cucumber_output)
         end
 
-        it 'uses double quotes for generated cucumber expression snippets with apostrophes' do
+        it 'uses double quotes for generated snippets with apostrophes' do
           @step_text = "Lucy hears Sean's message"
           cucumber_output = <<~CUKE.chomp
             Given("Lucy hears Sean's message") do
@@ -192,7 +192,7 @@ module Cucumber
           expect(snippet.to_s).to eq(cucumber_output)
         end
 
-        it 'escapes backslashes in single quoted cucumber expression snippets' do
+        it 'escapes backslashes in single quoted snippets' do
           @step_text = 'Lucy hears trailing \\'
           cucumber_output = <<~'CUKE'.chomp
             Given('Lucy hears trailing \\') do
@@ -203,7 +203,7 @@ module Cucumber
           expect(snippet.to_s).to eq(cucumber_output)
         end
 
-        it 'escapes interpolation markers in double quoted cucumber expression snippets' do
+        it 'escapes interpolation markers in double quoted snippets' do
           @step_text = 'Lucy hears Sean\'s #@message'
           cucumber_output = <<~'CUKE'.chomp
             Given("Lucy hears Sean's \#@message") do

--- a/spec/cucumber/glue/snippet_spec.rb
+++ b/spec/cucumber/glue/snippet_spec.rb
@@ -181,10 +181,21 @@ module Cucumber
           expect(snippet.to_s).to eq(cucumber_output)
         end
 
-        it 'uses double quotes when generated cucumber expression snippets contain apostrophes' do
+        it 'uses double quotes for generated cucumber expression snippets with apostrophes' do
           @step_text = "Lucy hears Sean's message"
           cucumber_output = <<~CUKE.chomp
             Given("Lucy hears Sean's message") do
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
+
+          expect(snippet.to_s).to eq(cucumber_output)
+        end
+
+        it 'escapes interpolation markers in double quoted cucumber expression snippets' do
+          @step_text = 'Lucy hears Sean\'s #@message'
+          cucumber_output = <<~'CUKE'.chomp
+            Given("Lucy hears Sean's \#@message") do
               pending # Write code here that turns the phrase above into concrete actions
             end
           CUKE

--- a/spec/cucumber/glue/snippet_spec.rb
+++ b/spec/cucumber/glue/snippet_spec.rb
@@ -192,6 +192,17 @@ module Cucumber
           expect(snippet.to_s).to eq(cucumber_output)
         end
 
+        it 'escapes backslashes in single quoted cucumber expression snippets' do
+          @step_text = 'Lucy hears trailing \\'
+          cucumber_output = <<~'CUKE'.chomp
+            Given('Lucy hears trailing \\') do
+              pending # Write code here that turns the phrase above into concrete actions
+            end
+          CUKE
+
+          expect(snippet.to_s).to eq(cucumber_output)
+        end
+
         it 'escapes interpolation markers in double quoted cucumber expression snippets' do
           @step_text = 'Lucy hears Sean\'s #@message'
           cucumber_output = <<~'CUKE'.chomp

--- a/spec/cucumber/glue/snippet_spec.rb
+++ b/spec/cucumber/glue/snippet_spec.rb
@@ -181,7 +181,7 @@ module Cucumber
           expect(snippet.to_s).to eq(cucumber_output)
         end
 
-        it 'uses double quotes for generated snippets with apostrophes' do
+        it 'uses double quotes for generated snippets that contain apostrophes' do
           @step_text = "Lucy hears Sean's message"
           cucumber_output = <<~CUKE.chomp
             Given("Lucy hears Sean's message") do
@@ -192,7 +192,7 @@ module Cucumber
           expect(snippet.to_s).to eq(cucumber_output)
         end
 
-        it 'escapes backslashes in single quoted snippets' do
+        it 'escapes backslashes when generating snippets' do
           @step_text = 'Lucy hears trailing \\'
           cucumber_output = <<~'CUKE'.chomp
             Given('Lucy hears trailing \\') do


### PR DESCRIPTION
## Summary

- Keep single-quoted generated Cucumber Expression snippets when the expression can be represented safely.
- Use double-quoted Ruby snippets when the generated expression contains an apostrophe, with escaping for double quotes, backslashes, and interpolation markers.
- Preserve backslash escaping for single-quoted snippets and cover apostrophe, interpolation, and trailing-backslash cases.

Fixes #1710

## Verification

- `bundle exec rspec spec/cucumber/glue/snippet_spec.rb`
- `bundle exec rspec`
- `bundle exec cucumber`
- `bundle exec rubocop`
- `git diff --check`

Local repros now print `Then("Lucy hears Sean's message")` and `Then('Lucy hears trailing \\')`, and both generated snippets compile with Ruby.
