### PR TITLE
The Formatter::HTML should not inherit from the MessageBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
   logic and some old rspec helper files)
 - Removed handling of a Ruby 2.1 system error (Minimum Ruby is now 3.2) ([luke-hill](https://github.com/luke-hill))
 
+### Fixed
+- Updated the `html-formatter` to access message stream correctly ([#1899](https://github.com/cucumber/cucumber-ruby/pull/1899)) [brasmusson](https://github.com/brasmusson)
+
 ## [11.1.1] - 2026-06-25
 ### Changed
 - Change to use events to pass the data from "log" and "attach" calls from the step definitions to the formatters. With this the last part of the ancient (pre event) formatter inteface has been removed. ([#1881](https://github.com/cucumber/cucumber-ruby/pull/1881) [brasmusson](https://github.com/brasmusson))

--- a/features/docs/formatters/html.feature
+++ b/features/docs/formatters/html.feature
@@ -19,3 +19,7 @@ Feature: html formatter
     When I run `cucumber features/my_feature.feature --format html`
     Then it should fail
     And output should be html with title "Cucumber"
+    And the output should contain:
+    """
+    Scenario Outline: a scenario
+    """

--- a/lib/cucumber/formatter/html.rb
+++ b/lib/cucumber/formatter/html.rb
@@ -2,20 +2,22 @@
 
 require 'cucumber/html_formatter'
 
-require_relative 'message_builder'
+require_relative 'io'
 
 module Cucumber
   module Formatter
-    class HTML < MessageBuilder
+    class HTML
+      include Io
+
       def initialize(config)
+        @config = config
         @io = ensure_io(config.out_stream, config.error_stream)
         @html_formatter = Cucumber::HTMLFormatter::Formatter.new(@io)
         @html_formatter.write_pre_message
-        super(config)
+        config.on_event :envelope, &method(:on_envelope)
       end
 
       def on_envelope(event)
-        super(event)
         envelope = event.envelope
         @html_formatter.write_message(envelope)
         # TODO: Move this conditional logic into the HTML formatter proper

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -172,13 +172,13 @@ module Cucumber
     require 'cucumber/core/report/summary'
 
     def create_formatters
-      # Define all formatters which are specified via cli options
-      formatters
-      # Define the MessageBuilder formatter - Required until all messages are generated at the source
+      # Define the MessageBuilder - Required until all messages are generated at the source
       message_builder
       # `summary_report` and `global_hooks_summary_report` are used to determine the exit code
       summary_report
       global_hooks_summary_report
+      # Define all formatters which are specified via cli options
+      formatters
       fail_fast_report if @configuration.fail_fast?
       publish_banner_printer unless @configuration.publish_quiet?
     end

--- a/lib/cucumber/runtime.rb
+++ b/lib/cucumber/runtime.rb
@@ -175,8 +175,7 @@ module Cucumber
       # Define all formatters which are specified via cli options
       formatters
       # Define the MessageBuilder formatter - Required until all messages are generated at the source
-      #   Skip when a user formatter already inherits from MessageBuilder (e.g. HTML) to avoid sending every event twice.
-      message_builder unless formatters.any? { |f| f.is_a?(Formatter::MessageBuilder) }
+      message_builder
       # `summary_report` and `global_hooks_summary_report` are used to determine the exit code
       summary_report
       global_hooks_summary_report


### PR DESCRIPTION

# Description
* The  `Runtime` creates the `MessageBuilder` to always output the envelope it creates from event to the event bus. Therefore a formatter only need to listen to the `:envelope` events on the event bus.

This change should have been part of #1865. Since it was missed there #1890 occurred. #1891 fixed the symptom of #1890 but failed to remove the inheritance fo the `Formatter::HTML`

## Type of change

Please delete options that are not relevant.

- Refactoring (improvements to code design or tooling that don't change behaviour)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [X] New and existing tests are passing locally and on CI
- [X] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [x] CHANGELOG.md has been updated
