### PR TITLE
Make fetching the OS version work on Wine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ## [Unreleased]
 
+### Fixed
+- Make fetching the OS version work on Wine ([#1900](https://github.com/cucumber/cucumber-ruby/pull/1900) [mvz](https://github.com/mvz))
+
 ## [11.0.0] - 2026-04-14
 ### Added
 - Add timestamp to `Attachment` message

--- a/lib/cucumber/runtime/meta_message_builder.rb
+++ b/lib/cucumber/runtime/meta_message_builder.rb
@@ -70,7 +70,7 @@ module Cucumber
         def os
           Cucumber::Messages::Product.new(
             name: RbConfig::CONFIG['target_os'],
-            version: Sys::Uname.uname.version
+            version: Sys::Uname.version
           )
         end
 

--- a/spec/cucumber/runtime/meta_message_builder_spec.rb
+++ b/spec/cucumber/runtime/meta_message_builder_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Cucumber::Runtime::MetaMessageBuilder do
     end
 
     it 'has an os version' do
-      expect(subject.os.version).to eq(Sys::Uname.uname.version)
+      expect(subject.os.version).to eq(Sys::Uname.version)
     end
 
     it 'has a cpu name' do


### PR DESCRIPTION
# Description

Fetching version via Sys::Uname.uname makes sys-uname fetch a large number of OS properties. Under Wine, an unrelated property fails to be fetched, causing MetaMessageBuiler.os to raise an error. With this change, only the relevant value is fetched and the method succeeds.

The context is that I'm trying to get the Aruba test suite to run under Wine. Cucumber fails to start due to Sys::Uname.uname raising an error.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [x] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
