### PR TITLE
Fix spec for trap_thread_dump_signal

### DIFF
--- a/spec/cucumber/cli/main_spec.rb
+++ b/spec/cucumber/cli/main_spec.rb
@@ -73,11 +73,8 @@ RSpec.describe Cucumber::Cli::Main do
       let(:runtime) { double('runtime').as_null_object }
 
       it 'dumps the thread backtrace to the error stream' do
-        kill_line = 0
-
         allow(runtime).to receive(:run!) do
           Process.kill(thread_dump_signal, Process.pid)
-          kill_line = __LINE__ - 1
         end
 
         allow(runtime).to receive(:failure?).and_return(false)
@@ -86,21 +83,11 @@ RSpec.describe Cucumber::Cli::Main do
 
         subject.execute!(runtime)
 
-        tid = (Thread.current.object_id ^ Process.pid).to_s(36)
+        pattern = /Thread TID.+trap_thread_dump_signal/
 
-        if defined?(JRUBY_VERSION)
-          pattern = /Thread TID-[0-9a-z]+ SIGPWR handler /
-
-          # JRuby runs signal handlers asynchronously on a dedicated thread
-          deadline = Time.now + 2
-          sleep 0.01 while stderr.string !~ pattern && Time.now < deadline
-        elsif defined?(TruffleRuby)
-          # TruffleRuby does not dump the actual Process.kill call, but rather the internal core/thread.rb call
-          pattern = /Thread TID-#{tid} <no name> <internal:core> core\/thread.rb:/
-        else
-          pattern = RUBY_VERSION >= '3.4' ? /'Process\.kill'/ : /`kill'/
-          pattern = /Thread TID-#{tid} <no name> #{__FILE__}:#{kill_line}:in #{pattern}/
-        end
+        # Process.kill can be asynchronous, wait for the signal to be delivered
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+        sleep 0.01 while stderr.string !~ pattern && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
 
         expect(stderr.string).to match(pattern)
       end


### PR DESCRIPTION
# Description

* The spec was timing-dependant and therefore flaky.
* Use a common pattern guaranteed to match.
* Always wait for the signal since Process.kill can be asynchronous (and in real cases always is).
* See https://github.com/truffleruby/truffleruby/issues/4383#issuecomment-5038819762

Locally I added a `1000.times { ... }` around to spec and that way I could repro the failure locally (100 was not enough).
Before the fix it failed reliably a few times, after it passes reliably.

## Type of change

Please delete options that are not relevant.

- spec fix

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [x] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] RDoc comments have been updated
- [x] CHANGELOG.md has been updated (not user-facing so no entry)
